### PR TITLE
trillian/ctfe: allow separate metrics endpoint

### DIFF
--- a/trillian/integration/consoles/reads.html
+++ b/trillian/integration/consoles/reads.html
@@ -12,7 +12,7 @@
 <script>
 new PromConsole.Graph({
   node: document.querySelector("#httpReqsGraph"),
-  expr: "sum(rate(http_reqs{ep=~'Get.+', job='trillian-ctfe-http'}[5m])) without (job, instance, logid)",
+  expr: "sum(rate(http_reqs{ep=~'Get.+', job='trillian-ctfe-metrics-http'}[5m])) without (job, instance, logid)",
   yAxisFormatter: PromConsole.NumberFormatter.humanizeNoSmallPrefix,
   yHoverFormatter: PromConsole.NumberFormatter.humanizeNoSmallPrefix,
   yUnits: "/s",
@@ -26,7 +26,7 @@ new PromConsole.Graph({
 <script>
 new PromConsole.Graph({
   node: document.querySelector("#httpErrorsGraph"),
-  expr: "sum(http_rsps{ep=~'Get.+', job='trillian-ctfe-http', rc!='200'}) without (instance, logid, job) / ignoring (rc) sum(http_reqs{ep=~'Get.+', job='trillian-ctfe-http'}) without (instance, logid, job)",
+  expr: "sum(http_rsps{ep=~'Get.+', job='trillian-ctfe-metrics-http', rc!='200'}) without (instance, logid, job) / ignoring (rc) sum(http_reqs{ep=~'Get.+', job='trillian-ctfe-metrics-http'}) without (instance, logid, job)",
   yAxisFormatter: PromConsole.NumberFormatter.humanizeNoSmallPrefix,
   yHoverFormatter: PromConsole.NumberFormatter.humanizeNoSmallPrefix,
   yTitle: "Error Rate",

--- a/trillian/integration/consoles/trillian.html
+++ b/trillian/integration/consoles/trillian.html
@@ -11,7 +11,7 @@
 <script>
 new PromConsole.Graph({
   node: document.querySelector("#treeSizeGraph"),
-  expr:"max(last_sth_treesize{job='trillian-ctfe-http'}) without (instance, job)",
+  expr:"max(last_sth_treesize{job='trillian-ctfe-metrics-http'}) without (instance, job)",
   yAxisFormatter: PromConsole.NumberFormatter.humanizeNoSmallPrefix,
   yHoverFormatter: PromConsole.NumberFormatter.humanizeNoSmallPrefix,
   yTitle: "Tree Size"
@@ -40,7 +40,7 @@ new PromConsole.Graph({
 <script>
 new PromConsole.Graph({
   node: document.querySelector("#knownLogsGraph"),
-  expr: "max(known_logs{job='trillian-ctfe-http'}) without (instance, job) - on (logid) max(known_logs{job='trillian-logsigner-http'}) without (instance, job)",
+  expr: "max(known_logs{job='trillian-ctfe-metrics-http'}) without (instance, job) - on (logid) max(known_logs{job='trillian-logsigner-http'}) without (instance, job)",
   yAxisFormatter: PromConsole.NumberFormatter.humanizeNoSmallPrefix,
   yHoverFormatter: PromConsole.NumberFormatter.humanizeNoSmallPrefix,
   yUnits: "/s",

--- a/trillian/integration/consoles/writes.html
+++ b/trillian/integration/consoles/writes.html
@@ -12,7 +12,7 @@
 <script>
 new PromConsole.Graph({
   node: document.querySelector("#httpReqsGraph"),
-  expr: "sum(rate(http_reqs{ep=~'Add.+', job='trillian-ctfe-http'}[5m])) without (job, instance, logid)",
+  expr: "sum(rate(http_reqs{ep=~'Add.+', job='trillian-ctfe-metrics-http'}[5m])) without (job, instance, logid)",
   yAxisFormatter: PromConsole.NumberFormatter.humanizeNoSmallPrefix,
   yHoverFormatter: PromConsole.NumberFormatter.humanizeNoSmallPrefix,
   yUnits: "/s",
@@ -27,7 +27,7 @@ new PromConsole.Graph({
 new PromConsole.Graph({
   name: "HTTP Errors",
   node: document.querySelector("#httpErrorsGraph"),
-  expr: "sum(http_rsps{ep=~'Add.+', job='trillian-ctfe-http', rc!='200'}) without (instance, logid, job) / ignoring (rc) sum(http_reqs{ep=~'Add.+', job='trillian-ctfe-http'}) without (instance, logid, job)",
+  expr: "sum(http_rsps{ep=~'Add.+', job='trillian-ctfe-metrics-http', rc!='200'}) without (instance, logid, job) / ignoring (rc) sum(http_reqs{ep=~'Add.+', job='trillian-ctfe-metrics-http'}) without (instance, logid, job)",
   yAxisFormatter: PromConsole.NumberFormatter.humanizeNoSmallPrefix,
   yHoverFormatter: PromConsole.NumberFormatter.humanizeNoSmallPrefix,
   yTitle: "Error Rate",

--- a/trillian/integration/ct_functions.sh
+++ b/trillian/integration/ct_functions.sh
@@ -34,11 +34,12 @@ ct_prep_test() {
 
   echo "Launching CT personalities"
   for ((i=0; i < http_server_count; i++)); do
-    port=$(pick_unused_port)
+    local port=$(pick_unused_port)
     CT_SERVERS="${CT_SERVERS},localhost:${port}"
+    local metrics_port=$(pick_unused_port ${port})
 
-    echo "Starting CT HTTP server on localhost:${port}"
-    ./ct_server ${ETCD_OPTS} --log_config="${CT_CFG}" --log_rpc_server="${RPC_SERVERS}" --http_endpoint="localhost:${port}" &
+    echo "Starting CT HTTP server on localhost:${port}, metrics on localhost:${metrics_port}"
+    ./ct_server ${ETCD_OPTS} --log_config="${CT_CFG}" --log_rpc_server="${RPC_SERVERS}" --http_endpoint="localhost:${port}" --metrics_endpoint="localhost:${metrics_port}" &
     pid=$!
     CT_SERVER_PIDS+=(${pid})
     wait_for_server_startup ${port}
@@ -48,6 +49,7 @@ ct_prep_test() {
   if [[ ! -z "${ETCD_OPTS}" ]]; then
     echo "Registered HTTP endpoints"
     ETCDCTL_API=3 etcdctl get trillian-ctfe-http/ --prefix
+    ETCDCTL_API=3 etcdctl get trillian-ctfe-metrics-http/ --prefix
   fi
 
   if [[ -x "${PROMETHEUS_DIR}/prometheus" ]]; then
@@ -55,7 +57,7 @@ ct_prep_test() {
         echo "Building etcdiscover"
         go build github.com/google/trillian/monitoring/prometheus/etcdiscover
         echo "Launching etcd service monitor"
-        ./etcdiscover ${ETCD_OPTS} --etcd_services=trillian-ctfe-http,trillian-logserver-http,trillian-logsigner-http -target=./trillian.json --logtostderr &
+        ./etcdiscover ${ETCD_OPTS} --etcd_services=trillian-ctfe-metrics-http,trillian-logserver-http,trillian-logsigner-http -target=./trillian.json --logtostderr &
         ETCDISCOVER_PID=$!
         echo "Launching Prometheus (default location localhost:9090)"
         ${PROMETHEUS_DIR}/prometheus --config.file=${GOPATH}/src/github.com/google/certificate-transparency-go/trillian/integration/prometheus.yml \

--- a/trillian/integration/ct_functions.sh
+++ b/trillian/integration/ct_functions.sh
@@ -11,8 +11,9 @@ CT_CFG=
 #   - number of log signers to run
 #   - number of CT personality instances to run
 # Populates:
-#  - CT_SERVERS     : list of HTTP addresses (comma separated)
-#  - CT_SERVER_PIDS : bash array of CT HTTP server pids
+#  - CT_SERVERS         : list of HTTP addresses (comma separated)
+#  - CT_METRICS_SERVERS : list of HTTP addresses (comma separated) serving metrics
+#  - CT_SERVER_PIDS     : bash array of CT HTTP server pids
 # in addition to the variables populated by log_prep_test.
 # If etcd and Prometheus are configured, it also populates:
 #  - ETCDISCOVER_PID : pid of etcd service watcher
@@ -37,6 +38,7 @@ ct_prep_test() {
     local port=$(pick_unused_port)
     CT_SERVERS="${CT_SERVERS},localhost:${port}"
     local metrics_port=$(pick_unused_port ${port})
+    CT_METRICS_SERVERS="${CT_METRICS_SERVERS},localhost:${metrics_port}"
 
     echo "Starting CT HTTP server on localhost:${port}, metrics on localhost:${metrics_port}"
     ./ct_server ${ETCD_OPTS} --log_config="${CT_CFG}" --log_rpc_server="${RPC_SERVERS}" --http_endpoint="localhost:${port}" --metrics_endpoint="localhost:${metrics_port}" &
@@ -45,6 +47,7 @@ ct_prep_test() {
     wait_for_server_startup ${port}
   done
   CT_SERVERS="${CT_SERVERS:1}"
+  CT_METRICS_SERVERS="${CT_METRICS_SERVERS:1}"
 
   if [[ ! -z "${ETCD_OPTS}" ]]; then
     echo "Registered HTTP endpoints"

--- a/trillian/integration/ct_integration.go
+++ b/trillian/integration/ct_integration.go
@@ -100,13 +100,13 @@ func NewRandomPool(servers string, pubKey *keyspb.PublicKey, prefix string) (Cli
 // RunCTIntegrationForLog tests against the log with configuration cfg, with a set
 // of comma-separated server addresses given by servers, assuming that testdir holds
 // a variety of test data files.
-func RunCTIntegrationForLog(cfg *configpb.LogConfig, servers, testdir string, mmd time.Duration, stats *logStats) error {
+func RunCTIntegrationForLog(cfg *configpb.LogConfig, servers, metricsServers, testdir string, mmd time.Duration, stats *logStats) error {
 	pool, err := NewRandomPool(servers, cfg.PublicKey, cfg.Prefix)
 	if err != nil {
 		return fmt.Errorf("failed to create pool: %v", err)
 	}
 	ctx := context.Background()
-	if err := stats.check(cfg, servers); err != nil {
+	if err := stats.check(cfg, metricsServers); err != nil {
 		return fmt.Errorf("unexpected stats check: %v", err)
 	}
 
@@ -155,7 +155,7 @@ func RunCTIntegrationForLog(cfg *configpb.LogConfig, servers, testdir string, mm
 		return fmt.Errorf("AwaitTreeSize(1)=(nil,%v); want (_,nil)", err)
 	}
 	fmt.Printf("%s: Got STH(time=%q, size=%d): roothash=%x\n", cfg.Prefix, timeFromMS(sth1.Timestamp), sth1.TreeSize, sth1.SHA256RootHash)
-	if err := stats.check(cfg, servers); err != nil {
+	if err := stats.check(cfg, metricsServers); err != nil {
 		return fmt.Errorf("unexpected stats check: %v", err)
 	}
 
@@ -206,7 +206,7 @@ func RunCTIntegrationForLog(cfg *configpb.LogConfig, servers, testdir string, mm
 	if err := checkCTConsistencyProof(sth1, sth2, proof12); err != nil {
 		return fmt.Errorf("got CheckCTConsistencyProof(sth1,sth2,proof12)=%v; want nil", err)
 	}
-	if err := stats.check(cfg, servers); err != nil {
+	if err := stats.check(cfg, metricsServers); err != nil {
 		return fmt.Errorf("unexpected stats check: %v", err)
 	}
 
@@ -219,7 +219,7 @@ func RunCTIntegrationForLog(cfg *configpb.LogConfig, servers, testdir string, mm
 	if len(proof02) != 0 {
 		return fmt.Errorf("len(proof02)=%d; want 0", len(proof02))
 	}
-	if err := stats.check(cfg, servers); err != nil {
+	if err := stats.check(cfg, metricsServers); err != nil {
 		return fmt.Errorf("unexpected stats check: %v", err)
 	}
 
@@ -239,7 +239,7 @@ func RunCTIntegrationForLog(cfg *configpb.LogConfig, servers, testdir string, mm
 		}
 	}
 	fmt.Printf("%s: Uploaded leaf02-leaf%02d to log, got SCTs\n", cfg.Prefix, count)
-	if err := stats.check(cfg, servers); err != nil {
+	if err := stats.check(cfg, metricsServers); err != nil {
 		return fmt.Errorf("unexpected stats check: %v", err)
 	}
 
@@ -295,7 +295,7 @@ func RunCTIntegrationForLog(cfg *configpb.LogConfig, servers, testdir string, mm
 		return fmt.Errorf("retrieved cert hashes don't match uploaded cert hashes, diff:\n%v", diff)
 	}
 	fmt.Printf("%s: Got entries [1:%d+1]\n", cfg.Prefix, count)
-	if err := stats.check(cfg, servers); err != nil {
+	if err := stats.check(cfg, metricsServers); err != nil {
 		return fmt.Errorf("unexpected stats check: %v", err)
 	}
 
@@ -328,7 +328,7 @@ func RunCTIntegrationForLog(cfg *configpb.LogConfig, servers, testdir string, mm
 		}
 	}
 	fmt.Printf("%s: Got inclusion proofs [1:%d+1]\n", cfg.Prefix, count)
-	if err := stats.check(cfg, servers); err != nil {
+	if err := stats.check(cfg, metricsServers); err != nil {
 		return fmt.Errorf("unexpected stats check: %v", err)
 	}
 
@@ -349,7 +349,7 @@ func RunCTIntegrationForLog(cfg *configpb.LogConfig, servers, testdir string, mm
 	}
 	stats.done(ctfe.AddChainName, 400)
 	fmt.Printf("%s: AddChain(leaf-only)=nil,%v\n", cfg.Prefix, err)
-	if err := stats.check(cfg, servers); err != nil {
+	if err := stats.check(cfg, metricsServers); err != nil {
 		return fmt.Errorf("unexpected stats check: %v", err)
 	}
 
@@ -404,7 +404,7 @@ func RunCTIntegrationForLog(cfg *configpb.LogConfig, servers, testdir string, mm
 	if !bytes.Equal(ts.PrecertEntry.TBSCertificate, tbs) {
 		return fmt.Errorf("leaf[%d].ts.PrecertEntry differs from originally uploaded cert", precertIndex)
 	}
-	if err := stats.check(cfg, servers); err != nil {
+	if err := stats.check(cfg, metricsServers); err != nil {
 		return fmt.Errorf("unexpected stats check: %v", err)
 	}
 
@@ -440,7 +440,7 @@ func RunCTIntegrationForLog(cfg *configpb.LogConfig, servers, testdir string, mm
 	if err := Verifier.VerifyInclusionProof(rsp.LeafIndex, int64(sthN1.TreeSize), rsp.AuditPath, sthN1.SHA256RootHash[:], leafData); err != nil {
 		return fmt.Errorf("got VerifyInclusionProof(%d,%d,...)=%v; want nil", precertIndex, sthN1.TreeSize, err)
 	}
-	if err := stats.check(cfg, servers); err != nil {
+	if err := stats.check(cfg, metricsServers); err != nil {
 		return fmt.Errorf("unexpected stats check: %v", err)
 	}
 

--- a/trillian/integration/ct_integration_test.go
+++ b/trillian/integration/ct_integration_test.go
@@ -31,6 +31,7 @@ import (
 )
 
 var httpServersFlag = flag.String("ct_http_servers", "localhost:8092", "Comma-separated list of (assumed interchangeable) servers, each as address:port")
+var metricsServersFlag = flag.String("ct_metrics_servers", "localhost:8093", "Comma-separated list of (assumed interchangeable) metrics servers, each as address:port")
 var testDir = flag.String("testdata_dir", "testdata", "Name of directory with test data")
 var seed = flag.Int64("seed", -1, "Seed for random number generation")
 var logConfigFlag = flag.String("log_config", "", "File holding log config in JSON")
@@ -61,7 +62,7 @@ func TestLiveCTIntegration(t *testing.T) {
 			if !*skipStats {
 				stats = newLogStats(cfg.LogId)
 			}
-			if err := RunCTIntegrationForLog(cfg, *httpServersFlag, *testDir, *mmdFlag, stats); err != nil {
+			if err := RunCTIntegrationForLog(cfg, *httpServersFlag, *metricsServersFlag, *testDir, *mmdFlag, stats); err != nil {
 				t.Errorf("%s: failed: %v", cfg.Prefix, err)
 			}
 		})
@@ -124,7 +125,7 @@ func TestInProcessCTIntegration(t *testing.T) {
 			t.Run(cfg.Prefix, func(t *testing.T) {
 				t.Parallel()
 				stats := newLogStats(cfg.LogId)
-				if err := RunCTIntegrationForLog(cfg, env.CTAddr, "../testdata", mmd, stats); err != nil {
+				if err := RunCTIntegrationForLog(cfg, env.CTAddr, env.CTAddr, "../testdata", mmd, stats); err != nil {
 					t.Errorf("%s: failed: %v", cfg.Prefix, err)
 				}
 			})

--- a/trillian/integration/ct_integration_test.sh
+++ b/trillian/integration/ct_integration_test.sh
@@ -26,7 +26,7 @@ TO_KILL+=(${CT_SERVER_PIDS[@]})
 echo "Running test(s)"
 pushd "${INTEGRATION_DIR}"
 set +e
-go test -v -run ".*LiveCT.*" --timeout=5m ./ --log_config "${CT_CFG}" --ct_http_servers=${CT_SERVERS} --testdata_dir=${GOPATH}/src/github.com/google/certificate-transparency-go/trillian/testdata
+go test -v -run ".*LiveCT.*" --timeout=5m ./ --log_config "${CT_CFG}" --ct_http_servers=${CT_SERVERS} --ct_metrics_servers=${CT_METRICS_SERVERS} --testdata_dir=${GOPATH}/src/github.com/google/certificate-transparency-go/trillian/testdata
 RESULT=$?
 set -e
 popd


### PR DESCRIPTION
Add a command line option to expose metrics on a separate endpoint,
and update the integration tests to configure and use such an endpoint.

Fixes #18 