### PR TITLE
trillian/hammer: cope with bigger logs

### DIFF
--- a/trillian/integration/ct_hammer/main.go
+++ b/trillian/integration/ct_hammer/main.go
@@ -188,6 +188,6 @@ func main() {
 		}
 	}
 	if errCount > 0 {
-		os.Exit(1)
+		glog.Exitf("non-zero error count (%d), exiting", errCount)
 	}
 }


### PR DESCRIPTION
Don't generate an invalid request if we don't know a recent tree
size, as there's no way to guess how big is invalid.

Even when we do know an STH, use a bigger gap just in case the
log is growing super fast.