### PR TITLE
x509util: add go-fuzz entrypoint

### DIFF
--- a/x509util/fuzz.go
+++ b/x509util/fuzz.go
@@ -1,0 +1,26 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package x509util
+
+import "github.com/google/certificate-transparency-go/x509"
+
+// Fuzz is a go-fuzz (https://github.com/dvyukov/go-fuzz) entrypoint
+// for fuzzing the parsing of X509 certificates.
+func Fuzz(data []byte) int {
+	if _, err := x509.ParseCertificate(data); err == nil {
+		return 1
+	}
+	return 0
+}


### PR DESCRIPTION
Suitable corpus would be any collection of interesting certificates,
e.g. those built in https://github.com/google/x509test.