### PR TITLE
Minor improvements to ctclient tool

### DIFF
--- a/client/ctclient/ctclient.go
+++ b/client/ctclient/ctclient.go
@@ -226,7 +226,7 @@ func main() {
 		addChain(ctx, logClient)
 	case "getroots", "get_roots", "get-roots":
 		getRoots(ctx, logClient)
-	case "getentries", "get_entries":
+	case "getentries", "get_entries", "get-entries":
 		getEntries(ctx, logClient)
 	default:
 		dieWithUsage(fmt.Sprintf("Unknown command '%s'", cmd))

--- a/client/ctclient/ctclient.go
+++ b/client/ctclient/ctclient.go
@@ -177,7 +177,7 @@ func showTBSCert(tbs []byte) {
 }
 
 func dieWithUsage(msg string) {
-	fmt.Fprintf(os.Stderr, msg)
+	fmt.Fprintln(os.Stderr, msg)
 	fmt.Fprintf(os.Stderr, "Usage: ctclient [options] <cmd>\n"+
 		"where cmd is one of:\n"+
 		"   sth         retrieve signed tree head\n"+


### PR DESCRIPTION
Fixed formatting of message output by `dieWithUsage()` and added "get-entries" as a synonym for the "getentries" command.