### PR TITLE
Delete uses of DefaultSignerFactory

### DIFF
--- a/trillian/ctfe/ct_server/main.go
+++ b/trillian/ctfe/ct_server/main.go
@@ -32,11 +32,15 @@ import (
 	"github.com/google/certificate-transparency-go/trillian/ctfe/configpb"
 	"github.com/google/certificate-transparency-go/trillian/util"
 	"github.com/google/trillian"
-	"github.com/google/trillian/crypto/keys"
 	"github.com/google/trillian/monitoring/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/naming"
+
+	// Register PEMKeyFile, PrivateKey and PKCS11Config ProtoHandlers
+	_ "github.com/google/trillian/crypto/keys/der/proto"
+	_ "github.com/google/trillian/crypto/keys/pem/proto"
+	_ "github.com/google/trillian/crypto/keys/pkcs11/proto"
 )
 
 // Global flags that affect all log instances.
@@ -117,10 +121,8 @@ func main() {
 	defer conn.Close()
 	client := trillian.NewTrillianLogClient(conn)
 
-	sf := &keys.DefaultSignerFactory{}
-
 	for _, c := range cfg {
-		handlers, err := ctfe.SetUpInstance(ctx, client, c, sf, *rpcDeadlineFlag, prometheus.MetricFactory{})
+		handlers, err := ctfe.SetUpInstance(ctx, client, c, *rpcDeadlineFlag, prometheus.MetricFactory{})
 		if err != nil {
 			glog.Exitf("Failed to set up log instance for %+v: %v", cfg, err)
 		}

--- a/trillian/ctfe/instance.go
+++ b/trillian/ctfe/instance.go
@@ -77,7 +77,7 @@ var stringToKeyUsage = map[string]x509.ExtKeyUsage{
 
 // SetUpInstance sets up a log instance that uses the specified client to communicate
 // with the Trillian RPC back end.
-func SetUpInstance(ctx context.Context, client trillian.TrillianLogClient, cfg *configpb.LogConfig, sf keys.SignerFactory, deadline time.Duration, mf monitoring.MetricFactory) (*PathHandlers, error) {
+func SetUpInstance(ctx context.Context, client trillian.TrillianLogClient, cfg *configpb.LogConfig, deadline time.Duration, mf monitoring.MetricFactory) (*PathHandlers, error) {
 	// Check config validity.
 	if len(cfg.RootsPemFile) == 0 {
 		return nil, errors.New("need to specify RootsPemFile")
@@ -100,7 +100,7 @@ func SetUpInstance(ctx context.Context, client trillian.TrillianLogClient, cfg *
 		return nil, fmt.Errorf("failed to unmarshal cfg.PrivateKey: %v", err)
 	}
 
-	key, err := sf.NewSigner(ctx, keyProto.Message)
+	key, err := keys.NewSigner(ctx, keyProto.Message)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load private key: %v", err)
 	}

--- a/trillian/ctfe/instance_test.go
+++ b/trillian/ctfe/instance_test.go
@@ -20,18 +20,19 @@ import (
 	"testing"
 	"time"
 
+	// Register PEMKeyFile ProtoHandler
+	_ "github.com/google/trillian/crypto/keys/pem/proto"
+
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/timestamp"
 	ct "github.com/google/certificate-transparency-go"
 	"github.com/google/certificate-transparency-go/trillian/ctfe/configpb"
-	"github.com/google/trillian/crypto/keys"
 	"github.com/google/trillian/crypto/keyspb"
 	"github.com/google/trillian/monitoring"
 )
 
 func TestSetUpInstance(t *testing.T) {
 	ctx := context.Background()
-	sf := &keys.DefaultSignerFactory{}
 
 	privKey, err := ptypes.MarshalAny(&keyspb.PEMKeyFile{Path: "../testdata/ct-http-server.privkey.pem", Password: "dirk"})
 	if err != nil {
@@ -155,8 +156,7 @@ func TestSetUpInstance(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		_, err := SetUpInstance(ctx, nil, &test.cfg, sf, time.Second, monitoring.InertMetricFactory{})
-		if err != nil {
+		if _, err := SetUpInstance(ctx, nil, &test.cfg, time.Second, monitoring.InertMetricFactory{}); err != nil {
 			if test.errStr == "" {
 				t.Errorf("(%v).SetUpInstance()=_,%v; want _,nil", test.desc, err)
 			} else if !strings.Contains(err.Error(), test.errStr) {
@@ -183,7 +183,6 @@ func equivalentTimes(a *time.Time, b *timestamp.Timestamp) bool {
 
 func TestSetUpInstanceSetsValidationOpts(t *testing.T) {
 	ctx := context.Background()
-	sf := &keys.DefaultSignerFactory{}
 
 	start := &timestamp.Timestamp{Seconds: 10000}
 	limit := &timestamp.Timestamp{Seconds: 12000}
@@ -239,7 +238,7 @@ func TestSetUpInstanceSetsValidationOpts(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		h, err := SetUpInstance(ctx, nil, &test.cfg, sf, time.Second, monitoring.InertMetricFactory{})
+		h, err := SetUpInstance(ctx, nil, &test.cfg, time.Second, monitoring.InertMetricFactory{})
 		if err != nil {
 			t.Errorf("%v: SetUpInstance() = %v, want no error", test.desc, err)
 			continue

--- a/trillian/integration/ct_integration_test.go
+++ b/trillian/integration/ct_integration_test.go
@@ -28,6 +28,10 @@ import (
 	"github.com/google/certificate-transparency-go/trillian/ctfe"
 	"github.com/google/certificate-transparency-go/trillian/ctfe/configpb"
 	"github.com/google/trillian/crypto/keyspb"
+
+	// Register PEMKeyFile and PrivateKey ProtoHandlers
+	_ "github.com/google/trillian/crypto/keys/der/proto"
+	_ "github.com/google/trillian/crypto/keys/pem/proto"
 )
 
 var httpServersFlag = flag.String("ct_http_servers", "localhost:8092", "Comma-separated list of (assumed interchangeable) servers, each as address:port")

--- a/trillian/integration/logenv.go
+++ b/trillian/integration/logenv.go
@@ -26,7 +26,6 @@ import (
 	"github.com/google/certificate-transparency-go/trillian/ctfe"
 	"github.com/google/certificate-transparency-go/trillian/ctfe/configpb"
 	"github.com/google/trillian"
-	"github.com/google/trillian/crypto/keys"
 	"github.com/google/trillian/monitoring/prometheus"
 	"github.com/google/trillian/testonly/integration"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -72,9 +71,8 @@ func NewCTLogEnv(ctx context.Context, cfgs []*configpb.LogConfig, numSequencers 
 	go func(env *integration.LogEnv, server *http.Server, listener net.Listener, cfgs []*configpb.LogConfig) {
 		defer wg.Done()
 		client := trillian.NewTrillianLogClient(env.ClientConn)
-		sf := &keys.DefaultSignerFactory{}
 		for _, cfg := range cfgs {
-			handlers, err := ctfe.SetUpInstance(ctx, client, cfg, sf, 10*time.Second, prometheus.MetricFactory{})
+			handlers, err := ctfe.SetUpInstance(ctx, client, cfg, 10*time.Second, prometheus.MetricFactory{})
 			if err != nil {
 				glog.Fatalf("Failed to set up log instance for %+v: %v", cfg, err)
 			}


### PR DESCRIPTION
PR google/trillian#734 deletes DefaultSignerFactory and moves/renames some crypto funcs. This PR makes the required changes to accommodate this.