### PR TITLE
trillian/ctfe: fix missing empty proof case

### DIFF
--- a/trillian/ctfe/handlers.go
+++ b/trillian/ctfe/handlers.go
@@ -473,6 +473,7 @@ func getSTHConsistency(ctx context.Context, c LogContext, w http.ResponseWriter,
 		}
 	} else {
 		glog.V(2).Infof("%s: GetSTHConsistency(%d, %d) starts from 0 so return empty proof", c.LogPrefix, first, second)
+		jsonRsp.Consistency = emptyProof
 	}
 
 	w.Header().Set(contentTypeHeader, contentTypeJSON)

--- a/trillian/ctfe/handlers_test.go
+++ b/trillian/ctfe/handlers_test.go
@@ -1128,6 +1128,15 @@ func TestGetSTHConsistency(t *testing.T) {
 			want: http.StatusBadRequest,
 		},
 		{
+			req:  "first=0&second=1",
+			want: http.StatusOK,
+			httpRsp: &ct.GetSTHConsistencyResponse{
+				Consistency: nil,
+			},
+			// Check a nil proof is passed through as '[]' not 'null' in raw JSON.
+			httpJSON: "{\"consistency\":[]}",
+		},
+		{
 			req:  "first=998&second=997",
 			want: http.StatusBadRequest,
 		},


### PR DESCRIPTION
For get-sth-consistency?first=0 we always return an empty proof;
this needs to be forced to be [] in JSON.

Missed case in commit 35b97ca625df ("trillian/ctfe: force empty proof
to []")