### PR TITLE
Pass --private_key_format flag to createtree command

### DIFF
--- a/trillian/integration/ct_functions.sh
+++ b/trillian/integration/ct_functions.sh
@@ -92,6 +92,7 @@ ct_provision() {
     # TODO(daviddrysdale): Consider using distinct keys for each log
     tree_id=$(./createtree \
       --admin_server="${admin_server}" \
+      --private_key_format=PrivateKey \
       --pem_key_path=${GOPATH}/src/github.com/google/certificate-transparency-go/trillian/testdata/log-rpc-server.privkey.pem \
       --pem_key_password=towel \
       --signature_algorithm=ECDSA)


### PR DESCRIPTION
As of google/trillian#762, this flag is now required unless letting Trillian generate a key.