### PR TITLE
Allow requests for consistency proofs where first=second

### DIFF
--- a/trillian/ctfe/handlers.go
+++ b/trillian/ctfe/handlers.go
@@ -875,7 +875,7 @@ func parseGetSTHConsistencyRange(r *http.Request) (int64, int64, error) {
 	if first < 0 || second < 0 {
 		return 0, 0, fmt.Errorf("first and second params cannot be <0: %d %d", first, second)
 	}
-	if second <= first {
+	if second < first {
 		return 0, 0, fmt.Errorf("invalid first, second params: %d %d", first, second)
 	}
 

--- a/trillian/ctfe/handlers_test.go
+++ b/trillian/ctfe/handlers_test.go
@@ -33,7 +33,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/golang/mock/gomock"
-	ct "github.com/google/certificate-transparency-go"
+	"github.com/google/certificate-transparency-go"
 	"github.com/google/certificate-transparency-go/tls"
 	cttestonly "github.com/google/certificate-transparency-go/trillian/ctfe/testonly"
 	"github.com/google/certificate-transparency-go/trillian/mockclient"
@@ -1124,10 +1124,6 @@ func TestGetSTHConsistency(t *testing.T) {
 			want: http.StatusBadRequest,
 		},
 		{
-			req:  "first=6&second=6",
-			want: http.StatusBadRequest,
-		},
-		{
 			req:  "first=0&second=1",
 			want: http.StatusOK,
 			httpRsp: &ct.GetSTHConsistencyResponse{
@@ -1225,6 +1221,27 @@ func TestGetSTHConsistency(t *testing.T) {
 			},
 			// Check a nil proof is passed through as '[]' not 'null' in raw JSON.
 			httpJSON: "{\"consistency\":[]}",
+		},
+		{
+			req:    "first=332&second=332",
+			first:  332,
+			second: 332,
+			want:   http.StatusOK,
+			rpcRsp: &trillian.GetConsistencyProofResponse{
+				Proof: &trillian.Proof{
+					LeafIndex: 0,
+					Hashes:    nil,
+				},
+			},
+			httpRsp: &ct.GetSTHConsistencyResponse{
+				Consistency: nil,
+			},
+			// Check a nil proof is passed through as '[]' not 'null' in raw JSON.
+			httpJSON: "{\"consistency\":[]}",
+		},
+		{
+			req:  "first=332&second=331",
+			want: http.StatusBadRequest,
 		},
 	}
 


### PR DESCRIPTION
These requests don't really make sense but this is for better compatibility with C++ logs, which return an empty proof for this case. Needs log backend change in other repo:

https://github.com/google/trillian/pull/819