### PR TITLE
LogClient.GetEntries parses X509Certs, Precerts like docs imply.

### DIFF
--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -116,6 +116,7 @@ func TestScannerMatchSubjectRegexMatchesPrecertificateCommonName(t *testing.T) {
 	const SubjectName = "www.example.com"
 	const SubjectRegEx = ".*example.com"
 	var precert ct.Precertificate
+	precert.TBSCertificate = &x509.Certificate{}
 	precert.TBSCertificate.Subject.CommonName = SubjectName
 
 	m := MatchSubjectRegex{nil, regexp.MustCompile(SubjectRegEx)}
@@ -128,6 +129,7 @@ func TestScannerMatchSubjectRegexIgnoresDifferentPrecertificateCommonName(t *tes
 	const SubjectName = "www.google.com"
 	const SubjectRegEx = ".*example.com"
 	var precert ct.Precertificate
+	precert.TBSCertificate = &x509.Certificate{}
 	precert.TBSCertificate.Subject.CommonName = SubjectName
 
 	m := MatchSubjectRegex{nil, regexp.MustCompile(SubjectRegEx)}
@@ -140,6 +142,7 @@ func TestScannerMatchSubjectRegexIgnoresDifferentPrecertificateSAN(t *testing.T)
 	const SubjectName = "www.google.com"
 	const SubjectRegEx = ".*example.com"
 	var precert ct.Precertificate
+	precert.TBSCertificate = &x509.Certificate{}
 	precert.TBSCertificate.Subject.CommonName = SubjectName
 
 	m := MatchSubjectRegex{nil, regexp.MustCompile(SubjectRegEx)}
@@ -156,6 +159,7 @@ func TestScannerMatchSubjectRegexMatchesPrecertificateSAN(t *testing.T) {
 	const SubjectName = "www.example.com"
 	const SubjectRegEx = ".*example.com"
 	var precert ct.Precertificate
+	precert.TBSCertificate = &x509.Certificate{}
 	precert.TBSCertificate.Subject.CommonName = SubjectName
 
 	m := MatchSubjectRegex{nil, regexp.MustCompile(SubjectRegEx)}

--- a/types.go
+++ b/types.go
@@ -202,6 +202,8 @@ type LogEntry struct {
 	Precert  *Precertificate   // Extracted precertificate
 	JSONData []byte
 
+	// Chain holds the issuing certificate chain, starting with the
+	// issuer of the leaf certificate / pre-certificate.
 	Chain []ASN1Cert
 }
 
@@ -331,18 +333,37 @@ type MerkleTreeLeaf struct {
 
 // Precertificate represents the parsed CT Precertificate structure.
 type Precertificate struct {
-	// Raw DER bytes of the precert
-	Raw []byte
+	// DER-encoded pre-certificate as originally added, which includes a
+	// poison extension and a signature generated over the pre-cert by
+	// the pre-cert issuer (which might differ from the issuer of the final
+	// cert, see RFC6962 s3.1).
+	Submitted ASN1Cert
 	// SHA256 hash of the issuing key
 	IssuerKeyHash [sha256.Size]byte
 	// Parsed TBSCertificate structure, held in an x509.Certificate for convenience.
-	TBSCertificate x509.Certificate
+	TBSCertificate *x509.Certificate
 }
 
 // X509Certificate returns the X.509 Certificate contained within the
 // MerkleTreeLeaf.
 func (m *MerkleTreeLeaf) X509Certificate() (*x509.Certificate, error) {
+	if m.TimestampedEntry.EntryType != X509LogEntryType {
+		return nil, fmt.Errorf("cannot call X509Certificate on a MerkleTreeLeaf that is not an X509 entry")
+	}
 	return x509.ParseCertificate(m.TimestampedEntry.X509Entry.Data)
+}
+
+// Precertificate returns the X.509 Precertificate contained within the MerkleTreeLeaf.
+//
+// The returned precertificate is embedded in an x509.Certificate, but is in the
+// form stored internally in the log rather than the original submitted form
+// (i.e. it does not include the poison extension and any changes to reflect the
+// final certificate's issuer have been made; see x509.BuildPrecertTBS).
+func (m *MerkleTreeLeaf) Precertificate() (*x509.Certificate, error) {
+	if m.TimestampedEntry.EntryType != PrecertLogEntryType {
+		return nil, fmt.Errorf("cannot call Precertificate on a MerkleTreeLeaf that is not a precert entry")
+	}
+	return x509.ParseTBSCertificate(m.TimestampedEntry.PrecertEntry.TBSCertificate)
 }
 
 // URI paths for Log requests; see section 4.


### PR DESCRIPTION
The docs for [ct.LogEntry](https://godoc.org/github.com/google/certificate-transparency-go#LogEntry) say that either X509Cert, Precert, or JSONData will be populated. I was surprised to see that in the output of LogClient.GetEntries, all three were nil. This PR addresses that, and some refactors of the API's consumers:
- The ctclient command outputs precerts as PEM-encoded X.509.
- The scanner package calls LogClient.GetRawEntries and re-implements LogClient.GetEntries with more graceful error handling.
- ct.Precertificate's TBSCertificate field was changed to a pointer and nil-pointer accesses were fixed.