### PR TITLE
Improve error response messages for get-sth-consistency

### DIFF
--- a/trillian/ctfe/handlers.go
+++ b/trillian/ctfe/handlers.go
@@ -862,14 +862,23 @@ func parseGetEntryAndProofParams(r *http.Request) (int64, int64, error) {
 }
 
 func parseGetSTHConsistencyRange(r *http.Request) (int64, int64, error) {
-	first, err := strconv.ParseInt(r.FormValue(getSTHConsistencyParamFirst), 10, 64)
-	if err != nil {
-		return 0, 0, err
+	firstVal := r.FormValue(getSTHConsistencyParamFirst)
+	secondVal := r.FormValue(getSTHConsistencyParamSecond)
+	if firstVal == "" {
+		return 0, 0, fmt.Errorf("parameter 'first' is required")
+	}
+	if secondVal == "" {
+		return 0, 0, fmt.Errorf("parameter 'second' is required")	
 	}
 
-	second, err := strconv.ParseInt(r.FormValue(getSTHConsistencyParamSecond), 10, 64)
+	first, err := strconv.ParseInt(firstVal, 10, 64)
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, fmt.Errorf("parameter 'first' is malformed")
+	}
+
+	second, err := strconv.ParseInt(secondVal, 10, 64)
+	if err != nil {
+		return 0, 0, fmt.Errorf("parameter 'second' is malformed")
 	}
 
 	if first < 0 || second < 0 {

--- a/trillian/ctfe/handlers.go
+++ b/trillian/ctfe/handlers.go
@@ -868,7 +868,7 @@ func parseGetSTHConsistencyRange(r *http.Request) (int64, int64, error) {
 		return 0, 0, fmt.Errorf("parameter 'first' is required")
 	}
 	if secondVal == "" {
-		return 0, 0, fmt.Errorf("parameter 'second' is required")	
+		return 0, 0, fmt.Errorf("parameter 'second' is required")
 	}
 
 	first, err := strconv.ParseInt(firstVal, 10, 64)

--- a/trillian/ctfe/handlers.go
+++ b/trillian/ctfe/handlers.go
@@ -865,20 +865,20 @@ func parseGetSTHConsistencyRange(r *http.Request) (int64, int64, error) {
 	firstVal := r.FormValue(getSTHConsistencyParamFirst)
 	secondVal := r.FormValue(getSTHConsistencyParamSecond)
 	if firstVal == "" {
-		return 0, 0, fmt.Errorf("parameter 'first' is required")
+		return 0, 0, errors.New("parameter 'first' is required")
 	}
 	if secondVal == "" {
-		return 0, 0, fmt.Errorf("parameter 'second' is required")
+		return 0, 0, errors.New("parameter 'second' is required")
 	}
 
 	first, err := strconv.ParseInt(firstVal, 10, 64)
 	if err != nil {
-		return 0, 0, fmt.Errorf("parameter 'first' is malformed")
+		return 0, 0, errors.New("parameter 'first' is malformed")
 	}
 
 	second, err := strconv.ParseInt(secondVal, 10, 64)
 	if err != nil {
-		return 0, 0, fmt.Errorf("parameter 'second' is malformed")
+		return 0, 0, errors.New("parameter 'second' is malformed")
 	}
 
 	if first < 0 || second < 0 {

--- a/trillian/ctfe/handlers_test.go
+++ b/trillian/ctfe/handlers_test.go
@@ -1102,26 +1102,37 @@ func TestGetSTHConsistency(t *testing.T) {
 		{
 			req:  "",
 			want: http.StatusBadRequest,
+			errStr: "parameter 'first' is required",
 		},
 		{
 			req:  "first=apple&second=orange",
 			want: http.StatusBadRequest,
+			errStr: "parameter 'first' is malformed",
+		},
+		{
+			req:  "first=1&last=2",
+			want: http.StatusBadRequest,
+			errStr: "parameter 'second' is required",
 		},
 		{
 			req:  "first=1&second=a",
 			want: http.StatusBadRequest,
+			errStr: "parameter 'second' is malformed",
 		},
 		{
 			req:  "first=a&second=2",
 			want: http.StatusBadRequest,
+			errStr: "parameter 'first' is malformed",
 		},
 		{
 			req:  "first=-1&second=10",
 			want: http.StatusBadRequest,
+			errStr: "first and second params cannot be <0: -1 10",
 		},
 		{
 			req:  "first=10&second=-11",
 			want: http.StatusBadRequest,
+			errStr: "first and second params cannot be <0: 10 -11",
 		},
 		{
 			req:  "first=0&second=1",
@@ -1133,20 +1144,30 @@ func TestGetSTHConsistency(t *testing.T) {
 			httpJSON: "{\"consistency\":[]}",
 		},
 		{
+			// Check that unrecognized parameters are ignored.
+			req:  "first=0&second=1&third=2&fourth=3",
+			want: http.StatusOK,
+			httpRsp: &ct.GetSTHConsistencyResponse{},
+		},
+		{
 			req:  "first=998&second=997",
 			want: http.StatusBadRequest,
+			errStr: "invalid first, second params: 998 997",
 		},
 		{
 			req:  "first=1000&second=200",
 			want: http.StatusBadRequest,
+			errStr: "invalid first, second params: 1000 200",
 		},
 		{
 			req:  "first=10",
 			want: http.StatusBadRequest,
+			errStr: "parameter 'second' is required",
 		},
 		{
 			req:  "second=20",
 			want: http.StatusBadRequest,
+			errStr: "parameter 'first' is required",
 		},
 		{
 			req:    "first=10&second=20",


### PR DESCRIPTION
This PR ensures that failures to find or parse the parameters 'first' and 'second' are reported in the API response with sensible messages rather than passing through the underlying Go error.