### PR TITLE
Make the String method take a LogID instead of a *LogID.

### DIFF
--- a/logid/logid.go
+++ b/logid/logid.go
@@ -84,6 +84,6 @@ func (l LogID) Bytes() []byte {
 }
 
 // String base64-encodes a LogID for ease of debugging.
-func (l *LogID) String() string {
-	return fmt.Sprintf("logid:[%s]", base64.StdEncoding.EncodeToString(l[:]))
+func (l LogID) String() string {
+	return fmt.Sprintf("logid:[%s]", base64.StdEncoding.EncodeToString(l.Bytes()))
 }


### PR DESCRIPTION
This seems to work better with various formatters. Also use the Bytes method to get the raw bytes.