### PR TITLE
ct_hammer: skip add-[pre-]chain if no certs

### DIFF
--- a/trillian/integration/hammer.go
+++ b/trillian/integration/hammer.go
@@ -667,7 +667,9 @@ func (s *hammerState) chooseOp() (ctfe.EntrypointName, bool) {
 	if len(s.nextOp) > 0 {
 		ep := s.nextOp[0]
 		s.nextOp = s.nextOp[1:]
-		return ep, false
+		if s.cfg.EPBias.Bias[ep] > 0 {
+			return ep, false
+		}
 	}
 	ep := s.cfg.EPBias.Choose()
 	return ep, s.cfg.EPBias.Invalid(ep)


### PR DESCRIPTION
Make it easier to use the hammer in a read-only mode by just skipping
the test certs and key.