### PR TITLE
Implement multi log config support in ctfe main

### DIFF
--- a/trillian/ctfe/ct_server/main.go
+++ b/trillian/ctfe/ct_server/main.go
@@ -130,7 +130,6 @@ func main() {
 	clientMap := make(map[string]trillian.TrillianLogClient)
 	for _, be := range beMap {
 		glog.Infof("Dialling backend: %v", be)
-		var conn *grpc.ClientConn
 		bal := grpc.RoundRobin(res)
 		opts := []grpc.DialOption{grpc.WithInsecure(), grpc.WithBalancer(bal)}
 		if len(beMap) == 1 {

--- a/trillian/ctfe/instance.go
+++ b/trillian/ctfe/instance.go
@@ -194,7 +194,7 @@ func ValidateLogMultiConfig(cfg *configpb.LogMultiConfig) (map[string]*configpb.
 }
 
 // ToMultiLogConfig creates a multi backend config proto from the data
-// loaded from a single backend configuration file. All the log configs
+// loaded from a single-backend configuration file. All the log configs
 // reference a default backend spec as provided.
 func ToMultiLogConfig(cfg []*configpb.LogConfig, beSpec string) *configpb.LogMultiConfig {
 	defaultBackend := &configpb.LogBackend{Name: "default", BackendSpec: beSpec}

--- a/trillian/ctfe/instance_test.go
+++ b/trillian/ctfe/instance_test.go
@@ -23,6 +23,7 @@ import (
 	// Register PEMKeyFile ProtoHandler
 	_ "github.com/google/trillian/crypto/keys/pem/proto"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/timestamp"
 	ct "github.com/google/certificate-transparency-go"
@@ -387,6 +388,61 @@ func TestValidateLogMultiConfig(t *testing.T) {
 
 		if len(test.errStr) > 0 && (err == nil || !strings.Contains(err.Error(), test.errStr)) {
 			t.Errorf("ValidateLogMultiConfig()=%v, want: %v (%v)", err, test.errStr, test.desc)
+		}
+	}
+}
+
+func TestToMultiLogConfig(t *testing.T) {
+	var tests = []struct {
+		desc string
+		cfg  []*configpb.LogConfig
+		want *configpb.LogMultiConfig
+	}{
+		{
+			desc: "one valid log config",
+			cfg: []*configpb.LogConfig{
+				{LogId: 1, Prefix: "test"},
+			},
+			want: &configpb.LogMultiConfig{
+				Backends: &configpb.LogBackendSet{
+					Backend: []*configpb.LogBackend{{Name: "default", BackendSpec: "spec"}},
+				},
+				LogConfigs: &configpb.LogConfigSet{
+					Config: []*configpb.LogConfig{{Prefix: "test", LogId: 1, LogBackendName: "default"}},
+				},
+			},
+		},
+		{
+			desc: "three valid log configs",
+			cfg: []*configpb.LogConfig{
+				{LogId: 1, Prefix: "test1"},
+				{LogId: 2, Prefix: "test2"},
+				{LogId: 3, Prefix: "test3"},
+			},
+			want: &configpb.LogMultiConfig{
+				Backends: &configpb.LogBackendSet{
+					Backend: []*configpb.LogBackend{{Name: "default", BackendSpec: "spec"}},
+				},
+				LogConfigs: &configpb.LogConfigSet{
+					Config: []*configpb.LogConfig{
+						{Prefix: "test1", LogId: 1, LogBackendName: "default"},
+						{Prefix: "test2", LogId: 2, LogBackendName: "default"},
+						{Prefix: "test3", LogId: 3, LogBackendName: "default"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		got, beMap := ToMultiLogConfig(test.cfg, "spec")
+
+		if !proto.Equal(got, test.want) {
+			t.Errorf("TestToMultiLogConfig() got: %v, want: %v (%v)", got, test.want, test.desc)
+		}
+		// Should always produce a 1 element size backend map
+		if got, want := len(beMap), 1; got != want {
+			t.Errorf("TestToMultiLogConfig() backend map size got: %v, want: %v (%v)", got, want, test.desc)
 		}
 	}
 }

--- a/trillian/ctfe/instance_test.go
+++ b/trillian/ctfe/instance_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/timestamp"
-	ct "github.com/google/certificate-transparency-go"
+	"github.com/google/certificate-transparency-go"
 	"github.com/google/certificate-transparency-go/trillian/ctfe/configpb"
 	"github.com/google/trillian/crypto/keyspb"
 	"github.com/google/trillian/monitoring"
@@ -435,14 +435,10 @@ func TestToMultiLogConfig(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		got, beMap := ToMultiLogConfig(test.cfg, "spec")
+		got := ToMultiLogConfig(test.cfg, "spec")
 
 		if !proto.Equal(got, test.want) {
 			t.Errorf("TestToMultiLogConfig() got: %v, want: %v (%v)", got, test.want, test.desc)
-		}
-		// Should always produce a 1 element size backend map
-		if got, want := len(beMap), 1; got != want {
-			t.Errorf("TestToMultiLogConfig() backend map size got: %v, want: %v (%v)", got, want, test.desc)
 		}
 	}
 }


### PR DESCRIPTION
This adds the ability for one set of CTFEs to talk to multiple log backend servers. Going to defer testing that case for the moment as it needs etcd / infrastructure set up and focus on not having broken the simple case that everybody is using.