### PR TITLE
trillian/ctfe: allow injection of an error mapper

### DIFF
--- a/trillian/ctfe/ct_server/main.go
+++ b/trillian/ctfe/ct_server/main.go
@@ -211,7 +211,8 @@ func awaitSignal(doneFn func()) {
 }
 
 func setupAndRegister(ctx context.Context, client trillian.TrillianLogClient, deadline time.Duration, cfg *configpb.LogConfig) error {
-	handlers, err := ctfe.SetUpInstance(ctx, client, cfg, deadline, prometheus.MetricFactory{})
+	opts := ctfe.InstanceOptions{Deadline: deadline, MetricFactory: prometheus.MetricFactory{}}
+	handlers, err := ctfe.SetUpInstance(ctx, client, cfg, opts)
 	if err != nil {
 		return err
 	}

--- a/trillian/ctfe/handlers_test.go
+++ b/trillian/ctfe/handlers_test.go
@@ -121,7 +121,8 @@ func setupTest(t *testing.T, pemRoots []string, signer *crypto.Signer) handlerTe
 		rejectExpired: false,
 		extKeyUsages:  []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
 	}
-	info.c = *NewLogContext(0x42, "test", vOpts, info.client, signer, time.Millisecond*500, fakeTimeSource, monitoring.InertMetricFactory{})
+	iOpts := InstanceOptions{Deadline: time.Millisecond * 500, MetricFactory: monitoring.InertMetricFactory{}}
+	info.c = *NewLogContext(0x42, "test", vOpts, info.client, signer, iOpts, fakeTimeSource)
 
 	for _, pemRoot := range pemRoots {
 		if !info.roots.AppendCertsFromPEM([]byte(pemRoot)) {

--- a/trillian/ctfe/instance_test.go
+++ b/trillian/ctfe/instance_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/timestamp"
-	"github.com/google/certificate-transparency-go"
+	ct "github.com/google/certificate-transparency-go"
 	"github.com/google/certificate-transparency-go/trillian/ctfe/configpb"
 	"github.com/google/trillian/crypto/keyspb"
 	"github.com/google/trillian/monitoring"
@@ -156,8 +156,9 @@ func TestSetUpInstance(t *testing.T) {
 		},
 	}
 
+	opts := InstanceOptions{Deadline: time.Second, MetricFactory: monitoring.InertMetricFactory{}}
 	for _, test := range tests {
-		if _, err := SetUpInstance(ctx, nil, &test.cfg, time.Second, monitoring.InertMetricFactory{}); err != nil {
+		if _, err := SetUpInstance(ctx, nil, &test.cfg, opts); err != nil {
 			if test.errStr == "" {
 				t.Errorf("(%v).SetUpInstance()=_,%v; want _,nil", test.desc, err)
 			} else if !strings.Contains(err.Error(), test.errStr) {
@@ -238,8 +239,9 @@ func TestSetUpInstanceSetsValidationOpts(t *testing.T) {
 		},
 	}
 
+	opts := InstanceOptions{Deadline: time.Second, MetricFactory: monitoring.InertMetricFactory{}}
 	for _, test := range tests {
-		h, err := SetUpInstance(ctx, nil, &test.cfg, time.Second, monitoring.InertMetricFactory{})
+		h, err := SetUpInstance(ctx, nil, &test.cfg, opts)
 		if err != nil {
 			t.Errorf("%v: SetUpInstance() = %v, want no error", test.desc, err)
 			continue

--- a/trillian/integration/logenv.go
+++ b/trillian/integration/logenv.go
@@ -71,8 +71,9 @@ func NewCTLogEnv(ctx context.Context, cfgs []*configpb.LogConfig, numSequencers 
 	go func(env *integration.LogEnv, server *http.Server, listener net.Listener, cfgs []*configpb.LogConfig) {
 		defer wg.Done()
 		client := trillian.NewTrillianLogClient(env.ClientConn)
+		opts := ctfe.InstanceOptions{Deadline: 10 * time.Second, MetricFactory: prometheus.MetricFactory{}}
 		for _, cfg := range cfgs {
-			handlers, err := ctfe.SetUpInstance(ctx, client, cfg, 10*time.Second, prometheus.MetricFactory{})
+			handlers, err := ctfe.SetUpInstance(ctx, client, cfg, opts)
 			if err != nil {
 				glog.Fatalf("Failed to set up log instance for %+v: %v", cfg, err)
 			}


### PR DESCRIPTION
Allow the top-level code that runs a CTFE to inject a custom error
mapping function to translate RPC errors into HTTP status codes.