### PR TITLE
Even more checks on log backend specs and tree ids.

### DIFF
--- a/trillian/ctfe/instance.go
+++ b/trillian/ctfe/instance.go
@@ -176,12 +176,12 @@ func SetUpInstance(ctx context.Context, client trillian.TrillianLogClient, cfg *
 //
 // 1. The backend set must define a set of log backends with distinct
 // (non empty) names and non empty backend specs.
-// 2. The log configs must all specify a log backend and each must be one of
+// 3. The backend specs must all be distinct.
+// 3. The log configs must all specify a log backend and each must be one of
 // those defined in the backend set.
-// 3. The prefixes of configured logs must all be distinct and must not be
+// 4. The prefixes of configured logs must all be distinct and must not be
 // empty.
-// 4. The set of tree ids for each configured backend must be distinct.
-// 5. The backend specs must all be distinct.
+// 5. The set of tree ids for each configured backend must be distinct.
 func ValidateLogMultiConfig(cfg *configpb.LogMultiConfig) (map[string]*configpb.LogBackend, error) {
 	// Check the backends have unique non empty names and build the map.
 	backendMap := make(map[string]*configpb.LogBackend)

--- a/trillian/ctfe/instance_test.go
+++ b/trillian/ctfe/instance_test.go
@@ -314,12 +314,27 @@ func TestValidateLogMultiConfig(t *testing.T) {
 		},
 		{
 			desc:   "dup backend name",
-			errStr: "duplicate backend",
+			errStr: "duplicate backend name",
 			cfg: configpb.LogMultiConfig{
 				Backends: &configpb.LogBackendSet{
 					[]*configpb.LogBackend{
 						{Name: "dup", BackendSpec: "testspec"},
 						{Name: "dup", BackendSpec: "testspec"},
+					},
+				},
+				LogConfigs: &configpb.LogConfigSet{
+					[]*configpb.LogConfig{},
+				},
+			},
+		},
+		{
+			desc:   "dup backend spec",
+			errStr: "duplicate backend spec",
+			cfg: configpb.LogMultiConfig{
+				Backends: &configpb.LogBackendSet{
+					[]*configpb.LogBackend{
+						{Name: "backend1", BackendSpec: "testspec"},
+						{Name: "backend2", BackendSpec: "testspec"},
 					},
 				},
 				LogConfigs: &configpb.LogConfigSet{
@@ -388,9 +403,27 @@ func TestValidateLogMultiConfig(t *testing.T) {
 				},
 				LogConfigs: &configpb.LogConfigSet{
 					[]*configpb.LogConfig{
-						{LogBackendName: "log1", Prefix: "prefix1"},
-						{LogBackendName: "log1", Prefix: "prefix2"},
-						{LogBackendName: "log1", Prefix: "prefix1"},
+						{LogBackendName: "log1", Prefix: "prefix1", LogId: 1},
+						{LogBackendName: "log1", Prefix: "prefix2", LogId: 2},
+						{LogBackendName: "log1", Prefix: "prefix1", LogId: 3},
+					},
+				},
+			},
+		},
+		{
+			desc:   "dup log ids on same backend",
+			errStr: "dup tree id",
+			cfg: configpb.LogMultiConfig{
+				Backends: &configpb.LogBackendSet{
+					[]*configpb.LogBackend{
+						{Name: "log1", BackendSpec: "testspec1"},
+					},
+				},
+				LogConfigs: &configpb.LogConfigSet{
+					[]*configpb.LogConfig{
+						{LogBackendName: "log1", Prefix: "prefix1", LogId: 1},
+						{LogBackendName: "log1", Prefix: "prefix2", LogId: 1},
+						{LogBackendName: "log1", Prefix: "prefix1", LogId: 1},
 					},
 				},
 			},
@@ -407,9 +440,28 @@ func TestValidateLogMultiConfig(t *testing.T) {
 				},
 				LogConfigs: &configpb.LogConfigSet{
 					[]*configpb.LogConfig{
-						{LogBackendName: "log1", Prefix: "prefix1"},
-						{LogBackendName: "log2", Prefix: "prefix2"},
-						{LogBackendName: "log3", Prefix: "prefix3"},
+						{LogBackendName: "log1", Prefix: "prefix1", LogId: 1},
+						{LogBackendName: "log2", Prefix: "prefix2", LogId: 2},
+						{LogBackendName: "log3", Prefix: "prefix3", LogId: 3},
+					},
+				},
+			},
+		},
+		{
+			desc: "valid config dup ids on different backends",
+			cfg: configpb.LogMultiConfig{
+				Backends: &configpb.LogBackendSet{
+					[]*configpb.LogBackend{
+						{Name: "log1", BackendSpec: "testspec1"},
+						{Name: "log2", BackendSpec: "testspec2"},
+						{Name: "log3", BackendSpec: "testspec3"},
+					},
+				},
+				LogConfigs: &configpb.LogConfigSet{
+					[]*configpb.LogConfig{
+						{LogBackendName: "log1", Prefix: "prefix1", LogId: 999},
+						{LogBackendName: "log2", Prefix: "prefix2", LogId: 999},
+						{LogBackendName: "log3", Prefix: "prefix3", LogId: 999},
 					},
 				},
 			},

--- a/trillian/ctfe/instance_test.go
+++ b/trillian/ctfe/instance_test.go
@@ -381,6 +381,8 @@ func TestValidateLogMultiConfig(t *testing.T) {
 				Backends: &configpb.LogBackendSet{
 					[]*configpb.LogBackend{
 						{Name: "log1", BackendSpec: "testspec1"},
+						{Name: "log2", BackendSpec: "testspec2"},
+						{Name: "log3", BackendSpec: "testspec3"},
 					},
 				},
 				LogConfigs: &configpb.LogConfigSet{


### PR DESCRIPTION
Backend specs must be distinct and treeids per backend must also be distinct.