### PR TITLE
 Add hammer support for temporal logs

### DIFF
--- a/trillian/ctfe/instance_test.go
+++ b/trillian/ctfe/instance_test.go
@@ -275,13 +275,11 @@ func TestValidateLogMultiConfig(t *testing.T) {
 			errStr: "empty backend name",
 			cfg: configpb.LogMultiConfig{
 				Backends: &configpb.LogBackendSet{
-					[]*configpb.LogBackend{
+					Backend: []*configpb.LogBackend{
 						{BackendSpec: "testspec"},
 					},
 				},
-				LogConfigs: &configpb.LogConfigSet{
-					[]*configpb.LogConfig{},
-				},
+				LogConfigs: &configpb.LogConfigSet{},
 			},
 		},
 		{
@@ -289,13 +287,11 @@ func TestValidateLogMultiConfig(t *testing.T) {
 			errStr: "empty backend_spec",
 			cfg: configpb.LogMultiConfig{
 				Backends: &configpb.LogBackendSet{
-					[]*configpb.LogBackend{
+					Backend: []*configpb.LogBackend{
 						{Name: "log1"},
 					},
 				},
-				LogConfigs: &configpb.LogConfigSet{
-					[]*configpb.LogConfig{},
-				},
+				LogConfigs: &configpb.LogConfigSet{},
 			},
 		},
 		{
@@ -303,13 +299,11 @@ func TestValidateLogMultiConfig(t *testing.T) {
 			errStr: "empty backend name",
 			cfg: configpb.LogMultiConfig{
 				Backends: &configpb.LogBackendSet{
-					[]*configpb.LogBackend{
+					Backend: []*configpb.LogBackend{
 						{},
 					},
 				},
-				LogConfigs: &configpb.LogConfigSet{
-					[]*configpb.LogConfig{},
-				},
+				LogConfigs: &configpb.LogConfigSet{},
 			},
 		},
 		{
@@ -317,14 +311,12 @@ func TestValidateLogMultiConfig(t *testing.T) {
 			errStr: "duplicate backend name",
 			cfg: configpb.LogMultiConfig{
 				Backends: &configpb.LogBackendSet{
-					[]*configpb.LogBackend{
+					Backend: []*configpb.LogBackend{
 						{Name: "dup", BackendSpec: "testspec"},
 						{Name: "dup", BackendSpec: "testspec"},
 					},
 				},
-				LogConfigs: &configpb.LogConfigSet{
-					[]*configpb.LogConfig{},
-				},
+				LogConfigs: &configpb.LogConfigSet{},
 			},
 		},
 		{
@@ -332,14 +324,12 @@ func TestValidateLogMultiConfig(t *testing.T) {
 			errStr: "duplicate backend spec",
 			cfg: configpb.LogMultiConfig{
 				Backends: &configpb.LogBackendSet{
-					[]*configpb.LogBackend{
+					Backend: []*configpb.LogBackend{
 						{Name: "backend1", BackendSpec: "testspec"},
 						{Name: "backend2", BackendSpec: "testspec"},
 					},
 				},
-				LogConfigs: &configpb.LogConfigSet{
-					[]*configpb.LogConfig{},
-				},
+				LogConfigs: &configpb.LogConfigSet{},
 			},
 		},
 		{
@@ -347,12 +337,12 @@ func TestValidateLogMultiConfig(t *testing.T) {
 			errStr: "empty backend",
 			cfg: configpb.LogMultiConfig{
 				Backends: &configpb.LogBackendSet{
-					[]*configpb.LogBackend{
+					Backend: []*configpb.LogBackend{
 						{Name: "log1"},
 					},
 				},
 				LogConfigs: &configpb.LogConfigSet{
-					[]*configpb.LogConfig{
+					Config: []*configpb.LogConfig{
 						{LogBackendName: "log2"},
 					},
 				},
@@ -363,12 +353,12 @@ func TestValidateLogMultiConfig(t *testing.T) {
 			errStr: "undefined backend",
 			cfg: configpb.LogMultiConfig{
 				Backends: &configpb.LogBackendSet{
-					[]*configpb.LogBackend{
+					Backend: []*configpb.LogBackend{
 						{Name: "log1", BackendSpec: "testspec"},
 					},
 				},
 				LogConfigs: &configpb.LogConfigSet{
-					[]*configpb.LogConfig{
+					Config: []*configpb.LogConfig{
 						{LogBackendName: "log2", Prefix: "prefix"},
 					},
 				},
@@ -379,14 +369,14 @@ func TestValidateLogMultiConfig(t *testing.T) {
 			errStr: "empty prefix",
 			cfg: configpb.LogMultiConfig{
 				Backends: &configpb.LogBackendSet{
-					[]*configpb.LogBackend{
+					Backend: []*configpb.LogBackend{
 						{Name: "log1", BackendSpec: "testspec1"},
 						{Name: "log2", BackendSpec: "testspec2"},
 						{Name: "log3", BackendSpec: "testspec3"},
 					},
 				},
 				LogConfigs: &configpb.LogConfigSet{
-					[]*configpb.LogConfig{
+					Config: []*configpb.LogConfig{
 						{LogBackendName: "log1", Prefix: "prefix1"},
 						{LogBackendName: "log2"},
 						{LogBackendName: "log3", Prefix: "prefix3"},
@@ -399,12 +389,12 @@ func TestValidateLogMultiConfig(t *testing.T) {
 			errStr: "duplicate prefix",
 			cfg: configpb.LogMultiConfig{
 				Backends: &configpb.LogBackendSet{
-					[]*configpb.LogBackend{
+					Backend: []*configpb.LogBackend{
 						{Name: "log1", BackendSpec: "testspec1"},
 					},
 				},
 				LogConfigs: &configpb.LogConfigSet{
-					[]*configpb.LogConfig{
+					Config: []*configpb.LogConfig{
 						{LogBackendName: "log1", Prefix: "prefix1", LogId: 1},
 						{LogBackendName: "log1", Prefix: "prefix2", LogId: 2},
 						{LogBackendName: "log1", Prefix: "prefix1", LogId: 3},
@@ -417,12 +407,12 @@ func TestValidateLogMultiConfig(t *testing.T) {
 			errStr: "dup tree id",
 			cfg: configpb.LogMultiConfig{
 				Backends: &configpb.LogBackendSet{
-					[]*configpb.LogBackend{
+					Backend: []*configpb.LogBackend{
 						{Name: "log1", BackendSpec: "testspec1"},
 					},
 				},
 				LogConfigs: &configpb.LogConfigSet{
-					[]*configpb.LogConfig{
+					Config: []*configpb.LogConfig{
 						{LogBackendName: "log1", Prefix: "prefix1", LogId: 1},
 						{LogBackendName: "log1", Prefix: "prefix2", LogId: 1},
 						{LogBackendName: "log1", Prefix: "prefix1", LogId: 1},
@@ -435,12 +425,12 @@ func TestValidateLogMultiConfig(t *testing.T) {
 			errStr: "invalid start",
 			cfg: configpb.LogMultiConfig{
 				Backends: &configpb.LogBackendSet{
-					[]*configpb.LogBackend{
+					Backend: []*configpb.LogBackend{
 						{Name: "log1", BackendSpec: "testspec1"},
 					},
 				},
 				LogConfigs: &configpb.LogConfigSet{
-					[]*configpb.LogConfig{
+					Config: []*configpb.LogConfig{
 						{
 							LogBackendName: "log1",
 							Prefix:         "prefix1",
@@ -457,12 +447,12 @@ func TestValidateLogMultiConfig(t *testing.T) {
 			errStr: "invalid limit",
 			cfg: configpb.LogMultiConfig{
 				Backends: &configpb.LogBackendSet{
-					[]*configpb.LogBackend{
+					Backend: []*configpb.LogBackend{
 						{Name: "log1", BackendSpec: "testspec1"},
 					},
 				},
 				LogConfigs: &configpb.LogConfigSet{
-					[]*configpb.LogConfig{
+					Config: []*configpb.LogConfig{
 						{
 							LogBackendName: "log1",
 							Prefix:         "prefix1",
@@ -479,12 +469,12 @@ func TestValidateLogMultiConfig(t *testing.T) {
 			errStr: "before start",
 			cfg: configpb.LogMultiConfig{
 				Backends: &configpb.LogBackendSet{
-					[]*configpb.LogBackend{
+					Backend: []*configpb.LogBackend{
 						{Name: "log1", BackendSpec: "testspec1"},
 					},
 				},
 				LogConfigs: &configpb.LogConfigSet{
-					[]*configpb.LogConfig{
+					Config: []*configpb.LogConfig{
 						{
 							LogBackendName: "log1",
 							Prefix:         "prefix1",
@@ -500,14 +490,14 @@ func TestValidateLogMultiConfig(t *testing.T) {
 			desc: "valid config",
 			cfg: configpb.LogMultiConfig{
 				Backends: &configpb.LogBackendSet{
-					[]*configpb.LogBackend{
+					Backend: []*configpb.LogBackend{
 						{Name: "log1", BackendSpec: "testspec1"},
 						{Name: "log2", BackendSpec: "testspec2"},
 						{Name: "log3", BackendSpec: "testspec3"},
 					},
 				},
 				LogConfigs: &configpb.LogConfigSet{
-					[]*configpb.LogConfig{
+					Config: []*configpb.LogConfig{
 						{LogBackendName: "log1", Prefix: "prefix1", LogId: 1},
 						{LogBackendName: "log2", Prefix: "prefix2", LogId: 2},
 						{LogBackendName: "log3", Prefix: "prefix3", LogId: 3},
@@ -519,14 +509,14 @@ func TestValidateLogMultiConfig(t *testing.T) {
 			desc: "valid config dup ids on different backends",
 			cfg: configpb.LogMultiConfig{
 				Backends: &configpb.LogBackendSet{
-					[]*configpb.LogBackend{
+					Backend: []*configpb.LogBackend{
 						{Name: "log1", BackendSpec: "testspec1"},
 						{Name: "log2", BackendSpec: "testspec2"},
 						{Name: "log3", BackendSpec: "testspec3"},
 					},
 				},
 				LogConfigs: &configpb.LogConfigSet{
-					[]*configpb.LogConfig{
+					Config: []*configpb.LogConfig{
 						{LogBackendName: "log1", Prefix: "prefix1", LogId: 999},
 						{LogBackendName: "log2", Prefix: "prefix2", LogId: 999},
 						{LogBackendName: "log3", Prefix: "prefix3", LogId: 999},
@@ -538,12 +528,12 @@ func TestValidateLogMultiConfig(t *testing.T) {
 			desc: "valid config - only not after start set",
 			cfg: configpb.LogMultiConfig{
 				Backends: &configpb.LogBackendSet{
-					[]*configpb.LogBackend{
+					Backend: []*configpb.LogBackend{
 						{Name: "log1", BackendSpec: "testspec1"},
 					},
 				},
 				LogConfigs: &configpb.LogConfigSet{
-					[]*configpb.LogConfig{
+					Config: []*configpb.LogConfig{
 						{LogBackendName: "log1", Prefix: "prefix1", LogId: 1, NotAfterStart: &timestamp.Timestamp{Seconds: 23}},
 					},
 				},
@@ -553,12 +543,12 @@ func TestValidateLogMultiConfig(t *testing.T) {
 			desc: "valid config - only not after limit set",
 			cfg: configpb.LogMultiConfig{
 				Backends: &configpb.LogBackendSet{
-					[]*configpb.LogBackend{
+					Backend: []*configpb.LogBackend{
 						{Name: "log1", BackendSpec: "testspec1"},
 					},
 				},
 				LogConfigs: &configpb.LogConfigSet{
-					[]*configpb.LogConfig{
+					Config: []*configpb.LogConfig{
 						{LogBackendName: "log1", Prefix: "prefix1", LogId: 1, NotAfterLimit: &timestamp.Timestamp{Seconds: 23}},
 					},
 				},
@@ -568,12 +558,12 @@ func TestValidateLogMultiConfig(t *testing.T) {
 			desc: "valid config with time range",
 			cfg: configpb.LogMultiConfig{
 				Backends: &configpb.LogBackendSet{
-					[]*configpb.LogBackend{
+					Backend: []*configpb.LogBackend{
 						{Name: "log1", BackendSpec: "testspec1"},
 					},
 				},
 				LogConfigs: &configpb.LogConfigSet{
-					[]*configpb.LogConfig{
+					Config: []*configpb.LogConfig{
 						{
 							LogBackendName: "log1",
 							Prefix:         "prefix1",

--- a/trillian/integration/ct_hammer/main.go
+++ b/trillian/integration/ct_hammer/main.go
@@ -115,18 +115,18 @@ func main() {
 		if err != nil {
 			glog.Exitf("failed to parse issuer for precert: %v", err)
 		}
-		if *leafNotAfter != "" {
-			notAfter, err := time.Parse(time.RFC3339, *leafNotAfter)
-			if err != nil {
-				glog.Exitf("Failed to parse leaf notAfter: %v", err)
-			}
-			glog.Infof("Using %v as notAfter date for generated leaf certificates", notAfter)
-			leafCert.NotAfter = notAfter
-		}
 	} else {
 		glog.Warningf("Warning: add-[pre-]chain operations disabled as no test data provided")
 		*addChainBias = 0
 		*addPreChainBias = 0
+	}
+
+	var notAfterOverride time.Time
+	if *leafNotAfter != "" {
+		notAfterOverride, err = time.Parse(time.RFC3339, *leafNotAfter)
+		if err != nil {
+			glog.Exitf("Failed to parse leaf notAfter: %v", err)
+		}
 	}
 
 	bias := integration.HammerBias{
@@ -207,6 +207,7 @@ func main() {
 			Limiter:           newLimiter(*limit),
 			MaxParallelChains: *maxParallelChains,
 			IgnoreErrors:      *ignoreErrors,
+			NotAfterOverride:  notAfterOverride,
 		}
 		go func(cfg integration.HammerConfig) {
 			defer wg.Done()

--- a/trillian/integration/ct_hammer/main.go
+++ b/trillian/integration/ct_hammer/main.go
@@ -30,7 +30,6 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/google/certificate-transparency-go"
 	"github.com/google/certificate-transparency-go/fixchain/ratelimiter"
 	"github.com/google/certificate-transparency-go/trillian/ctfe"
 	"github.com/google/certificate-transparency-go/trillian/integration"
@@ -38,6 +37,8 @@ import (
 	"github.com/google/trillian/monitoring"
 	"github.com/google/trillian/monitoring/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	ct "github.com/google/certificate-transparency-go"
 )
 
 var (

--- a/trillian/integration/ct_hammer/main.go
+++ b/trillian/integration/ct_hammer/main.go
@@ -30,7 +30,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	ct "github.com/google/certificate-transparency-go"
+	"github.com/google/certificate-transparency-go"
 	"github.com/google/certificate-transparency-go/fixchain/ratelimiter"
 	"github.com/google/certificate-transparency-go/trillian/ctfe"
 	"github.com/google/certificate-transparency-go/trillian/integration"

--- a/trillian/integration/ct_integration.go
+++ b/trillian/integration/ct_integration.go
@@ -485,7 +485,7 @@ func RunCTIntegrationForLog(cfg *configpb.LogConfig, servers, metricsServers, te
 	if err != nil {
 		return fmt.Errorf("failed to parse issuer for precert: %v", err)
 	}
-	prechain, tbs, err := makePrecertChain(chain[1], issuer, signer)
+	prechain, tbs, err := makePrecertChain(chain[1], issuer, signer, time.Time{} /*  notAfter */)
 	if err != nil {
 		return fmt.Errorf("failed to build pre-certificate: %v", err)
 	}
@@ -604,7 +604,7 @@ func checkCTConsistencyProof(sth1, sth2 *ct.SignedTreeHead, proof [][]byte) erro
 
 // makePrecertChain builds a precert chain based from the given cert chain and cert, converting and
 // re-signing relative to the given issuer.
-func makePrecertChain(chain []ct.ASN1Cert, issuer *x509.Certificate, signer crypto.Signer) ([]ct.ASN1Cert, []byte, error) {
+func makePrecertChain(chain []ct.ASN1Cert, issuer *x509.Certificate, signer crypto.Signer, notAfter time.Time) ([]ct.ASN1Cert, []byte, error) {
 	prechain := make([]ct.ASN1Cert, len(chain))
 	copy(prechain[1:], chain[1:])
 
@@ -612,6 +612,7 @@ func makePrecertChain(chain []ct.ASN1Cert, issuer *x509.Certificate, signer cryp
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to parse certificate to build precert from: %v", err)
 	}
+	cert.NotAfter = notAfter
 
 	prechain[0].Data, err = buildNewPrecertData(cert, issuer, signer)
 	if err != nil {
@@ -729,7 +730,10 @@ func makePreIssuerPrecertChain(chain []ct.ASN1Cert, issuer *x509.Certificate, si
 
 // makeCertChain builds a new cert chain based from the given cert chain, changing SubjectKeyId and
 // re-signing relative to the given issuer.
-func makeCertChain(chain []ct.ASN1Cert, cert, issuer *x509.Certificate, signer crypto.Signer) ([]ct.ASN1Cert, error) {
+func makeCertChain(chain []ct.ASN1Cert, template, issuer *x509.Certificate, signer crypto.Signer, notAfter time.Time) ([]ct.ASN1Cert, error) {
+	cert := *template
+	cert.NotAfter = notAfter
+
 	newchain := make([]ct.ASN1Cert, len(chain))
 	copy(newchain[1:], chain[1:])
 
@@ -742,7 +746,7 @@ func makeCertChain(chain []ct.ASN1Cert, cert, issuer *x509.Certificate, signer c
 
 	// Create a fresh certificate, signed by the intermediate CA.
 	var err error
-	newchain[0].Data, err = x509.CreateCertificate(cryptorand.Reader, cert, issuer, cert.PublicKey, signer)
+	newchain[0].Data, err = x509.CreateCertificate(cryptorand.Reader, &cert, issuer, cert.PublicKey, signer)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create certificate: %v", err)
 	}

--- a/trillian/integration/ct_integration.go
+++ b/trillian/integration/ct_integration.go
@@ -36,7 +36,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/certificate-transparency-go"
 	"github.com/google/certificate-transparency-go/client"
 	"github.com/google/certificate-transparency-go/jsonclient"
 	"github.com/google/certificate-transparency-go/merkletree"
@@ -50,6 +49,7 @@ import (
 	"github.com/kylelemons/godebug/pretty"
 	"golang.org/x/net/context/ctxhttp"
 
+	ct "github.com/google/certificate-transparency-go"
 	keyspem "github.com/google/trillian/crypto/keys/pem"
 )
 

--- a/trillian/integration/ct_integration.go
+++ b/trillian/integration/ct_integration.go
@@ -36,7 +36,7 @@ import (
 	"strings"
 	"time"
 
-	ct "github.com/google/certificate-transparency-go"
+	"github.com/google/certificate-transparency-go"
 	"github.com/google/certificate-transparency-go/client"
 	"github.com/google/certificate-transparency-go/jsonclient"
 	"github.com/google/certificate-transparency-go/merkletree"
@@ -459,7 +459,7 @@ func RunCTIntegrationForLog(cfg *configpb.LogConfig, servers, metricsServers, te
 	corruptChain := make([]ct.ASN1Cert, len(chain[1]))
 	copy(corruptChain, chain[1])
 	corruptAt := len(corruptChain[0].Data) - 3
-	corruptChain[0].Data[corruptAt] = (corruptChain[0].Data[corruptAt] + 1)
+	corruptChain[0].Data[corruptAt] = corruptChain[0].Data[corruptAt] + 1
 	if sct, err := t.client().AddChain(ctx, corruptChain); err == nil {
 		return fmt.Errorf("got AddChain(corrupt-cert)=(%+v,nil); want (nil,error)", sct)
 	}

--- a/trillian/integration/hammer.go
+++ b/trillian/integration/hammer.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/ptypes"
-	"github.com/google/certificate-transparency-go"
 	"github.com/google/certificate-transparency-go/client"
 	"github.com/google/certificate-transparency-go/merkletree"
 	"github.com/google/certificate-transparency-go/tls"
@@ -35,6 +34,8 @@ import (
 	"github.com/google/certificate-transparency-go/trillian/ctfe/configpb"
 	"github.com/google/certificate-transparency-go/x509"
 	"github.com/google/trillian/monitoring"
+
+	ct "github.com/google/certificate-transparency-go"
 )
 
 const defaultEmitSeconds = 10

--- a/trillian/integration/hammer.go
+++ b/trillian/integration/hammer.go
@@ -26,7 +26,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	ct "github.com/google/certificate-transparency-go"
+	"github.com/google/certificate-transparency-go"
 	"github.com/google/certificate-transparency-go/client"
 	"github.com/google/certificate-transparency-go/merkletree"
 	"github.com/google/certificate-transparency-go/tls"
@@ -150,7 +150,7 @@ func (hb HammerBias) Invalid(ep ctfe.EntrypointName) bool {
 	if chance <= 0 {
 		return false
 	}
-	return (rand.Intn(chance) == 0)
+	return rand.Intn(chance) == 0
 }
 
 type submittedCert struct {

--- a/trillian/integration/hammer.go
+++ b/trillian/integration/hammer.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	"github.com/golang/protobuf/ptypes"
 	"github.com/google/certificate-transparency-go"
 	"github.com/google/certificate-transparency-go/client"
 	"github.com/google/certificate-transparency-go/merkletree"
@@ -117,6 +118,9 @@ type HammerConfig struct {
 	EmitInterval time.Duration
 	// IgnoreErrors controls whether a hammer run fails immediately on any error.
 	IgnoreErrors bool
+	// NotAfterOverride is used as cert and precert's NotAfter if not zeroed.
+	// It takes precedence over automatic NotAfter fixing for temporal logs.
+	NotAfterOverride time.Time
 }
 
 // HammerBias indicates the bias for selecting different log operations.
@@ -253,6 +257,8 @@ type hammerState struct {
 	pending pendingCerts
 	// Operations that are required to fix dependencies.
 	nextOp []ctfe.EntrypointName
+	// notAfter is the NotAfter time used for new certs and precerts.
+	notAfter time.Time
 }
 
 func newHammerState(cfg *HammerConfig) (*hammerState, error) {
@@ -273,11 +279,42 @@ func newHammerState(cfg *HammerConfig) (*hammerState, error) {
 	if cfg.Limiter == nil {
 		cfg.Limiter = unLimited{}
 	}
+
+	notAfter, err := getNotAfter(cfg)
+	if err != nil {
+		return nil, err
+	}
+	glog.Infof("%v: using NotAfter = %v", cfg.LogCfg.Prefix, notAfter)
+
 	state := hammerState{
-		cfg:    cfg,
-		nextOp: make([]ctfe.EntrypointName, 0),
+		cfg:      cfg,
+		nextOp:   make([]ctfe.EntrypointName, 0),
+		notAfter: notAfter,
 	}
 	return &state, nil
+}
+
+// getNotAfter returns the NotAfter time to be used on new certs.
+// If cfg.NotAfterOverride is non-zero, it takes precedence and is returned.
+// If cfg.LogCfg is a temporal log, the halfway point between its NotAfterStart and NotAfterLimit is
+// returned.
+// Otherwise a zeroed time is returned.
+func getNotAfter(cfg *HammerConfig) (time.Time, error) {
+	if cfg.NotAfterOverride.UnixNano() > 0 {
+		return cfg.NotAfterOverride, nil
+	}
+	if cfg.LogCfg.NotAfterStart == nil || cfg.LogCfg.NotAfterLimit == nil {
+		return time.Time{}, nil
+	}
+	start, err := ptypes.Timestamp(cfg.LogCfg.NotAfterStart)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("error parsing NotAfterStart for %v: %v", cfg.LogCfg.Prefix, cfg.LogCfg.NotAfterStart)
+	}
+	limit, err := ptypes.Timestamp(cfg.LogCfg.NotAfterLimit)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("error parsing NotAfterLimit for %v: %v", cfg.LogCfg.Prefix, cfg.LogCfg.NotAfterLimit)
+	}
+	return time.Unix(0, (limit.UnixNano()-start.UnixNano())/2+start.UnixNano()), nil
 }
 
 func (s *hammerState) client() *client.LogClient {
@@ -322,7 +359,7 @@ func (s *hammerState) addMultiple(ctx context.Context, addOne func(context.Conte
 }
 
 func (s *hammerState) addChain(ctx context.Context) error {
-	chain, err := makeCertChain(s.cfg.LeafChain, s.cfg.LeafCert, s.cfg.CACert, s.cfg.Signer)
+	chain, err := makeCertChain(s.cfg.LeafChain, s.cfg.LeafCert, s.cfg.CACert, s.cfg.Signer, s.notAfter)
 	if err != nil {
 		return fmt.Errorf("failed to make fresh cert: %v", err)
 	}
@@ -356,7 +393,7 @@ func (s *hammerState) addChain(ctx context.Context) error {
 
 func (s *hammerState) addChainInvalid(ctx context.Context) error {
 	// Invalid because it's a pre-cert chain, not a cert chain.
-	chain, _, err := makePrecertChain(s.cfg.LeafChain, s.cfg.CACert, s.cfg.Signer)
+	chain, _, err := makePrecertChain(s.cfg.LeafChain, s.cfg.CACert, s.cfg.Signer, s.notAfter)
 	if err != nil {
 		return fmt.Errorf("failed to make fresh cert: %v", err)
 	}
@@ -368,7 +405,7 @@ func (s *hammerState) addChainInvalid(ctx context.Context) error {
 }
 
 func (s *hammerState) addPreChain(ctx context.Context) error {
-	prechain, tbs, err := makePrecertChain(s.cfg.LeafChain, s.cfg.CACert, s.cfg.Signer)
+	prechain, tbs, err := makePrecertChain(s.cfg.LeafChain, s.cfg.CACert, s.cfg.Signer, s.notAfter)
 	if err != nil {
 		return fmt.Errorf("failed to make fresh pre-cert: %v", err)
 	}
@@ -405,7 +442,7 @@ func (s *hammerState) addPreChain(ctx context.Context) error {
 
 func (s *hammerState) addPreChainInvalid(ctx context.Context) error {
 	// Invalid because it's a cert chain, not a pre-cert chain.
-	prechain, err := makeCertChain(s.cfg.LeafChain, s.cfg.LeafCert, s.cfg.CACert, s.cfg.Signer)
+	prechain, err := makeCertChain(s.cfg.LeafChain, s.cfg.LeafCert, s.cfg.CACert, s.cfg.Signer, s.notAfter)
 	if err != nil {
 		return fmt.Errorf("failed to make fresh pre-cert: %v", err)
 	}

--- a/trillian/integration/hammer_test.go
+++ b/trillian/integration/hammer_test.go
@@ -1,0 +1,299 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	"context"
+	"crypto"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/timestamp"
+	"github.com/google/certificate-transparency-go"
+	"github.com/google/certificate-transparency-go/client"
+	"github.com/google/certificate-transparency-go/jsonclient"
+	"github.com/google/certificate-transparency-go/tls"
+	"github.com/google/certificate-transparency-go/trillian/ctfe/configpb"
+	"github.com/google/certificate-transparency-go/x509"
+)
+
+func TestHammer_NotAfter(t *testing.T) {
+	keys := loadTestKeys(t)
+
+	s, lc := newFakeCTServer(t)
+	defer s.close()
+
+	now := time.Now()
+	notAfterStart := now.Add(-24 * time.Hour)
+	notAfterOverride := now.Add(23 * time.Hour)
+	notAfterLimit := now.Add(24 * time.Hour)
+
+	ctx := context.Background()
+	addChain := func(hs *hammerState) error { return hs.addChain(ctx) }
+	addPreChain := func(hs *hammerState) error { return hs.addPreChain(ctx) }
+
+	tests := []struct {
+		desc                                           string
+		fn                                             func(hs *hammerState) error
+		notAfterOverride, notAfterStart, notAfterLimit time.Time
+		// wantNotAfter is only checked if not zeroed
+		wantNotAfter time.Time
+	}{
+		{
+			desc: "nonTemporalAddChain",
+			fn:   addChain,
+		},
+		{
+			desc: "nonTemporalAddPreChain",
+			fn:   addPreChain,
+		},
+		{
+			desc:             "nonTemporalFixedAddChain",
+			fn:               addChain,
+			notAfterOverride: notAfterOverride,
+			wantNotAfter:     notAfterOverride,
+		},
+		{
+			desc:             "nonTemporalFixedAddPreChain",
+			fn:               addPreChain,
+			notAfterOverride: notAfterOverride,
+			wantNotAfter:     notAfterOverride,
+		},
+		{
+			desc:          "temporalAddChain",
+			fn:            addChain,
+			notAfterStart: notAfterStart,
+			notAfterLimit: notAfterLimit,
+		},
+		{
+			desc:          "temporalAddPreChain",
+			fn:            addPreChain,
+			notAfterStart: notAfterStart,
+			notAfterLimit: notAfterLimit,
+		},
+		{
+			desc:             "temporalFixedAddChain",
+			fn:               addChain,
+			notAfterOverride: notAfterOverride,
+			notAfterStart:    notAfterStart,
+			notAfterLimit:    notAfterLimit,
+			wantNotAfter:     notAfterOverride,
+		},
+		{
+			desc:             "temporalFixedAddPreChain",
+			fn:               addPreChain,
+			notAfterOverride: notAfterOverride,
+			notAfterStart:    notAfterStart,
+			notAfterLimit:    notAfterLimit,
+			wantNotAfter:     notAfterOverride,
+		},
+	}
+
+	for _, test := range tests {
+		s.reset()
+
+		var startPB, limitPB *timestamp.Timestamp
+		if ts := test.notAfterStart; ts.UnixNano() > 0 {
+			startPB, _ = ptypes.TimestampProto(ts)
+		}
+		if ts := test.notAfterLimit; ts.UnixNano() > 0 {
+			limitPB, _ = ptypes.TimestampProto(ts)
+		}
+		hs, err := newHammerState(&HammerConfig{
+			CACert:     keys.caCert,
+			ClientPool: RandomPool{lc},
+			LeafChain:  keys.leafChain,
+			LeafCert:   keys.leafCert,
+			LogCfg: &configpb.LogConfig{
+				NotAfterStart: startPB,
+				NotAfterLimit: limitPB,
+			},
+			Signer:           keys.signer,
+			NotAfterOverride: test.notAfterOverride,
+		})
+		if err != nil {
+			t.Errorf("%v: newHammerState() returned err = %v", test.desc, err)
+			continue
+		}
+
+		if err := test.fn(hs); err != nil {
+			t.Errorf("%v: addChain() returned err = %v", test.desc, err)
+			continue
+		}
+		if got, want := len(s.addedCerts), 1; got != want {
+			t.Errorf("%v: unexpected number of certs added to server, got = %v, want = %v", test.desc, got, want)
+			continue
+		}
+		temporal := startPB != nil || limitPB != nil
+		for i, cert := range s.addedCerts {
+			switch got, fixed := cert.NotAfter, test.wantNotAfter.UnixNano() > 0; {
+			case fixed && got.Unix() != test.wantNotAfter.Unix(): // second precision is OK
+				t.Errorf("%v: cert #%v has NotAfter = %v, want = %v", test.desc, i, got, test.wantNotAfter)
+			case !fixed && temporal && (got.Before(test.notAfterStart) || got.After(test.notAfterLimit)):
+				t.Errorf("%v: cert #%v has NotAfter = %v, want %v <= NotAfter <= %v", test.desc, i, got, test.notAfterStart, test.notAfterLimit)
+			}
+		}
+	}
+}
+
+// fakeCTServer is a fake HTTP server that mimics a CT frontend.
+// It supports add-chain and add-pre-chain methods and saves the first certificate of the chain in
+// the addCerts field.
+// Callers should call reset() before usage to reset internal state and defer-call close() to ensure
+// the server is stopped and resources are freed.
+type fakeCTServer struct {
+	lis    net.Listener
+	server *http.Server
+
+	addedCerts []*x509.Certificate
+}
+
+func (s *fakeCTServer) addChain(w http.ResponseWriter, req *http.Request) {
+	body, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	addReq := &ct.AddChainRequest{}
+	if err := json.Unmarshal(body, addReq); err != nil {
+		writeErr(w, http.StatusBadRequest, err)
+		return
+	}
+
+	cert, err := x509.ParseCertificate(addReq.Chain[0])
+	if err != nil {
+		writeErr(w, http.StatusBadRequest, err)
+		return
+	}
+	s.addedCerts = append(s.addedCerts, cert)
+
+	dsBytes, err := tls.Marshal(tls.DigitallySigned{})
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, err)
+		return
+	}
+	resp := &ct.AddChainResponse{
+		SCTVersion: ct.V1,
+		Signature:  dsBytes,
+	}
+	respBytes, err := json.Marshal(resp)
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(respBytes)
+}
+
+func (s *fakeCTServer) close() {
+	if s.server != nil {
+		s.server.Close()
+	}
+	if s.lis != nil {
+		s.lis.Close()
+	}
+}
+
+func (s *fakeCTServer) reset() {
+	s.addedCerts = nil
+}
+
+func (s *fakeCTServer) serve() {
+	s.server.Serve(s.lis)
+}
+
+func writeErr(w http.ResponseWriter, status int, err error) {
+	w.WriteHeader(status)
+	io.WriteString(w, err.Error())
+}
+
+// newFakeCTServer creates and starts a fakeCTServer.
+// It returns the started server and a client to the same server.
+func newFakeCTServer(t *testing.T) (*fakeCTServer, *client.LogClient) {
+	s := &fakeCTServer{}
+
+	var err error
+	s.lis, err = net.Listen("tcp", "")
+	if err != nil {
+		s.close()
+		t.Fatalf("net.Listen() returned err = %v", err)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ct/v1/add-chain", s.addChain)
+	mux.HandleFunc("/ct/v1/add-pre-chain", s.addChain)
+
+	s.server = &http.Server{Handler: mux}
+	go s.serve()
+
+	lc, err := client.New(fmt.Sprintf("http://%s", s.lis.Addr()), nil, jsonclient.Options{})
+	if err != nil {
+		t.Fatalf("client.New() returned err = %v", err)
+	}
+
+	return s, lc
+}
+
+// testKeys contains all keys and associated signer required for hammer tests.
+type testKeys struct {
+	caChain, leafChain []ct.ASN1Cert
+	caCert, leafCert   *x509.Certificate
+	signer             crypto.Signer
+}
+
+// loadTestKeys loads the test keys from the testdata/ directory.
+func loadTestKeys(t *testing.T) *testKeys {
+	t.Helper()
+
+	const testdataPath = "../testdata/"
+
+	caChain, err := GetChain(testdataPath, "int-ca.cert")
+	if err != nil {
+		t.Fatalf("GetChain() returned err = %v", err)
+	}
+	leafChain, err := GetChain(testdataPath, "leaf01.chain")
+	if err != nil {
+		t.Fatalf("GetChain() returned err = %v", err)
+	}
+	caCert, err := x509.ParseCertificate(caChain[0].Data)
+	if err != nil {
+		t.Fatalf("x509.ParseCertificate() returned err = %v", err)
+	}
+	leafCert, err := x509.ParseCertificate(leafChain[0].Data)
+	if err != nil {
+		t.Fatalf("x509.ParseCertificate() returned err = %v", err)
+	}
+	signer, err := MakeSigner(testdataPath)
+	if err != nil {
+		t.Fatalf("MakeSigner() returned err = %v", err)
+	}
+
+	return &testKeys{
+		caChain:   caChain,
+		leafChain: leafChain,
+		caCert:    caCert,
+		leafCert:  leafCert,
+		signer:    signer,
+	}
+}

--- a/trillian/integration/hammer_test.go
+++ b/trillian/integration/hammer_test.go
@@ -28,12 +28,13 @@ import (
 
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/timestamp"
-	"github.com/google/certificate-transparency-go"
 	"github.com/google/certificate-transparency-go/client"
 	"github.com/google/certificate-transparency-go/jsonclient"
 	"github.com/google/certificate-transparency-go/tls"
 	"github.com/google/certificate-transparency-go/trillian/ctfe/configpb"
 	"github.com/google/certificate-transparency-go/x509"
+
+	ct "github.com/google/certificate-transparency-go"
 )
 
 func TestHammer_NotAfter(t *testing.T) {


### PR DESCRIPTION
When hammering temporal logs (LogConfig has both NotAfterStart and NotAfterLimit fields) the hammer will automatically set an appropriate NotAfter date for generated certificates.

For maximum flexibility, the existing leaf_not_after flag was preserved and had its behavior added to HammerConfig and hammerState, where it can be reused by multiple endpoints and more easily unit-tested. If present, leaf_not_after takes precedence over automatic NotAfter fixing.