### PR TITLE
Fix log api - pass context in api calls

### DIFF
--- a/trillian/ctfe/handlers.go
+++ b/trillian/ctfe/handlers.go
@@ -137,7 +137,7 @@ func (a AppHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	label1 := string(a.Name)
 	reqsCounter.Inc(label0, label1)
 	startTime := a.Context.TimeSource.Now()
-	a.Context.requestLog.Start(r.Context())
+	logCtx := a.Context.requestLog.Start(r.Context())
 	a.Context.requestLog.LogPrefix(a.Context.LogPrefix)
 	defer func() {
 		latency := a.Context.TimeSource.Now().Sub(startTime).Seconds()
@@ -163,7 +163,7 @@ func (a AppHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Many/most of the handlers forward the request on to the Log RPC server; impose a deadline
 	// on this onward request.
-	ctx, cancel := context.WithDeadline(r.Context(), getRPCDeadlineTime(a.Context))
+	ctx, cancel := context.WithDeadline(logCtx, getRPCDeadlineTime(a.Context))
 	defer cancel()
 
 	status, err := a.Handler(ctx, a.Context, w, r)

--- a/trillian/ctfe/handlers.go
+++ b/trillian/ctfe/handlers.go
@@ -138,7 +138,7 @@ func (a AppHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	reqsCounter.Inc(label0, label1)
 	startTime := a.Context.TimeSource.Now()
 	logCtx := a.Context.requestLog.Start(r.Context())
-	a.Context.requestLog.LogPrefix(a.Context.LogPrefix)
+	a.Context.requestLog.LogPrefix(logCtx, a.Context.LogPrefix)
 	defer func() {
 		latency := a.Context.TimeSource.Now().Sub(startTime).Seconds()
 		rspLatency.Observe(latency, label0, label1, strconv.Itoa(status))
@@ -147,7 +147,7 @@ func (a AppHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if r.Method != a.Method {
 		glog.Warningf("%s: %s wrong HTTP method: %v", a.Context.LogPrefix, a.Name, r.Method)
 		sendHTTPError(w, http.StatusMethodNotAllowed, fmt.Errorf("method not allowed: %s", r.Method))
-		a.Context.requestLog.Status(http.StatusMethodNotAllowed)
+		a.Context.requestLog.Status(logCtx, http.StatusMethodNotAllowed)
 		return
 	}
 
@@ -156,7 +156,7 @@ func (a AppHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if r.Method == http.MethodGet {
 		if err := r.ParseForm(); err != nil {
 			sendHTTPError(w, http.StatusBadRequest, fmt.Errorf("failed to parse form data: %v", err))
-			a.Context.requestLog.Status(http.StatusBadRequest)
+			a.Context.requestLog.Status(logCtx, http.StatusBadRequest)
 			return
 		}
 	}
@@ -167,7 +167,7 @@ func (a AppHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 
 	status, err := a.Handler(ctx, a.Context, w, r)
-	a.Context.requestLog.Status(status)
+	a.Context.requestLog.Status(ctx, status)
 	glog.V(2).Infof("%s: %s <= status=%d", a.Context.LogPrefix, a.Name, status)
 	rspsCounter.Inc(label0, label1, strconv.Itoa(status))
 	if err != nil {
@@ -311,14 +311,14 @@ func addChainInternal(ctx context.Context, c LogContext, w http.ResponseWriter, 
 	}
 	// Log the DERs now because they might not parse as valid X.509.
 	for _, der := range addChainReq.Chain {
-		c.requestLog.AddDERToChain(der)
+		c.requestLog.AddDERToChain(ctx, der)
 	}
 	chain, err := verifyAddChain(c, addChainReq, w, isPrecert)
 	if err != nil {
 		return http.StatusBadRequest, fmt.Errorf("failed to verify add-chain contents: %v", err)
 	}
 	for _, cert := range chain {
-		c.requestLog.AddCertToChain(cert)
+		c.requestLog.AddCertToChain(ctx, cert)
 	}
 	// Get the current time in the form used throughout RFC6962, namely milliseconds since Unix
 	// epoch, and use this throughout.
@@ -466,7 +466,7 @@ func getSTHConsistency(ctx context.Context, c LogContext, w http.ResponseWriter,
 	if err != nil {
 		return http.StatusBadRequest, fmt.Errorf("failed to parse consistency range: %v", err)
 	}
-	c.requestLog.FirstAndSecond(first, second)
+	c.requestLog.FirstAndSecond(ctx, first, second)
 	var jsonRsp ct.GetSTHConsistencyResponse
 	if first != 0 {
 		req := trillian.GetConsistencyProofRequest{LogId: c.logID, FirstTreeSize: first, SecondTreeSize: second}
@@ -523,8 +523,8 @@ func getProofByHash(ctx context.Context, c LogContext, w http.ResponseWriter, r 
 	if err != nil || treeSize < 1 {
 		return http.StatusBadRequest, fmt.Errorf("get-proof-by-hash: missing or invalid tree_size: %v", r.FormValue(getProofParamTreeSize))
 	}
-	c.requestLog.LeafHash(leafHash)
-	c.requestLog.TreeSize(treeSize)
+	c.requestLog.LeafHash(ctx, leafHash)
+	c.requestLog.TreeSize(ctx, treeSize)
 
 	// Per RFC 6962 section 4.5 the API returns a single proof. This should be the lowest leaf index
 	// Because we request order by sequence and we only passed one hash then the first result is
@@ -581,7 +581,7 @@ func getEntries(ctx context.Context, c LogContext, w http.ResponseWriter, r *htt
 	if err != nil {
 		return http.StatusBadRequest, fmt.Errorf("bad range on get-entries request: %v", err)
 	}
-	c.requestLog.StartAndEnd(start, end)
+	c.requestLog.StartAndEnd(ctx, start, end)
 
 	// Now make a request to the backend to get the relevant leaves
 	req := trillian.GetLeavesByIndexRequest{
@@ -652,8 +652,8 @@ func getEntryAndProof(ctx context.Context, c LogContext, w http.ResponseWriter, 
 	if err != nil {
 		return http.StatusBadRequest, fmt.Errorf("failed to parse get-entry-and-proof params: %v", err)
 	}
-	c.requestLog.LeafIndex(leafIndex)
-	c.requestLog.TreeSize(treeSize)
+	c.requestLog.LeafIndex(ctx, leafIndex)
+	c.requestLog.TreeSize(ctx, treeSize)
 
 	req := trillian.GetEntryAndProofRequest{LogId: c.logID, LeafIndex: leafIndex, TreeSize: treeSize}
 	rsp, err := c.rpcClient.GetEntryAndProof(ctx, &req)

--- a/trillian/ctfe/requestlog.go
+++ b/trillian/ctfe/requestlog.go
@@ -34,8 +34,8 @@ const vLevel = 9
 type RequestLog interface {
 	// Start will be called once at the beginning of handling each request.
 	// The supplied context will be the one used for request processing and
-	// can be used by the logger to set values.
-	Start(context.Context)
+	// can be used by the logger to set values on the returned context.
+	Start(context.Context) context.Context
 	// LogPrefix will be called once per request to set the log prefix.
 	LogPrefix(string)
 	// AddDERToChain will be called once for each certificate in a submitted
@@ -73,8 +73,9 @@ type DefaultRequestLog struct {
 }
 
 // Start logs the start of request processing.
-func (dlr *DefaultRequestLog) Start(ctx context.Context) {
+func (dlr *DefaultRequestLog) Start(ctx context.Context) context.Context {
 	glog.V(vLevel).Info("RL: Start")
+	return ctx
 }
 
 // LogPrefix logs the prefix of the CT log that this request is for.

--- a/trillian/ctfe/requestlog.go
+++ b/trillian/ctfe/requestlog.go
@@ -35,6 +35,8 @@ type RequestLog interface {
 	// Start will be called once at the beginning of handling each request.
 	// The supplied context will be the one used for request processing and
 	// can be used by the logger to set values on the returned context.
+	// The returned context should be used in all the following calls to
+	// this API. This is normally arranged by the request handler code.
 	Start(context.Context) context.Context
 	// LogPrefix will be called once per request to set the log prefix.
 	LogPrefix(context.Context, string)
@@ -79,18 +81,18 @@ func (dlr *DefaultRequestLog) Start(ctx context.Context) context.Context {
 }
 
 // LogPrefix logs the prefix of the CT log that this request is for.
-func (dlr *DefaultRequestLog) LogPrefix(c context.Context, p string) {
+func (dlr *DefaultRequestLog) LogPrefix(_ context.Context, p string) {
 	glog.V(vLevel).Infof("RL: LogPrefix: %s", p)
 }
 
 // AddDERToChain logs the raw bytes of a submitted certificate.
-func (dlr *DefaultRequestLog) AddDERToChain(c context.Context, d []byte) {
+func (dlr *DefaultRequestLog) AddDERToChain(_ context.Context, d []byte) {
 	glog.V(vLevel).Infof("RL: Cert DER: %s", hex.EncodeToString(d))
 }
 
 // AddCertToChain logs some issuer / subject / timing fields from a
 // certificate that is part of a submitted chain.
-func (dlr *DefaultRequestLog) AddCertToChain(c context.Context, cert *x509.Certificate) {
+func (dlr *DefaultRequestLog) AddCertToChain(_ context.Context, cert *x509.Certificate) {
 	glog.V(vLevel).Infof("RL: Cert: Sub: %s Iss: %s notBef: %s notAft: %s",
 		x509util.NameToString(cert.Subject),
 		x509util.NameToString(cert.Issuer),
@@ -99,31 +101,31 @@ func (dlr *DefaultRequestLog) AddCertToChain(c context.Context, cert *x509.Certi
 }
 
 // FirstAndSecond logs request parameters.
-func (dlr *DefaultRequestLog) FirstAndSecond(c context.Context, f, s int64) {
+func (dlr *DefaultRequestLog) FirstAndSecond(_ context.Context, f, s int64) {
 	glog.V(vLevel).Infof("RL: First: %d Second: %d", f, s)
 }
 
 // StartAndEnd logs request parameters.
-func (dlr *DefaultRequestLog) StartAndEnd(c context.Context, s, e int64) {
+func (dlr *DefaultRequestLog) StartAndEnd(_ context.Context, s, e int64) {
 	glog.V(vLevel).Infof("RL: Start: %d End: %d", s, e)
 }
 
 // LeafIndex logs request parameters.
-func (dlr *DefaultRequestLog) LeafIndex(c context.Context, li int64) {
+func (dlr *DefaultRequestLog) LeafIndex(_ context.Context, li int64) {
 	glog.V(vLevel).Infof("RL: LeafIndex: %d", li)
 }
 
 // TreeSize logs request parameters.
-func (dlr *DefaultRequestLog) TreeSize(c context.Context, ts int64) {
+func (dlr *DefaultRequestLog) TreeSize(_ context.Context, ts int64) {
 	glog.V(vLevel).Infof("RL: TreeSize: %d", ts)
 }
 
 // LeafHash logs request parameters.
-func (dlr *DefaultRequestLog) LeafHash(c context.Context, lh []byte) {
+func (dlr *DefaultRequestLog) LeafHash(_ context.Context, lh []byte) {
 	glog.V(vLevel).Infof("RL: LeafHash: %s", hex.EncodeToString(lh))
 }
 
 // Status logs the response HTTP status code after processing completes.
-func (dlr *DefaultRequestLog) Status(c context.Context, s int) {
+func (dlr *DefaultRequestLog) Status(_ context.Context, s int) {
 	glog.V(vLevel).Infof("RL: Status: %d", s)
 }

--- a/trillian/ctfe/requestlog.go
+++ b/trillian/ctfe/requestlog.go
@@ -37,34 +37,34 @@ type RequestLog interface {
 	// can be used by the logger to set values on the returned context.
 	Start(context.Context) context.Context
 	// LogPrefix will be called once per request to set the log prefix.
-	LogPrefix(string)
+	LogPrefix(context.Context, string)
 	// AddDERToChain will be called once for each certificate in a submitted
 	// chain. It's called early in request processing so the supplied bytes
 	// have not been checked for validity. Calls will be in order of the
 	// certificates as presented in the request with the root last.
-	AddDERToChain([]byte)
+	AddDERToChain(context.Context, []byte)
 	// AddCertToChain will be called once for each certificate in the chain
 	// after it has been parsed and verified. Calls will be in order of the
 	// certificates as presented in the request with the root last.
-	AddCertToChain(*x509.Certificate)
+	AddCertToChain(context.Context, *x509.Certificate)
 	// FirstAndSecond will be called once for a consistency proof request with
 	// the first and second tree sizes involved (if they parse correctly).
-	FirstAndSecond(int64, int64)
+	FirstAndSecond(context.Context, int64, int64)
 	// StartAndEnd will be called once for a get entries request with the
 	// endpoints of the range requested (if they parse correctly).
-	StartAndEnd(int64, int64)
+	StartAndEnd(context.Context, int64, int64)
 	// LeafIndex will be called once with the index of a leaf being requested
 	// by get entry and proof (if the request params parse correctly).
-	LeafIndex(int64)
+	LeafIndex(context.Context, int64)
 	// TreeSize will be called once with the requested tree size for get entry
 	// and proof requests (if the request params parse correctly).
-	TreeSize(int64)
+	TreeSize(context.Context, int64)
 	// LeafHash will be called once for get proof by hash requests with the
 	// requested hash value (if the parameters parse correctly).
-	LeafHash([]byte)
+	LeafHash(context.Context, []byte)
 	// Status will be called once to set the HTTP status code that was the
 	// the result after the request has been handled.
-	Status(int)
+	Status(context.Context, int)
 }
 
 // DefaultRequestLog is an implementation of RequestLog that does nothing
@@ -79,51 +79,51 @@ func (dlr *DefaultRequestLog) Start(ctx context.Context) context.Context {
 }
 
 // LogPrefix logs the prefix of the CT log that this request is for.
-func (dlr *DefaultRequestLog) LogPrefix(p string) {
+func (dlr *DefaultRequestLog) LogPrefix(c context.Context, p string) {
 	glog.V(vLevel).Infof("RL: LogPrefix: %s", p)
 }
 
 // AddDERToChain logs the raw bytes of a submitted certificate.
-func (dlr *DefaultRequestLog) AddDERToChain(d []byte) {
+func (dlr *DefaultRequestLog) AddDERToChain(c context.Context, d []byte) {
 	glog.V(vLevel).Infof("RL: Cert DER: %s", hex.EncodeToString(d))
 }
 
 // AddCertToChain logs some issuer / subject / timing fields from a
 // certificate that is part of a submitted chain.
-func (dlr *DefaultRequestLog) AddCertToChain(c *x509.Certificate) {
+func (dlr *DefaultRequestLog) AddCertToChain(c context.Context, cert *x509.Certificate) {
 	glog.V(vLevel).Infof("RL: Cert: Sub: %s Iss: %s notBef: %s notAft: %s",
-		x509util.NameToString(c.Subject),
-		x509util.NameToString(c.Issuer),
-		c.NotBefore.Format(time.RFC1123Z),
-		c.NotAfter.Format(time.RFC1123Z))
+		x509util.NameToString(cert.Subject),
+		x509util.NameToString(cert.Issuer),
+		cert.NotBefore.Format(time.RFC1123Z),
+		cert.NotAfter.Format(time.RFC1123Z))
 }
 
 // FirstAndSecond logs request parameters.
-func (dlr *DefaultRequestLog) FirstAndSecond(f, s int64) {
+func (dlr *DefaultRequestLog) FirstAndSecond(c context.Context, f, s int64) {
 	glog.V(vLevel).Infof("RL: First: %d Second: %d", f, s)
 }
 
 // StartAndEnd logs request parameters.
-func (dlr *DefaultRequestLog) StartAndEnd(s, e int64) {
+func (dlr *DefaultRequestLog) StartAndEnd(c context.Context, s, e int64) {
 	glog.V(vLevel).Infof("RL: Start: %d End: %d", s, e)
 }
 
 // LeafIndex logs request parameters.
-func (dlr *DefaultRequestLog) LeafIndex(li int64) {
+func (dlr *DefaultRequestLog) LeafIndex(c context.Context, li int64) {
 	glog.V(vLevel).Infof("RL: LeafIndex: %d", li)
 }
 
 // TreeSize logs request parameters.
-func (dlr *DefaultRequestLog) TreeSize(ts int64) {
+func (dlr *DefaultRequestLog) TreeSize(c context.Context, ts int64) {
 	glog.V(vLevel).Infof("RL: TreeSize: %d", ts)
 }
 
 // LeafHash logs request parameters.
-func (dlr *DefaultRequestLog) LeafHash(lh []byte) {
+func (dlr *DefaultRequestLog) LeafHash(c context.Context, lh []byte) {
 	glog.V(vLevel).Infof("RL: LeafHash: %s", hex.EncodeToString(lh))
 }
 
 // Status logs the response HTTP status code after processing completes.
-func (dlr *DefaultRequestLog) Status(s int) {
+func (dlr *DefaultRequestLog) Status(c context.Context, s int) {
 	glog.V(vLevel).Infof("RL: Status: %d", s)
 }


### PR DESCRIPTION
Make the handler code call the context setup function so request handlers have access to values set on it.