### PR TITLE
Improve crlcheck command line tool

### DIFF
--- a/x509util/crlcheck/crlcheck.go
+++ b/x509util/crlcheck/crlcheck.go
@@ -19,16 +19,20 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io/ioutil"
+	"net/http"
 	"os"
+	"time"
 
 	"github.com/google/certificate-transparency-go/x509"
 	"github.com/google/certificate-transparency-go/x509util"
 )
 
 var (
-	caFile  = flag.String("ca", "", "CA certificate file")
-	verbose = flag.Bool("verbose", false, "Verbose output")
-	strict  = flag.Bool("strict", false, "Strict validation of CRL contents")
+	caFile      = flag.String("ca", "", "CA certificate file")
+	verbose     = flag.Bool("verbose", false, "Verbose output")
+	strict      = flag.Bool("strict", false, "Strict validation of CRL contents")
+	expectCerts = flag.Bool("cert", false, "Input files are certificates not CRLs")
 )
 
 func main() {
@@ -54,34 +58,46 @@ func main() {
 		}
 	}
 
-	errcount := 0
-	for _, filename := range flag.Args() {
-		dataList, err := x509util.ReadPossiblePEMURL(filename, "X509 CRL")
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "%s: failed to read data: %v\n", filename, err)
-			errcount++
-			continue
-		}
-
-		for _, data := range dataList {
-			if err := processCRL(data, caCerts); err != nil {
-				fmt.Fprintf(os.Stderr, "%s: %v\n", filename, err)
-				errcount++
+	errored := false
+	for _, arg := range flag.Args() {
+		if *expectCerts {
+			if err := processCertArg(arg, caCerts); err != nil {
+				fmt.Fprintf(os.Stderr, "%s: failed to read certificate data: %v\n", arg, err)
+				errored = true
+			}
+		} else {
+			if err := processCRLArg(arg, caCerts); err != nil {
+				fmt.Fprintf(os.Stderr, "%s: failed to read CRL data: %v\n", arg, err)
+				errored = true
 			}
 		}
 	}
-	if errcount > 0 {
+
+	if errored {
 		os.Exit(1)
 	}
 }
 
-func processCRL(data []byte, caCerts []*x509.Certificate) error {
+func processCRLArg(arg string, caCerts []*x509.Certificate) error {
+	dataList, err := x509util.ReadPossiblePEMURL(arg, "X509 CRL")
+	if err != nil {
+		return err
+	}
+	for _, data := range dataList {
+		if _, err := processCRL(data, caCerts); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func processCRL(data []byte, caCerts []*x509.Certificate) (*x509.CertificateList, error) {
 	certList, err := x509.ParseCertificateListDER(data)
 	if certList == nil {
-		return fmt.Errorf("parse error: %v", err)
+		return nil, fmt.Errorf("CRL parse error: %v", err)
 	}
 	if err != nil && *strict {
-		return fmt.Errorf("strict parse error: %v", err)
+		return nil, fmt.Errorf("strict CRL parse error: %v", err)
 	}
 	if *verbose {
 		fmt.Print(x509util.CRLToString(certList))
@@ -93,13 +109,123 @@ func processCRL(data []byte, caCerts []*x509.Certificate) error {
 		if err := caCert.CheckCertificateListSignature(certList); err != nil {
 			verifyErr = err
 		} else {
+			if *verbose {
+				fmt.Printf("CRL signature verified against CA cert %q\n", x509util.NameToString(caCert.Subject))
+			}
 			verifyErr = nil
 			verified = true
 			break
 		}
 	}
 	if !verified {
-		return fmt.Errorf("verification error: %v", verifyErr)
+		return nil, fmt.Errorf("verification error: %v", verifyErr)
 	}
+	return certList, nil
+}
+
+func processCertArg(filename string, caCerts []*x509.Certificate) error {
+	dataList, err := x509util.ReadPossiblePEMFile(filename, "CERTIFICATE")
+	if err != nil {
+		return err
+	}
+	if len(dataList) == 0 {
+		return fmt.Errorf("no certs found in %s", filename)
+	}
+
+	if len(caCerts) == 0 {
+		// No user-provided CA certs, so use any later entries in the file as possible issuers.
+		for i := 1; i < len(dataList); i++ {
+			issuer, err := x509.ParseCertificate(dataList[i])
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "failed to parse [%d] in chain: %v", i, err)
+				continue
+			}
+			if *verbose {
+				fmt.Printf("treating cert [%d] with subject %q as potential issuer\n", i, x509util.NameToString(issuer.Subject))
+			}
+			caCerts = append(caCerts, issuer)
+		}
+	}
+	return processCert(dataList[0], caCerts)
+}
+
+func processCert(data []byte, caCerts []*x509.Certificate) error {
+	client := &http.Client{}
+
+	cert, err := x509.ParseCertificate(data)
+	if err != nil {
+		return fmt.Errorf("certificate parse error: %v", err)
+	}
+	issuer, err := getIssuer(cert, client)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to retrieve issuer for cert: %v\n", err)
+	}
+	if issuer != nil {
+		if *verbose {
+			fmt.Printf("using issuer %q\n", x509util.NameToString(issuer.Subject))
+		}
+		caCerts = append(caCerts, issuer)
+	}
+	expired := false
+	if time.Now().After(cert.NotAfter) {
+		fmt.Printf("certificate is expired (since %v)\n", cert.NotAfter)
+		expired = true
+	}
+	for _, crldp := range cert.CRLDistributionPoints {
+		if *verbose {
+			fmt.Printf("retrieving CRL from %q\n", crldp)
+		}
+		rsp, err := client.Get(crldp)
+		if err != nil || rsp.StatusCode != http.StatusOK {
+			return fmt.Errorf("failed to get CRL from %q: %v", crldp, err)
+		}
+		body, err := ioutil.ReadAll(rsp.Body)
+		if err != nil {
+			return fmt.Errorf("failed to read CRL from %q: %v", crldp, err)
+		}
+		rsp.Body.Close()
+		certList, err := processCRL(body, caCerts)
+		if err != nil {
+			return err
+		}
+		if expired {
+			continue
+		}
+		// Check the CRL for the presence of the original cert.
+		for _, rev := range certList.TBSCertList.RevokedCertificates {
+			if rev.SerialNumber.Cmp(cert.SerialNumber) == 0 {
+				fmt.Printf("%s: certificate with serial number %v revoked at %v\n", crldp, cert.SerialNumber, rev.RevocationTime)
+				if rev.RevocationReason != x509.Unspecified {
+					fmt.Printf("  revocation reason: %s\v", x509util.RevocationReasonToString(rev.RevocationReason))
+				}
+				break
+			}
+		}
+	}
+
 	return nil
+}
+
+func getIssuer(cert *x509.Certificate, client *http.Client) (*x509.Certificate, error) {
+	if len(cert.IssuingCertificateURL) == 0 {
+		return nil, nil
+	}
+	issuerURL := cert.IssuingCertificateURL[0]
+	if *verbose {
+		fmt.Printf("retrieving issuer from %q\n", issuerURL)
+	}
+	rsp, err := client.Get(issuerURL)
+	if err != nil || rsp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to get issuer from %q: %v", issuerURL, err)
+	}
+	defer rsp.Body.Close()
+	body, err := ioutil.ReadAll(rsp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read issuer from %q: %v", issuerURL, err)
+	}
+	issuers, err := x509.ParseCertificates(body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse issuer cert: %v", err)
+	}
+	return issuers[0], nil
 }

--- a/x509util/crlcheck/crlcheck.go
+++ b/x509util/crlcheck/crlcheck.go
@@ -63,6 +63,8 @@ func main() {
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "%s: %v\n", filename, err)
 				errcount++
+			}
+			if certList == nil {
 				continue
 			}
 			crls = append(crls, certList)

--- a/x509util/revoked.go
+++ b/x509util/revoked.go
@@ -24,7 +24,8 @@ import (
 	"github.com/google/certificate-transparency-go/x509/pkix"
 )
 
-func revocationReasonToString(reason x509.RevocationReasonCode) string {
+// RevocationReasonToString generates a string describing a revocation reason code.
+func RevocationReasonToString(reason x509.RevocationReasonCode) string {
 	switch reason {
 	case x509.Unspecified:
 		return "Unspecified"
@@ -145,7 +146,7 @@ func CRLToString(crl *x509.CertificateList) string {
 		if count > 0 {
 			result.WriteString(fmt.Sprintf("            X509v3 CRL Reason Code:"))
 			showCritical(critical)
-			result.WriteString(fmt.Sprintf("                %s\n", revocationReasonToString(c.RevocationReason)))
+			result.WriteString(fmt.Sprintf("                %s\n", RevocationReasonToString(c.RevocationReason)))
 		}
 		count, critical = OIDInExtensions(x509.OIDExtensionInvalidityDate, c.Extensions)
 		if count > 0 {


### PR DESCRIPTION
```bash
% crlcheck --cert revoked.pem 
E0115 14:43:31.461245   42606 crlcheck.go:185] http://crl3.digicert.com/ssca-sha2-g5.crl: certificate with serial number 2238508373096059399630658340676916584 revoked at 2016-09-02 21:28:48 +0000 UTC
E0115 14:43:31.964028   42606 crlcheck.go:185] http://crl4.digicert.com/ssca-sha2-g5.crl: certificate with serial number 2238508373096059399630658340676916584 revoked at 2016-09-02 21:28:48 +0000 UTC
% crlcheck --cert expired.pem
E0115 14:43:38.658144   42614 crlcheck.go:161] certificate is expired (since 2014-04-06 23:59:59 +0000 UTC)
```