### PR TITLE
trillian: improve extension processing

### DIFF
--- a/trillian/ctfe/handlers.go
+++ b/trillian/ctfe/handlers.go
@@ -815,7 +815,7 @@ func marshalAndWriteAddChainResponse(sct *ct.SignedCertificateTimestamp, signer 
 		SCTVersion: ct.Version(sct.SCTVersion),
 		Timestamp:  sct.Timestamp,
 		ID:         logID[:],
-		Extensions: "",
+		Extensions: base64.StdEncoding.EncodeToString(sct.Extensions),
 		Signature:  sig,
 	}
 

--- a/trillian/ctfe/serialize.go
+++ b/trillian/ctfe/serialize.go
@@ -83,7 +83,7 @@ func buildV1SCT(signer *crypto.Signer, leaf *ct.MerkleTreeLeaf) (*ct.SignedCerti
 	sctInput := ct.SignedCertificateTimestamp{
 		SCTVersion: ct.V1,
 		Timestamp:  leaf.TimestampedEntry.Timestamp,
-		Extensions: ct.CTExtensions{},
+		Extensions: leaf.TimestampedEntry.Extensions,
 	}
 	data, err := ct.SerializeSCTSignatureInput(sctInput, ct.LogEntry{Leaf: *leaf})
 	if err != nil {
@@ -113,7 +113,7 @@ func buildV1SCT(signer *crypto.Signer, leaf *ct.MerkleTreeLeaf) (*ct.SignedCerti
 		SCTVersion: ct.V1,
 		LogID:      ct.LogID{KeyID: logID},
 		Timestamp:  sctInput.Timestamp,
-		Extensions: ct.CTExtensions{},
+		Extensions: sctInput.Extensions,
 		Signature:  digitallySigned,
 	}, nil
 }


### PR DESCRIPTION
Slight tweaks to allow for the unlikely event of RFC6962 extensions
ever getting used.

Tested by temporarily changing the CT personality to store some data
in the Extensions field of newly added entries; ran the integration script
successfully (which includes signature verification etc.)