### PR TITLE
x509: drop inert error check

### DIFF
--- a/x509/x509.go
+++ b/x509/x509.go
@@ -1033,9 +1033,6 @@ func BuildPrecertTBS(tbsData []byte, preIssuer *Certificate) ([]byte, error) {
 			return nil, fmt.Errorf("pre-cert has no authority-key-id extension to update")
 		}
 		tbs.Extensions[keyAt].Value = issuerKeyID
-		if err != nil {
-			return nil, fmt.Errorf("failed to marshal new auth key ID: %v", err)
-		}
 	}
 
 	data, err := asn1.Marshal(tbs)


### PR DESCRIPTION
Commit 308855f505e444c931 ("x509: use pre-issuer in precert building")
replaced an asn1.Marshal call but left the error check in place; it's
now pointless, so remove it.

Fixes #135