### PR TITLE
scanner,preload: remove channel buffers

### DIFF
--- a/preload/preloader/preloader.go
+++ b/preload/preloader/preloader.go
@@ -173,7 +173,7 @@ func main() {
 	}
 	scanner := scanner.NewScanner(fetchLogClient, opts)
 
-	bufferSize := *batchSize * *parallelFetch
+	bufferSize := 10 * *parallelSubmit
 	certs := make(chan *ct.LogEntry, bufferSize)
 	precerts := make(chan *ct.LogEntry, bufferSize)
 	addedCerts := make(chan *preload.AddedCert, bufferSize)

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -285,8 +285,8 @@ func (s *Scanner) Scan(ctx context.Context, foundCert func(*ct.LogEntry), foundP
 
 	ticker := time.NewTicker(time.Second)
 	startTime := time.Now()
-	fetches := make(chan fetchRange, 1000)
-	jobs := make(chan entryInfo, 100000)
+	fetches := make(chan fetchRange)
+	jobs := make(chan entryInfo)
 	go func() {
 		for range ticker.C {
 			certsProcessed := atomic.LoadInt64(&s.certsProcessed)

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -48,6 +48,9 @@ type ScannerOptions struct { // nolint:golint
 	// Number of concurrent fethers to run
 	ParallelFetch int
 
+	// Number of fetched entries to buffer on their way to the callbacks
+	BufferSize int
+
 	// Log entry index to start fetching & matching at
 	StartIndex int64
 
@@ -286,7 +289,7 @@ func (s *Scanner) Scan(ctx context.Context, foundCert func(*ct.LogEntry), foundP
 	ticker := time.NewTicker(time.Second)
 	startTime := time.Now()
 	fetches := make(chan fetchRange)
-	jobs := make(chan entryInfo)
+	jobs := make(chan entryInfo, s.opts.BufferSize)
 	go func() {
 		for range ticker.C {
 			certsProcessed := atomic.LoadInt64(&s.certsProcessed)


### PR DESCRIPTION
The fetches chan buffer can be removed without any impact as the
generator is fast, and has to block on the consumer anyway.

The big arbitrary jobs buffer feels misplaced hidden in a generic-use
Scanner object, it should be up to the application to decide if it wants to
queue or not. It also unavoidably completely fills when the consumer is
slower than the fetcher (like in preload), adding 6GB of memory usage.

The point of buffering in preload is to not ever have a submitter block
on a fetch. Assuming a fetch takes at most X times a submit, and
considering fetches are batched while submits are not, a buffer of
length X (for each submitter) will suffice to guarantee that. I picked
10 as a conservative X, but I suspect it might be < 1.

Notice how preload can make a more informed decision on queueing than
scanner, confirming the choice about the jobs buffer.

[Imported from #36]