### PR TITLE
jsonclient: Short-circuit retries on context errors.

### DIFF
--- a/jsonclient/client.go
+++ b/jsonclient/client.go
@@ -250,6 +250,10 @@ func (c *JSONClient) PostAndParseWithRetry(ctx context.Context, path string, req
 	for {
 		httpRsp, body, err := c.PostAndParse(ctx, path, req, rsp)
 		if err != nil {
+			// Don't retry context errors.
+			if err == context.Canceled || err == context.DeadlineExceeded {
+				return nil, nil, err
+			}
 			wait := c.backoff.set(nil)
 			c.logger.Printf("Request failed, backing-off for %s: %s", wait, err)
 		} else {


### PR DESCRIPTION
Without this, cancellation leads to weird log messages, like
Request failed, backing-off for 1s: context cancelled. It also means the
function doesn't return as quickly as it could under cancellation.