### PR TITLE
x509: make nil CFDataRef types version-specific

### DIFF
--- a/x509/nilref_nil_darwin.go
+++ b/x509/nilref_nil_darwin.go
@@ -1,0 +1,26 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build cgo,!arm,!arm64,!ios,!go1.10
+
+package x509
+
+/*
+#cgo CFLAGS: -mmacosx-version-min=10.6 -D__MAC_OS_X_VERSION_MAX_ALLOWED=1080
+#cgo LDFLAGS: -framework CoreFoundation -framework Security
+
+#include <CoreFoundation/CoreFoundation.h>
+*/
+import "C"
+
+// For Go versions before 1.10, nil values for Apple's CoreFoundation
+// CF*Ref types were represented by nil.  See:
+//   https://github.com/golang/go/commit/b868616b63a8
+func setNilCFRef(v *C.CFDataRef) {
+	*v = nil
+}
+
+func isNilCFRef(v C.CFDataRef) bool {
+	return v == nil
+}

--- a/x509/nilref_zero_darwin.go
+++ b/x509/nilref_zero_darwin.go
@@ -1,0 +1,26 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build cgo,!arm,!arm64,!ios,go1.10
+
+package x509
+
+/*
+#cgo CFLAGS: -mmacosx-version-min=10.6 -D__MAC_OS_X_VERSION_MAX_ALLOWED=1080
+#cgo LDFLAGS: -framework CoreFoundation -framework Security
+
+#include <CoreFoundation/CoreFoundation.h>
+*/
+import "C"
+
+// For Go versions >= 1.10, nil values for Apple's CoreFoundation
+// CF*Ref types are represented by zero.  See:
+//   https://github.com/golang/go/commit/b868616b63a8
+func setNilCFRef(v *C.CFDataRef) {
+	*v = 0
+}
+
+func isNilCFRef(v C.CFDataRef) bool {
+	return v == 0
+}

--- a/x509/root_cgo_darwin.go
+++ b/x509/root_cgo_darwin.go
@@ -221,8 +221,10 @@ import (
 func loadSystemRoots() (*CertPool, error) {
 	roots := NewCertPool()
 
-	var data C.CFDataRef = nil
-	var untrustedData C.CFDataRef = nil
+	var data C.CFDataRef
+	setNilCFRef(&data)
+	var untrustedData C.CFDataRef
+	setNilCFRef(&untrustedData)
 	err := C.FetchPEMRootsCTX509(&data, &untrustedData)
 	if err == -1 {
 		// TODO: better error message
@@ -232,7 +234,7 @@ func loadSystemRoots() (*CertPool, error) {
 	defer C.CFRelease(C.CFTypeRef(data))
 	buf := C.GoBytes(unsafe.Pointer(C.CFDataGetBytePtr(data)), C.int(C.CFDataGetLength(data)))
 	roots.AppendCertsFromPEM(buf)
-	if untrustedData == nil {
+	if isNilCFRef(untrustedData) {
 		return roots, nil
 	}
 	defer C.CFRelease(C.CFTypeRef(untrustedData))


### PR DESCRIPTION
Go 1.10 needs C.CFDataRef to have nil value of '0'
Go 1.9 nees C.CFDataRef to have nil value of 'nil'

As we have a fork of crypto/x509, our source code for x509 can be
a different version than the current compiler.

We need our code to work with both 1.9 and 1.10, so encapsulate
setting and testing for nil CFDataRef into a couple of version-specific
functions.

Fixes #153 and #131 (hopefully).