### PR TITLE
travis: re-enable a coverage build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ go: 1.9
 env:
   - GCE_CI=true GOFLAGS=
   - GOFLAGS=-race
-  - GOFLAGS=      WITH_ETCD=true
+  - GOFLAGS=      WITH_ETCD=true WITH_COVERAGE=true
   - GOFLAGS=-race WITH_ETCD=true
 
 matrix:
@@ -46,7 +46,7 @@ script:
   - set -e
   - export TRILLIAN_SQL_DRIVER=mysql
   - cd $HOME/gopath/src/github.com/google/certificate-transparency-go
-  - ./scripts/presubmit.sh ${PRESUBMIT_OPTS}
+  - ./scripts/presubmit.sh ${PRESUBMIT_OPTS} ${WITH_COVERAGE:+--coverage}
   - |
       # Check re-generation didn't change anything
       status=$(git status --porcelain | grep -v coverage) || :


### PR DESCRIPTION
Commit aac643b1ebd6 ("Shift to use gometalinter") synced
scripts/presubmit.sh with the Trillian version, but didn't
update travis.yml to match and so coverage generation stopped
happening.