### PR TITLE
Use NewSigner API

### DIFF
--- a/trillian/ctfe/handlers_test.go
+++ b/trillian/ctfe/handlers_test.go
@@ -18,6 +18,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	gocrypto "crypto"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -33,9 +34,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/golang/mock/gomock"
-	ct "github.com/google/certificate-transparency-go"
 	"github.com/google/certificate-transparency-go/tls"
-	cttestonly "github.com/google/certificate-transparency-go/trillian/ctfe/testonly"
 	"github.com/google/certificate-transparency-go/trillian/mockclient"
 	"github.com/google/certificate-transparency-go/trillian/testdata"
 	"github.com/google/certificate-transparency-go/trillian/util"
@@ -47,6 +46,9 @@ import (
 	"github.com/kylelemons/godebug/pretty"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	ct "github.com/google/certificate-transparency-go"
+	cttestonly "github.com/google/certificate-transparency-go/trillian/ctfe/testonly"
 )
 
 // Arbitrary time for use in tests
@@ -553,9 +555,9 @@ func TestGetSTH(t *testing.T) {
 		func() {
 			var signer *crypto.Signer
 			if test.signErr != nil {
-				signer = crypto.NewSHA256Signer(testdata.NewSignerWithErr(key, test.signErr))
+				signer = crypto.NewSigner(0, testdata.NewSignerWithErr(key, test.signErr), gocrypto.SHA256)
 			} else {
-				signer = crypto.NewSHA256Signer(testdata.NewSignerWithFixedSig(key, fakeSignature))
+				signer = crypto.NewSigner(0, testdata.NewSignerWithFixedSig(key, fakeSignature), gocrypto.SHA256)
 			}
 
 			info := setupTest(t, []string{cttestonly.CACertPEM}, signer)

--- a/trillian/ctfe/instance.go
+++ b/trillian/ctfe/instance.go
@@ -16,6 +16,7 @@ package ctfe
 
 import (
 	"context"
+	"crypto"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -27,7 +28,7 @@ import (
 	"github.com/google/certificate-transparency-go/trillian/util"
 	"github.com/google/certificate-transparency-go/x509"
 	"github.com/google/trillian"
-	"github.com/google/trillian/crypto"
+	tcrypto "github.com/google/trillian/crypto"
 	"github.com/google/trillian/crypto/keys"
 	"github.com/google/trillian/monitoring"
 )
@@ -125,7 +126,10 @@ func SetUpInstance(ctx context.Context, client trillian.TrillianLogClient, cfg *
 	if err != nil {
 		return nil, fmt.Errorf("failed to load private key: %v", err)
 	}
-	signer := crypto.NewSHA256Signer(key)
+	signer := &tcrypto.Signer{
+		Hash:   crypto.SHA256,
+		Signer: key,
+	}
 
 	var keyUsages []x509.ExtKeyUsage
 	if len(cfg.ExtKeyUsages) > 0 {

--- a/trillian/ctfe/serialize_test.go
+++ b/trillian/ctfe/serialize_test.go
@@ -16,10 +16,10 @@ package ctfe
 
 import (
 	"bytes"
+	gocrypto "crypto"
 	"crypto/sha256"
 	"testing"
 
-	ct "github.com/google/certificate-transparency-go"
 	"github.com/google/certificate-transparency-go/tls"
 	"github.com/google/certificate-transparency-go/trillian/ctfe/testonly"
 	"github.com/google/certificate-transparency-go/trillian/testdata"
@@ -28,6 +28,8 @@ import (
 	"github.com/google/trillian/crypto"
 	"github.com/google/trillian/crypto/keys/pem"
 	"github.com/kylelemons/godebug/pretty"
+
+	ct "github.com/google/certificate-transparency-go"
 )
 
 func TestBuildV1MerkleTreeLeafForCert(t *testing.T) {
@@ -151,8 +153,9 @@ func TestSignV1TreeHead(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not create signer: %v", err)
 	}
-	signer := crypto.NewSHA256Signer(privKey)
-	c := &LogContext{logID: 6962, signer: signer}
+	logID := int64(6962)
+	signer := crypto.NewSigner(logID, privKey, gocrypto.SHA256)
+	c := &LogContext{logID: logID, signer: signer}
 
 	sth := ct.SignedTreeHead{
 		Version:   ct.V1,
@@ -210,8 +213,9 @@ func TestSignV1TreeHeadDifferentSigners(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not create signer1: %v", err)
 	}
-	signer1 := crypto.NewSHA256Signer(privKey)
-	c1 := &LogContext{logID: 6962, signer: signer1}
+	logID := int64(6962)
+	signer1 := crypto.NewSigner(logID, privKey, gocrypto.SHA256)
+	c1 := &LogContext{logID: logID, signer: signer1}
 
 	signer2, err := setupSigner(fakeSignature)
 	if err != nil {

--- a/trillian/ctfe/structures_test.go
+++ b/trillian/ctfe/structures_test.go
@@ -15,15 +15,17 @@
 package ctfe
 
 import (
+	gocrypto "crypto"
 	"testing"
 	"time"
 
-	ct "github.com/google/certificate-transparency-go"
 	"github.com/google/certificate-transparency-go/tls"
 	"github.com/google/certificate-transparency-go/trillian/testdata"
 	"github.com/google/trillian/crypto"
 	"github.com/google/trillian/crypto/keys/pem"
 	"github.com/kylelemons/godebug/pretty"
+
+	ct "github.com/google/certificate-transparency-go"
 )
 
 var (
@@ -88,7 +90,7 @@ func setupSigner(fakeSig []byte) (*crypto.Signer, error) {
 		return nil, err
 	}
 
-	return crypto.NewSHA256Signer(testdata.NewSignerWithFixedSig(key, fakeSig)), nil
+	return crypto.NewSigner(0, testdata.NewSignerWithFixedSig(key, fakeSig), gocrypto.SHA256), nil
 }
 
 // Creates a dummy cert chain


### PR DESCRIPTION
Explicitly set the `KeyID` and hash function for signing. 

Depends on google/trillian#1049
Part of google/trillian#958