### PR TITLE
Update handlers and tests for the behaviour changes in trillian #995.

### DIFF
--- a/trillian/ctfe/handlers.go
+++ b/trillian/ctfe/handlers.go
@@ -582,7 +582,7 @@ func getProofByHash(ctx context.Context, c *LogContext, w http.ResponseWriter, r
 	// Additional sanity checks on the response.
 	if len(rsp.Proof) == 0 {
 		// The backend returns the STH even when there is no proof, so explicitly
-		// map this to 4xx".
+		// map this to 4xx.
 		return http.StatusNotFound, errors.New("get-proof-by-hash: backend did not return a proof")
 	}
 	if !checkAuditPath(rsp.Proof[0].Hashes) {

--- a/trillian/ctfe/handlers.go
+++ b/trillian/ctfe/handlers.go
@@ -727,6 +727,12 @@ func getEntryAndProof(ctx context.Context, c *LogContext, w http.ResponseWriter,
 		return c.toHTTPStatus(err), fmt.Errorf("backend GetEntryAndProof request failed: %v", err)
 	}
 
+	if rsp.GetSignedLogRoot() != nil && rsp.GetSignedLogRoot().TreeSize < treeSize {
+		// If tree size is not large enough return the 4xx here, would previously
+		// have come from the error status mapping above.
+		return http.StatusBadRequest, fmt.Errorf("need tree size: %d for proof but only got: %d", req.TreeSize, rsp.GetSignedLogRoot().TreeSize)
+	}
+
 	// Apply some checks that we got reasonable data from the backend
 	if rsp.Proof == nil || rsp.Leaf == nil || len(rsp.Proof.Hashes) == 0 || len(rsp.Leaf.LeafValue) == 0 {
 		return http.StatusInternalServerError, fmt.Errorf("got RPC bad response, possible extra info: %v", rsp)

--- a/trillian/ctfe/handlers.go
+++ b/trillian/ctfe/handlers.go
@@ -507,7 +507,7 @@ func getSTHConsistency(ctx context.Context, c *LogContext, w http.ResponseWriter
 		}
 
 		// We can get here with a tree size too small to satisfy the proof.
-		if rsp.GetSignedLogRoot().TreeSize < second {
+		if rsp.GetSignedLogRoot() != nil && rsp.GetSignedLogRoot().TreeSize < second {
 			return http.StatusBadRequest, fmt.Errorf("need tree size: %d for proof but only got: %d", second, rsp.SignedLogRoot.TreeSize)
 		}
 
@@ -575,14 +575,14 @@ func getProofByHash(ctx context.Context, c *LogContext, w http.ResponseWriter, r
 
 	// We could fail to get the proof because the tree size that the server has
 	// is not large enough.
-	if rsp.GetSignedLogRoot().TreeSize < treeSize {
+	if rsp.GetSignedLogRoot() != nil && rsp.GetSignedLogRoot().TreeSize < treeSize {
 		return http.StatusNotFound, fmt.Errorf("log returned tree size: %d but we expected: %d", rsp.SignedLogRoot.TreeSize, treeSize)
 	}
 
 	// Additional sanity checks
 	if len(rsp.Proof) == 0 {
 		// This is no longer a 5xx error as backend returns the STH. Previously
-		// the 4xx was returned via the toHttpStatus(err) above.w
+		// the 4xx was returned via the toHttpStatus(err) above.
 		return http.StatusNotFound, errors.New("get-proof-by-hash: backend did not return a proof")
 	}
 	if !checkAuditPath(rsp.Proof[0].Hashes) {

--- a/trillian/ctfe/handlers_test.go
+++ b/trillian/ctfe/handlers_test.go
@@ -1546,6 +1546,65 @@ func TestGetEntryAndProof(t *testing.T) {
 				},
 			},
 		},
+		{
+			req:  "leaf_index=1&tree_size=3",
+			want: http.StatusBadRequest,
+			rpcRsp: &trillian.GetEntryAndProofResponse{
+				SignedLogRoot: &trillian.SignedLogRoot{
+					// Server returns a tree just large enough for the proof.
+					TreeSize: 2,
+				},
+				Proof: &trillian.Proof{},
+			},
+		},
+		{
+			req:  "leaf_index=1&tree_size=3",
+			want: http.StatusOK,
+			rpcRsp: &trillian.GetEntryAndProofResponse{
+				SignedLogRoot: &trillian.SignedLogRoot{
+					// Server returns a tree just large enough for the proof.
+					TreeSize: 3,
+				},
+				Proof: &trillian.Proof{
+					LeafIndex: 2,
+					Hashes: [][]byte{
+						[]byte("abcdef"),
+						[]byte("ghijkl"),
+						[]byte("mnopqr"),
+					},
+				},
+				// To match merkleLeaf above.
+				Leaf: &trillian.LogLeaf{
+					LeafValue:      leafBytes,
+					MerkleLeafHash: []byte("ahash"),
+					ExtraData:      []byte("extra"),
+				},
+			},
+		},
+		{
+			req:  "leaf_index=1&tree_size=3",
+			want: http.StatusOK,
+			rpcRsp: &trillian.GetEntryAndProofResponse{
+				SignedLogRoot: &trillian.SignedLogRoot{
+					// Server returns a tree larger than needed for the proof.
+					TreeSize: 300,
+				},
+				Proof: &trillian.Proof{
+					LeafIndex: 2,
+					Hashes: [][]byte{
+						[]byte("abcdef"),
+						[]byte("ghijkl"),
+						[]byte("mnopqr"),
+					},
+				},
+				// To match merkleLeaf above.
+				Leaf: &trillian.LogLeaf{
+					LeafValue:      leafBytes,
+					MerkleLeafHash: []byte("ahash"),
+					ExtraData:      []byte("extra"),
+				},
+			},
+		},
 	}
 
 	info := setupTest(t, nil, nil)


### PR DESCRIPTION
Note: This won't build until the API changes from #995 are merged into the trillian repo.

This mostly changes cases that were 4xx returned via the HTTP status code mapping to be explicitly returned if the server returns a tree size too small to handle the request.