### PR TITLE
Use tcrypto for trillian/crypto import

### DIFF
--- a/trillian/ctfe/handlers.go
+++ b/trillian/ctfe/handlers.go
@@ -32,15 +32,16 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	ct "github.com/google/certificate-transparency-go"
 	"github.com/google/certificate-transparency-go/tls"
 	"github.com/google/certificate-transparency-go/trillian/util"
 	"github.com/google/certificate-transparency-go/x509"
 	"github.com/google/trillian"
-	"github.com/google/trillian/crypto"
 	"github.com/google/trillian/monitoring"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	ct "github.com/google/certificate-transparency-go"
+	tcrypto "github.com/google/trillian/crypto"
 )
 
 // TODO(drysdale): remove this flag once everything has migrated to ByRange
@@ -229,7 +230,7 @@ type LogContext struct {
 	// rpcClient is the client used to communicate with the trillian backend
 	rpcClient trillian.TrillianLogClient
 	// signer signs objects
-	signer *crypto.Signer
+	signer *tcrypto.Signer
 	// rpcDeadline is the deadline that will be set on all backend RPC requests
 	rpcDeadline time.Duration
 
@@ -242,7 +243,7 @@ type LogContext struct {
 }
 
 // NewLogContext creates a new instance of LogContext.
-func NewLogContext(logID int64, prefix string, validationOpts CertValidationOpts, rpcClient trillian.TrillianLogClient, signer *crypto.Signer, instanceOpts InstanceOptions, timeSource util.TimeSource) *LogContext {
+func NewLogContext(logID int64, prefix string, validationOpts CertValidationOpts, rpcClient trillian.TrillianLogClient, signer *tcrypto.Signer, instanceOpts InstanceOptions, timeSource util.TimeSource) *LogContext {
 	ctx := &LogContext{
 		logID:          logID,
 		urlPrefix:      prefix,
@@ -885,7 +886,7 @@ func extraDataForChain(chain []*x509.Certificate, isPrecert bool) ([]byte, error
 
 // marshalAndWriteAddChainResponse is used by add-chain and add-pre-chain to create and write
 // the JSON response to the client
-func marshalAndWriteAddChainResponse(sct *ct.SignedCertificateTimestamp, signer *crypto.Signer, w http.ResponseWriter) error {
+func marshalAndWriteAddChainResponse(sct *ct.SignedCertificateTimestamp, signer *tcrypto.Signer, w http.ResponseWriter) error {
 	logID, err := GetCTLogID(signer.Public())
 	if err != nil {
 		return fmt.Errorf("failed to marshal logID: %v", err)

--- a/trillian/ctfe/handlers_test.go
+++ b/trillian/ctfe/handlers_test.go
@@ -18,7 +18,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	gocrypto "crypto"
+	"crypto"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -40,7 +40,6 @@ import (
 	"github.com/google/certificate-transparency-go/trillian/util"
 	"github.com/google/certificate-transparency-go/x509"
 	"github.com/google/trillian"
-	"github.com/google/trillian/crypto"
 	"github.com/google/trillian/crypto/keys/pem"
 	"github.com/google/trillian/monitoring"
 	"github.com/kylelemons/godebug/pretty"
@@ -49,6 +48,7 @@ import (
 
 	ct "github.com/google/certificate-transparency-go"
 	cttestonly "github.com/google/certificate-transparency-go/trillian/ctfe/testonly"
+	tcrypto "github.com/google/trillian/crypto"
 )
 
 // Arbitrary time for use in tests
@@ -110,7 +110,7 @@ type handlerTestInfo struct {
 }
 
 // setupTest creates mock objects and contexts.  Caller should invoke info.mockCtrl.Finish().
-func setupTest(t *testing.T, pemRoots []string, signer *crypto.Signer) handlerTestInfo {
+func setupTest(t *testing.T, pemRoots []string, signer *tcrypto.Signer) handlerTestInfo {
 	t.Helper()
 	info := handlerTestInfo{
 		mockCtrl: gomock.NewController(t),
@@ -553,11 +553,11 @@ func TestGetSTH(t *testing.T) {
 	for _, test := range tests {
 		// Run deferred funcs at the end of each iteration.
 		func() {
-			var signer *crypto.Signer
+			var signer *tcrypto.Signer
 			if test.signErr != nil {
-				signer = crypto.NewSigner(0, testdata.NewSignerWithErr(key, test.signErr), gocrypto.SHA256)
+				signer = tcrypto.NewSigner(0, testdata.NewSignerWithErr(key, test.signErr), crypto.SHA256)
 			} else {
-				signer = crypto.NewSigner(0, testdata.NewSignerWithFixedSig(key, fakeSignature), gocrypto.SHA256)
+				signer = tcrypto.NewSigner(0, testdata.NewSignerWithFixedSig(key, fakeSignature), crypto.SHA256)
 			}
 
 			info := setupTest(t, []string{cttestonly.CACertPEM}, signer)

--- a/trillian/ctfe/serialize_test.go
+++ b/trillian/ctfe/serialize_test.go
@@ -16,7 +16,7 @@ package ctfe
 
 import (
 	"bytes"
-	gocrypto "crypto"
+	"crypto"
 	"crypto/sha256"
 	"testing"
 
@@ -25,11 +25,11 @@ import (
 	"github.com/google/certificate-transparency-go/trillian/testdata"
 	"github.com/google/certificate-transparency-go/x509"
 	"github.com/google/certificate-transparency-go/x509util"
-	"github.com/google/trillian/crypto"
 	"github.com/google/trillian/crypto/keys/pem"
 	"github.com/kylelemons/godebug/pretty"
 
 	ct "github.com/google/certificate-transparency-go"
+	tcrypto "github.com/google/trillian/crypto"
 )
 
 func TestBuildV1MerkleTreeLeafForCert(t *testing.T) {
@@ -154,7 +154,7 @@ func TestSignV1TreeHead(t *testing.T) {
 		t.Fatalf("could not create signer: %v", err)
 	}
 	logID := int64(6962)
-	signer := crypto.NewSigner(logID, privKey, gocrypto.SHA256)
+	signer := tcrypto.NewSigner(logID, privKey, crypto.SHA256)
 	c := &LogContext{logID: logID, signer: signer}
 
 	sth := ct.SignedTreeHead{
@@ -214,7 +214,7 @@ func TestSignV1TreeHeadDifferentSigners(t *testing.T) {
 		t.Fatalf("could not create signer1: %v", err)
 	}
 	logID := int64(6962)
-	signer1 := crypto.NewSigner(logID, privKey, gocrypto.SHA256)
+	signer1 := tcrypto.NewSigner(logID, privKey, crypto.SHA256)
 	c1 := &LogContext{logID: logID, signer: signer1}
 
 	signer2, err := setupSigner(fakeSignature)

--- a/trillian/ctfe/structures_test.go
+++ b/trillian/ctfe/structures_test.go
@@ -15,17 +15,17 @@
 package ctfe
 
 import (
-	gocrypto "crypto"
+	"crypto"
 	"testing"
 	"time"
 
 	"github.com/google/certificate-transparency-go/tls"
 	"github.com/google/certificate-transparency-go/trillian/testdata"
-	"github.com/google/trillian/crypto"
 	"github.com/google/trillian/crypto/keys/pem"
 	"github.com/kylelemons/godebug/pretty"
 
 	ct "github.com/google/certificate-transparency-go"
+	tcrypto "github.com/google/trillian/crypto"
 )
 
 var (
@@ -84,13 +84,13 @@ func TestSerializeLogEntry(t *testing.T) {
 
 // Creates a fake signer for use in interaction tests.
 // It will always return fakeSig when asked to sign something.
-func setupSigner(fakeSig []byte) (*crypto.Signer, error) {
+func setupSigner(fakeSig []byte) (*tcrypto.Signer, error) {
 	key, err := pem.UnmarshalPublicKey(testdata.DemoPublicKey)
 	if err != nil {
 		return nil, err
 	}
 
-	return crypto.NewSigner(0, testdata.NewSignerWithFixedSig(key, fakeSig), gocrypto.SHA256), nil
+	return tcrypto.NewSigner(0, testdata.NewSignerWithFixedSig(key, fakeSig), crypto.SHA256), nil
 }
 
 // Creates a dummy cert chain


### PR DESCRIPTION
Use consistent import names.
Prefer not to rename go core packages.