### PR TITLE
Wean CTFE off trillian "tcrypto" for Go "crypto"

### DIFF
--- a/tls/types.go
+++ b/tls/types.go
@@ -14,7 +14,13 @@
 
 package tls
 
-import "fmt"
+import (
+	"crypto"
+	"crypto/dsa"
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"fmt"
+)
 
 // DigitallySigned gives information about a signature, including the algorithm used
 // and the signature value.  Defined in RFC 5246 s4.7.
@@ -92,5 +98,20 @@ func (s SignatureAlgorithm) String() string {
 		return "ECDSA"
 	default:
 		return fmt.Sprintf("UNKNOWN(%d)", s)
+	}
+}
+
+// SignatureAlgorithmFromPubKey returns the algorithm used for this public key.
+// ECDSA, RSA, and DSA keys are supported. Other key types will return Anonymous.
+func SignatureAlgorithmFromPubKey(k crypto.PublicKey) SignatureAlgorithm {
+	switch k.(type) {
+	case *ecdsa.PublicKey:
+		return ECDSA
+	case *rsa.PublicKey:
+		return RSA
+	case *dsa.PublicKey:
+		return DSA
+	default:
+		return Anonymous
 	}
 }

--- a/tls/types_test.go
+++ b/tls/types_test.go
@@ -15,8 +15,10 @@
 package tls
 
 import (
-	"crypto/x509"
-	"encoding/pem"
+	"crypto"
+	"crypto/dsa"
+	"crypto/ecdsa"
+	"crypto/rsa"
 	"testing"
 )
 
@@ -80,41 +82,18 @@ func TestDigitallySignedString(t *testing.T) {
 	}
 }
 
-const (
-	ecdsaPublicKey = `
------BEGIN PUBLIC KEY-----
-MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEvuynpVdR+5xSNaVBb//1fqO6Nb/nC+WvRQ4bALzy4G+QbByvO1Qpm2eUzTdDUnsLN5hp3pIXYAmtjvjY1fFZEg==
------END PUBLIC KEY-----`
-
-	rsaPublicKey = `
------BEGIN PUBLIC KEY-----
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsMB4reLZhs+2ReYX01nZpqLBQ9uhcZvBmzH54RsZDTb5khw+luSXKbLKXxdbQfrsxURbeVdugDNnV897VI43znuiKJ19Y/XS3N5Z7Q97/GOxOxGFObP0DovCAPblxAMaQBb+U9jkVt/4bHcNIOTZl/lXgX+yp58lH5uPfDwav/hVNg7QkAW3BxQZ5wiLTTZUILoTMjax4R24pULlg/Wt/rT4bDj8rxUgYR60MuO93jdBtNGwmzdCYyk4cEmrPEgCueRC6jFafUzlLjvuX89ES9n98LxX+gBANA7RpVPkJd0kfWFHO1JRUEJr++WjU3x4la2Xs4tUNX4QBSJP4XEOXwIDAQAB
------END PUBLIC KEY-----`
-
-	dsaPublicKey = `
------BEGIN PUBLIC KEY-----
-MIIDRjCCAjkGByqGSM44BAEwggIsAoIBAQDgLI6pXvqpcOY33lzeZrjUBHxphiz0I9VKF9vGpWymNfBptQ75bpQFe16jBjaOGwDImASHTp53XskQJLOXC4bZxoRUHsm8bHQVZHQhYgxn8ZDQX/40zOR1d73y1TXSiULo6rDKVlM+fFcm33tGv+ZOdfaIhW17c5jvDAy6UWqQakasvL+kfiejIDGHjLVFWwX0vLCG+pAomgO6snQHGcPhDO9uxEYPd9on7YTgBrpa2IcXk5jFeY8xOxMnMwoBojRvH97+ivdBR1yW8f+4FAGg5o1eFV5ZqoUAF8GO3BBEwluMGNeT7gMgl4PO8N8xBxJulHd3tLW5qkW0cBPwkbzzAiEAvdYeMPamsFAyd7s07dt78wxXyHGrwVl2AcQBo0QTATkCggEASH9Rp+EjNkL7uCqGJ78P4tjJM+2+xaEhZpJ/kTzq6DtdFhu5Rov6lN5NnZKPSUNYr9Vkmu88ru0iND1N37z0rJpImksXKxCv0AwBkwtqCwf9jjkTrZiGRzP8xf789wK+uG7Uud20ml9QzXKr9Af9WrRx3DtCq44PBaIlhPvpZS9znCZsuUZqYZFW3/oD4EhwPgVLSWeulh1t33ku3mYQwVS8ZTdJGPyFRoD1dcQ4EchR4ce0u0nTXlqErWhfnmb9msF6dFCV0Mx5yrqxkEHbJ/vZgB4zAdOke7XiJsWqIok/7IJpJuVOvkY9NHgBdlq3xU180+pEo2NrGm4pbrGm1wOCAQUAAoIBAAGbucHEfgtcu++OQQjYqneukv4zqcP/PCJTP+GuXen6SH25V2ZlHC88lG6qdZVBPWZidAb9BSoUQpW7BzauKRqH7rKOsIeqvEPCiWBKA781Zi5HAWGhC4INJJx54Q66F54DkGlTRVFkXlGpAIudhfAIG//MyO9TIsLSgRyqjKWVm+/XhWDIT5iMJZZ/IgmbICueaa7go8poHuTTyUDPHPIeL5d9Aru7qD4JtX+UVy6GYKhWx/guv+A7zyJ8d1kMLsmUAro80DLPDoais2I8YPpbu+xTSLLswIYddDdwg3P8mMAGzuWY/ZLumwpRr/fbI+t2Sm9KKGNGkGGIKAg43cs=
------END PUBLIC KEY-----`
-)
-
 func TestSignatureAlgorithm(t *testing.T) {
 	for _, test := range []struct {
-		name   string
-		keyPEM string
-		want   SignatureAlgorithm
+		name string
+		key  crypto.PublicKey
+		want SignatureAlgorithm
 	}{
-		{name: "ECDSA", keyPEM: ecdsaPublicKey, want: ECDSA},
-		{name: "RSA", keyPEM: rsaPublicKey, want: RSA},
-		{name: "DSA", keyPEM: dsaPublicKey, want: DSA},
+		{name: "ECDSA", key: new(ecdsa.PublicKey), want: ECDSA},
+		{name: "RSA", key: new(rsa.PublicKey), want: RSA},
+		{name: "DSA", key: new(dsa.PublicKey), want: DSA},
 	} {
-		keyDER, _ := pem.Decode([]byte(test.keyPEM))
-		key, err := x509.ParsePKIXPublicKey(keyDER.Bytes)
-		if err != nil {
-			t.Errorf("der: could not parse public key as PKIX (%v)", err)
-			continue
-		}
 
-		if got := SignatureAlgorithmFromPubKey(key); got != test.want {
+		if got := SignatureAlgorithmFromPubKey(test.key); got != test.want {
 			t.Errorf("%v: SignatureAlgorithm() = %v, want %v", test.name, got, test.want)
 		}
 	}

--- a/tls/types_test.go
+++ b/tls/types_test.go
@@ -91,8 +91,8 @@ func TestSignatureAlgorithm(t *testing.T) {
 		{name: "ECDSA", key: new(ecdsa.PublicKey), want: ECDSA},
 		{name: "RSA", key: new(rsa.PublicKey), want: RSA},
 		{name: "DSA", key: new(dsa.PublicKey), want: DSA},
+		{name: "Other", key: "foo", want: Anonymous},
 	} {
-
 		if got := SignatureAlgorithmFromPubKey(test.key); got != test.want {
 			t.Errorf("%v: SignatureAlgorithm() = %v, want %v", test.name, got, test.want)
 		}

--- a/tls/types_test.go
+++ b/tls/types_test.go
@@ -14,7 +14,11 @@
 
 package tls
 
-import "testing"
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+)
 
 func TestHashAlgorithmString(t *testing.T) {
 	var tests = []struct {
@@ -72,6 +76,46 @@ func TestDigitallySignedString(t *testing.T) {
 	for _, test := range tests {
 		if got := test.ds.String(); got != test.want {
 			t.Errorf("%v.String()=%q; want %q", test.ds, got, test.want)
+		}
+	}
+}
+
+const (
+	ecdsaPublicKey = `
+-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEvuynpVdR+5xSNaVBb//1fqO6Nb/nC+WvRQ4bALzy4G+QbByvO1Qpm2eUzTdDUnsLN5hp3pIXYAmtjvjY1fFZEg==
+-----END PUBLIC KEY-----`
+
+	rsaPublicKey = `
+-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsMB4reLZhs+2ReYX01nZpqLBQ9uhcZvBmzH54RsZDTb5khw+luSXKbLKXxdbQfrsxURbeVdugDNnV897VI43znuiKJ19Y/XS3N5Z7Q97/GOxOxGFObP0DovCAPblxAMaQBb+U9jkVt/4bHcNIOTZl/lXgX+yp58lH5uPfDwav/hVNg7QkAW3BxQZ5wiLTTZUILoTMjax4R24pULlg/Wt/rT4bDj8rxUgYR60MuO93jdBtNGwmzdCYyk4cEmrPEgCueRC6jFafUzlLjvuX89ES9n98LxX+gBANA7RpVPkJd0kfWFHO1JRUEJr++WjU3x4la2Xs4tUNX4QBSJP4XEOXwIDAQAB
+-----END PUBLIC KEY-----`
+
+	dsaPublicKey = `
+-----BEGIN PUBLIC KEY-----
+MIIDRjCCAjkGByqGSM44BAEwggIsAoIBAQDgLI6pXvqpcOY33lzeZrjUBHxphiz0I9VKF9vGpWymNfBptQ75bpQFe16jBjaOGwDImASHTp53XskQJLOXC4bZxoRUHsm8bHQVZHQhYgxn8ZDQX/40zOR1d73y1TXSiULo6rDKVlM+fFcm33tGv+ZOdfaIhW17c5jvDAy6UWqQakasvL+kfiejIDGHjLVFWwX0vLCG+pAomgO6snQHGcPhDO9uxEYPd9on7YTgBrpa2IcXk5jFeY8xOxMnMwoBojRvH97+ivdBR1yW8f+4FAGg5o1eFV5ZqoUAF8GO3BBEwluMGNeT7gMgl4PO8N8xBxJulHd3tLW5qkW0cBPwkbzzAiEAvdYeMPamsFAyd7s07dt78wxXyHGrwVl2AcQBo0QTATkCggEASH9Rp+EjNkL7uCqGJ78P4tjJM+2+xaEhZpJ/kTzq6DtdFhu5Rov6lN5NnZKPSUNYr9Vkmu88ru0iND1N37z0rJpImksXKxCv0AwBkwtqCwf9jjkTrZiGRzP8xf789wK+uG7Uud20ml9QzXKr9Af9WrRx3DtCq44PBaIlhPvpZS9znCZsuUZqYZFW3/oD4EhwPgVLSWeulh1t33ku3mYQwVS8ZTdJGPyFRoD1dcQ4EchR4ce0u0nTXlqErWhfnmb9msF6dFCV0Mx5yrqxkEHbJ/vZgB4zAdOke7XiJsWqIok/7IJpJuVOvkY9NHgBdlq3xU180+pEo2NrGm4pbrGm1wOCAQUAAoIBAAGbucHEfgtcu++OQQjYqneukv4zqcP/PCJTP+GuXen6SH25V2ZlHC88lG6qdZVBPWZidAb9BSoUQpW7BzauKRqH7rKOsIeqvEPCiWBKA781Zi5HAWGhC4INJJx54Q66F54DkGlTRVFkXlGpAIudhfAIG//MyO9TIsLSgRyqjKWVm+/XhWDIT5iMJZZ/IgmbICueaa7go8poHuTTyUDPHPIeL5d9Aru7qD4JtX+UVy6GYKhWx/guv+A7zyJ8d1kMLsmUAro80DLPDoais2I8YPpbu+xTSLLswIYddDdwg3P8mMAGzuWY/ZLumwpRr/fbI+t2Sm9KKGNGkGGIKAg43cs=
+-----END PUBLIC KEY-----`
+)
+
+func TestSignatureAlgorithm(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		keyPEM string
+		want   SignatureAlgorithm
+	}{
+		{name: "ECDSA", keyPEM: ecdsaPublicKey, want: ECDSA},
+		{name: "RSA", keyPEM: rsaPublicKey, want: RSA},
+		{name: "DSA", keyPEM: dsaPublicKey, want: DSA},
+	} {
+		keyDER, _ := pem.Decode([]byte(test.keyPEM))
+		key, err := x509.ParsePKIXPublicKey(keyDER.Bytes)
+		if err != nil {
+			t.Errorf("der: could not parse public key as PKIX (%v)", err)
+			continue
+		}
+
+		if got := SignatureAlgorithmFromPubKey(key); got != test.want {
+			t.Errorf("%v: SignatureAlgorithm() = %v, want %v", test.name, got, test.want)
 		}
 	}
 }

--- a/trillian/ctfe/handlers.go
+++ b/trillian/ctfe/handlers.go
@@ -17,6 +17,7 @@ package ctfe
 import (
 	"bytes"
 	"context"
+	"crypto"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
@@ -41,7 +42,6 @@ import (
 	"google.golang.org/grpc/status"
 
 	ct "github.com/google/certificate-transparency-go"
-	tcrypto "github.com/google/trillian/crypto"
 )
 
 // TODO(drysdale): remove this flag once everything has migrated to ByRange
@@ -230,7 +230,7 @@ type LogContext struct {
 	// rpcClient is the client used to communicate with the trillian backend
 	rpcClient trillian.TrillianLogClient
 	// signer signs objects
-	signer *tcrypto.Signer
+	signer crypto.Signer
 	// rpcDeadline is the deadline that will be set on all backend RPC requests
 	rpcDeadline time.Duration
 
@@ -243,7 +243,7 @@ type LogContext struct {
 }
 
 // NewLogContext creates a new instance of LogContext.
-func NewLogContext(logID int64, prefix string, validationOpts CertValidationOpts, rpcClient trillian.TrillianLogClient, signer *tcrypto.Signer, instanceOpts InstanceOptions, timeSource util.TimeSource) *LogContext {
+func NewLogContext(logID int64, prefix string, validationOpts CertValidationOpts, rpcClient trillian.TrillianLogClient, signer crypto.Signer, instanceOpts InstanceOptions, timeSource util.TimeSource) *LogContext {
 	ctx := &LogContext{
 		logID:          logID,
 		urlPrefix:      prefix,
@@ -886,7 +886,7 @@ func extraDataForChain(chain []*x509.Certificate, isPrecert bool) ([]byte, error
 
 // marshalAndWriteAddChainResponse is used by add-chain and add-pre-chain to create and write
 // the JSON response to the client
-func marshalAndWriteAddChainResponse(sct *ct.SignedCertificateTimestamp, signer *tcrypto.Signer, w http.ResponseWriter) error {
+func marshalAndWriteAddChainResponse(sct *ct.SignedCertificateTimestamp, signer crypto.Signer, w http.ResponseWriter) error {
 	logID, err := GetCTLogID(signer.Public())
 	if err != nil {
 		return fmt.Errorf("failed to marshal logID: %v", err)

--- a/trillian/ctfe/handlers_test.go
+++ b/trillian/ctfe/handlers_test.go
@@ -48,7 +48,6 @@ import (
 
 	ct "github.com/google/certificate-transparency-go"
 	cttestonly "github.com/google/certificate-transparency-go/trillian/ctfe/testonly"
-	tcrypto "github.com/google/trillian/crypto"
 )
 
 // Arbitrary time for use in tests
@@ -110,7 +109,7 @@ type handlerTestInfo struct {
 }
 
 // setupTest creates mock objects and contexts.  Caller should invoke info.mockCtrl.Finish().
-func setupTest(t *testing.T, pemRoots []string, signer *tcrypto.Signer) handlerTestInfo {
+func setupTest(t *testing.T, pemRoots []string, signer crypto.Signer) handlerTestInfo {
 	t.Helper()
 	info := handlerTestInfo{
 		mockCtrl: gomock.NewController(t),
@@ -553,11 +552,11 @@ func TestGetSTH(t *testing.T) {
 	for _, test := range tests {
 		// Run deferred funcs at the end of each iteration.
 		func() {
-			var signer *tcrypto.Signer
+			var signer crypto.Signer
 			if test.signErr != nil {
-				signer = tcrypto.NewSigner(0, testdata.NewSignerWithErr(key, test.signErr), crypto.SHA256)
+				signer = testdata.NewSignerWithErr(key, test.signErr)
 			} else {
-				signer = tcrypto.NewSigner(0, testdata.NewSignerWithFixedSig(key, fakeSignature), crypto.SHA256)
+				signer = testdata.NewSignerWithFixedSig(key, fakeSignature)
 			}
 
 			info := setupTest(t, []string{cttestonly.CACertPEM}, signer)

--- a/trillian/ctfe/instance.go
+++ b/trillian/ctfe/instance.go
@@ -16,7 +16,6 @@ package ctfe
 
 import (
 	"context"
-	"crypto"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -28,7 +27,6 @@ import (
 	"github.com/google/certificate-transparency-go/trillian/util"
 	"github.com/google/certificate-transparency-go/x509"
 	"github.com/google/trillian"
-	tcrypto "github.com/google/trillian/crypto"
 	"github.com/google/trillian/crypto/keys"
 	"github.com/google/trillian/monitoring"
 )
@@ -126,10 +124,6 @@ func SetUpInstance(ctx context.Context, client trillian.TrillianLogClient, cfg *
 	if err != nil {
 		return nil, fmt.Errorf("failed to load private key: %v", err)
 	}
-	signer := &tcrypto.Signer{
-		Hash:   crypto.SHA256,
-		Signer: key,
-	}
 
 	var keyUsages []x509.ExtKeyUsage
 	if len(cfg.ExtKeyUsages) > 0 {
@@ -174,7 +168,7 @@ func SetUpInstance(ctx context.Context, client trillian.TrillianLogClient, cfg *
 		cfg.Prefix,
 		validationOpts,
 		client,
-		signer,
+		key,
 		opts,
 		new(util.SystemTimeSource))
 

--- a/trillian/ctfe/serialize.go
+++ b/trillian/ctfe/serialize.go
@@ -67,9 +67,8 @@ func buildV1SCT(signer crypto.Signer, leaf *ct.MerkleTreeLeaf) (*ct.SignedCertif
 		return nil, fmt.Errorf("failed to serialize SCT data: %v", err)
 	}
 
-	h := sha256.New()
-	h.Write(data)
-	signature, err := signer.Sign(rand.Reader, h.Sum(nil), crypto.SHA256)
+	h := sha256.Sum256(data)
+	signature, err := signer.Sign(rand.Reader, h[:], crypto.SHA256)
 	if err != nil {
 		return nil, fmt.Errorf("failed to sign SCT data: %v", err)
 	}

--- a/trillian/ctfe/serialize.go
+++ b/trillian/ctfe/serialize.go
@@ -15,16 +15,19 @@
 package ctfe
 
 import (
+	"crypto"
+	"crypto/rand"
+	"crypto/sha256"
 	"fmt"
 
-	ct "github.com/google/certificate-transparency-go"
 	"github.com/google/certificate-transparency-go/tls"
-	"github.com/google/trillian/crypto"
+
+	ct "github.com/google/certificate-transparency-go"
 )
 
 // signV1TreeHead signs a tree head for CT. The input STH should have been built from a
 // backend response and already checked for validity.
-func (c *LogContext) signV1TreeHead(signer *crypto.Signer, sth *ct.SignedTreeHead) error {
+func (c *LogContext) signV1TreeHead(signer crypto.Signer, sth *ct.SignedTreeHead) error {
 	sthBytes, err := ct.SerializeSTHSignatureInput(*sth)
 	if err != nil {
 		return err
@@ -34,24 +37,25 @@ func (c *LogContext) signV1TreeHead(signer *crypto.Signer, sth *ct.SignedTreeHea
 		return nil
 	}
 
-	signature, err := signer.Sign(sthBytes)
+	h := sha256.New()
+	h.Write(sthBytes)
+	signature, err := signer.Sign(rand.Reader, h.Sum(nil), crypto.SHA256)
 	if err != nil {
 		return err
 	}
 
 	sth.TreeHeadSignature = ct.DigitallySigned{
 		Algorithm: tls.SignatureAndHashAlgorithm{
-			Hash: tls.SHA256,
-			// This relies on the protobuf enum values matching the TLS-defined values.
-			Signature: tls.SignatureAlgorithm(crypto.SignatureAlgorithm(signer.Public())),
+			Hash:      tls.SHA256,
+			Signature: tls.SignatureAlgorithmFromPubKey(signer.Public()),
 		},
-		Signature: signature.Signature,
+		Signature: signature,
 	}
 	c.setLastSTHSignature(sthBytes, sth.TreeHeadSignature)
 	return nil
 }
 
-func buildV1SCT(signer *crypto.Signer, leaf *ct.MerkleTreeLeaf) (*ct.SignedCertificateTimestamp, error) {
+func buildV1SCT(signer crypto.Signer, leaf *ct.MerkleTreeLeaf) (*ct.SignedCertificateTimestamp, error) {
 	// Serialize SCT signature input to get the bytes that need to be signed
 	sctInput := ct.SignedCertificateTimestamp{
 		SCTVersion: ct.V1,
@@ -63,18 +67,19 @@ func buildV1SCT(signer *crypto.Signer, leaf *ct.MerkleTreeLeaf) (*ct.SignedCerti
 		return nil, fmt.Errorf("failed to serialize SCT data: %v", err)
 	}
 
-	signature, err := signer.Sign(data)
+	h := sha256.New()
+	h.Write(data)
+	signature, err := signer.Sign(rand.Reader, h.Sum(nil), crypto.SHA256)
 	if err != nil {
 		return nil, fmt.Errorf("failed to sign SCT data: %v", err)
 	}
 
 	digitallySigned := ct.DigitallySigned{
 		Algorithm: tls.SignatureAndHashAlgorithm{
-			Hash: tls.SHA256,
-			// This relies on the protobuf enum values matching the TLS-defined values.
-			Signature: tls.SignatureAlgorithm(crypto.SignatureAlgorithm(signer.Public())),
+			Hash:      tls.SHA256,
+			Signature: tls.SignatureAlgorithmFromPubKey(signer.Public()),
 		},
-		Signature: signature.Signature,
+		Signature: signature,
 	}
 
 	logID, err := GetCTLogID(signer.Public())

--- a/trillian/ctfe/serialize_test.go
+++ b/trillian/ctfe/serialize_test.go
@@ -16,7 +16,6 @@ package ctfe
 
 import (
 	"bytes"
-	"crypto"
 	"crypto/sha256"
 	"testing"
 
@@ -29,7 +28,6 @@ import (
 	"github.com/kylelemons/godebug/pretty"
 
 	ct "github.com/google/certificate-transparency-go"
-	tcrypto "github.com/google/trillian/crypto"
 )
 
 func TestBuildV1MerkleTreeLeafForCert(t *testing.T) {
@@ -149,12 +147,11 @@ func TestSignV1SCTForPrecertificate(t *testing.T) {
 }
 
 func TestSignV1TreeHead(t *testing.T) {
-	privKey, err := pem.UnmarshalPrivateKey(testdata.DemoPrivateKey, testdata.DemoPrivateKeyPass)
+	signer, err := pem.UnmarshalPrivateKey(testdata.DemoPrivateKey, testdata.DemoPrivateKeyPass)
 	if err != nil {
 		t.Fatalf("could not create signer: %v", err)
 	}
 	logID := int64(6962)
-	signer := tcrypto.NewSigner(logID, privKey, crypto.SHA256)
 	c := &LogContext{logID: logID, signer: signer}
 
 	sth := ct.SignedTreeHead{
@@ -209,12 +206,11 @@ func TestSignV1TreeHead(t *testing.T) {
 }
 
 func TestSignV1TreeHeadDifferentSigners(t *testing.T) {
-	privKey, err := pem.UnmarshalPrivateKey(testdata.DemoPrivateKey, testdata.DemoPrivateKeyPass)
+	signer1, err := pem.UnmarshalPrivateKey(testdata.DemoPrivateKey, testdata.DemoPrivateKeyPass)
 	if err != nil {
 		t.Fatalf("could not create signer1: %v", err)
 	}
 	logID := int64(6962)
-	signer1 := tcrypto.NewSigner(logID, privKey, crypto.SHA256)
 	c1 := &LogContext{logID: logID, signer: signer1}
 
 	signer2, err := setupSigner(fakeSignature)

--- a/trillian/ctfe/structures_test.go
+++ b/trillian/ctfe/structures_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/kylelemons/godebug/pretty"
 
 	ct "github.com/google/certificate-transparency-go"
-	tcrypto "github.com/google/trillian/crypto"
 )
 
 var (
@@ -84,13 +83,13 @@ func TestSerializeLogEntry(t *testing.T) {
 
 // Creates a fake signer for use in interaction tests.
 // It will always return fakeSig when asked to sign something.
-func setupSigner(fakeSig []byte) (*tcrypto.Signer, error) {
+func setupSigner(fakeSig []byte) (crypto.Signer, error) {
 	key, err := pem.UnmarshalPublicKey(testdata.DemoPublicKey)
 	if err != nil {
 		return nil, err
 	}
 
-	return tcrypto.NewSigner(0, testdata.NewSignerWithFixedSig(key, fakeSig), crypto.SHA256), nil
+	return testdata.NewSignerWithFixedSig(key, fakeSig), nil
 }
 
 // Creates a dummy cert chain


### PR DESCRIPTION
The CTFE was using trillian's "tcrypto" package for basic signing operations and then throwing away the extra fields that the "tcrypto" package produced. 

Using the proper Go crypto libraries directly reduces cross project dependencies and simplifies signing operations. 