### PR TITLE
Factor out Fetcher from Scanner

### DIFF
--- a/ctutil/sctscan/sctscan.go
+++ b/ctutil/sctscan/sctscan.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/google/certificate-transparency-go"
+	ct "github.com/google/certificate-transparency-go"
 	"github.com/google/certificate-transparency-go/client"
 	"github.com/google/certificate-transparency-go/ctutil"
 	"github.com/google/certificate-transparency-go/jsonclient"
@@ -89,12 +89,14 @@ func main() {
 	}
 
 	scanOpts := scanner.ScannerOptions{
-		Matcher:       EmbeddedSCTMatcher{},
-		BatchSize:     *batchSize,
-		NumWorkers:    *numWorkers,
-		ParallelFetch: *parallelFetch,
-		StartIndex:    *startIndex,
-		Quiet:         *quiet,
+		FetcherOptions: scanner.FetcherOptions{
+			BatchSize:     *batchSize,
+			ParallelFetch: *parallelFetch,
+			StartIndex:    *startIndex,
+			Quiet:         *quiet,
+		},
+		Matcher:    EmbeddedSCTMatcher{},
+		NumWorkers: *numWorkers,
 	}
 	s := scanner.NewScanner(logClient, scanOpts)
 

--- a/preload/preloader/preloader.go
+++ b/preload/preloader/preloader.go
@@ -163,13 +163,15 @@ func main() {
 	}
 
 	opts := scanner.ScannerOptions{
-		Matcher:       scanner.MatchAll{},
-		PrecertOnly:   *precertsOnly,
-		BatchSize:     *batchSize,
-		NumWorkers:    *numWorkers,
-		ParallelFetch: *parallelFetch,
-		StartIndex:    *startIndex,
-		Quiet:         *quiet,
+		FetcherOptions: scanner.FetcherOptions{
+			BatchSize:     *batchSize,
+			ParallelFetch: *parallelFetch,
+			StartIndex:    *startIndex,
+			Quiet:         *quiet,
+		},
+		Matcher:     scanner.MatchAll{},
+		PrecertOnly: *precertsOnly,
+		NumWorkers:  *numWorkers,
 	}
 	scanner := scanner.NewScanner(fetchLogClient, opts)
 

--- a/scanner/fetcher.go
+++ b/scanner/fetcher.go
@@ -1,0 +1,191 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scanner
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+
+	ct "github.com/google/certificate-transparency-go"
+	"github.com/google/certificate-transparency-go/client"
+)
+
+// FetcherOptions holds configuration options for the Fetcher.
+type FetcherOptions struct {
+	// Number of entries to request in one batch from the Log.
+	BatchSize int
+
+	// Number of concurrent fetcher workers to run.
+	ParallelFetch int
+
+	// [StartIndex, EndIndex) is a log entry range to fetch. If EndIndex == 0,
+	// then it gets reassigned to sth.TreeSize.
+	StartIndex int64
+	EndIndex   int64
+
+	// Don't print any status messages to stdout.
+	Quiet bool
+}
+
+// DefaultFetcherOptions returns new FetcherOptions with sensible defaults.
+func DefaultFetcherOptions() *FetcherOptions {
+	return &FetcherOptions{
+		BatchSize:     1000,
+		ParallelFetch: 1,
+		StartIndex:    0,
+		EndIndex:      0,
+		Quiet:         false,
+	}
+}
+
+// Fetcher is a tool that fetches entries from a CT Log.
+type Fetcher struct {
+	// Client used to talk to the CT log instance.
+	cli *client.LogClient
+	// Configuration options for this Fetcher instance.
+	opts *FetcherOptions
+
+	// Current STH of the Log this Fetcher sends queries to.
+	sth *ct.SignedTreeHead
+
+	// TODO(pavelkalinnikov): Consider log.Logger instead.
+	Log func(msg string)
+}
+
+// EntryBatch represents a contiguous range of entries of the Log.
+type EntryBatch struct {
+	start   int64          // LeafIndex of the first entry in the range.
+	entries []ct.LeafEntry // Entries of the range.
+}
+
+// fetchRange represents a range of certs to fetch from a CT log.
+type fetchRange struct {
+	start int64 // inclusive
+	end   int64 // inclusive
+}
+
+// NewFetcher creates a Fetcher instance using client to talk to the log,
+// taking configuration options from opts.
+func NewFetcher(cli *client.LogClient, opts *FetcherOptions) *Fetcher {
+	fetcher := &Fetcher{cli: cli, opts: opts}
+	if opts.Quiet {
+		fetcher.Log = func(msg string) {}
+	} else {
+		fetcher.Log = func(msg string) { log.Print(msg) }
+	}
+	return fetcher
+}
+
+// Prepare caches the latest Log's STH in the Fetcher and returns it. It also
+// adjusts the entry range to fit the size of the tree.
+func (f *Fetcher) Prepare(ctx context.Context) (*ct.SignedTreeHead, error) {
+	sth, err := f.cli.GetSTH(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("GetSTH() failed: %v", err)
+	}
+	f.Log(fmt.Sprintf("Got STH with %d certs", sth.TreeSize))
+	if f.opts.EndIndex == 0 || f.opts.EndIndex > int64(sth.TreeSize) {
+		f.opts.EndIndex = int64(sth.TreeSize)
+	}
+	f.sth = sth
+	return sth, nil
+}
+
+// Run performs fetching of the Log. Blocks until scanning is complete or
+// context is cancelled. For each successfully fetched batch, pushes it to the
+// out channel.
+func (f *Fetcher) Run(ctx context.Context, out chan<- EntryBatch) error {
+	f.Log("Starting up Fetcher...\n")
+
+	if f.sth == nil {
+		if _, err := f.Prepare(ctx); err != nil {
+			return err
+		}
+	}
+
+	jobs := f.genJobs(ctx)
+
+	// Run fetcher workers.
+	var wg sync.WaitGroup
+	for w, cnt := 0, f.opts.ParallelFetch; w < cnt; w++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			f.runWorker(ctx, jobs, out)
+			f.Log(fmt.Sprintf("Fetcher worker %d finished", idx))
+		}(w)
+	}
+	wg.Wait()
+
+	return nil
+}
+
+// getJobs returns a channel of fetching jobs, each job is a Log entry range.
+// Can be stopped using ctx.
+func (f *Fetcher) genJobs(ctx context.Context) <-chan fetchRange {
+	start, end := f.opts.StartIndex, f.opts.EndIndex
+	batch := int64(f.opts.BatchSize)
+
+	jobs := make(chan fetchRange)
+	go func() {
+		defer close(jobs)
+		for start < end {
+			batchEnd := min(start+batch, end)
+			next := fetchRange{start, batchEnd - 1}
+			select {
+			case <-ctx.Done():
+				f.Log(fmt.Sprintf("genJobs cancelled: %v", ctx.Err()))
+				return
+			case jobs <- next:
+			}
+			start = batchEnd
+		}
+	}()
+	return jobs
+}
+
+// Worker function for fetcher jobs.
+// Accepts cert ranges to fetch over the jobs channel, and if the fetch is
+// successful sends the []entryInfo slice to the batches channel. Will retry
+// failed attempts to retrieve ranges indefinitely.
+func (f *Fetcher) runWorker(ctx context.Context, jobs <-chan fetchRange, out chan<- EntryBatch) {
+	for r := range jobs {
+		// Logs MAY return fewer than the number of leaves requested. Only complete
+		// if we actually got all the leaves we were expecting.
+		for r.start <= r.end {
+			// Fetcher.Run() can be cancelled while we are looping over this job.
+			if err := ctx.Err(); err != nil {
+				f.Log(fmt.Sprintf("Context closed: %v", err))
+				return
+			}
+			resp, err := f.cli.GetRawEntries(ctx, r.start, r.end)
+			if err != nil {
+				f.Log(fmt.Sprintf("GetRawEntries() failed: %v", err))
+				continue
+			}
+			out <- EntryBatch{start: r.start, entries: resp.Entries}
+			r.start += int64(len(resp.Entries))
+		}
+	}
+}
+
+func min(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/scanner/scanlog/scanlog.go
+++ b/scanner/scanlog/scanlog.go
@@ -206,13 +206,15 @@ func main() {
 	}
 
 	opts := scanner.ScannerOptions{
-		Matcher:       matcher,
-		BatchSize:     *batchSize,
-		NumWorkers:    *numWorkers,
-		ParallelFetch: *parallelFetch,
-		StartIndex:    *startIndex,
-		EndIndex:      *endIndex,
-		Quiet:         *quiet,
+		FetcherOptions: scanner.FetcherOptions{
+			BatchSize:     *batchSize,
+			ParallelFetch: *parallelFetch,
+			StartIndex:    *startIndex,
+			EndIndex:      *endIndex,
+			Quiet:         *quiet,
+		},
+		Matcher:    matcher,
+		NumWorkers: *numWorkers,
 	}
 	scanner := scanner.NewScanner(logClient, opts)
 

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -279,12 +279,12 @@ func (s *Scanner) Scan(ctx context.Context, foundCert func(*ct.LogEntry), foundP
 	}
 
 	flatten := func(b EntryBatch) {
-		for i, e := range b.entries {
-			entries <- entryInfo{index: b.start + int64(i), entry: e}
+		for i, e := range b.Entries {
+			entries <- entryInfo{index: b.Start + int64(i), entry: e}
 		}
 	}
 	err = s.fetcher.Run(ctx, flatten)
-	close(entries) // Causes matcher workers terminate.
+	close(entries) // Causes matcher workers to terminate.
 	wg.Wait()      // Wait until they terminate.
 	if err != nil {
 		return err

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -196,11 +196,13 @@ func TestScannerEndToEnd(t *testing.T) {
 		t.Fatal(err)
 	}
 	opts := ScannerOptions{
-		Matcher:       &MatchSubjectRegex{regexp.MustCompile(".*\\.google\\.com"), nil},
-		BatchSize:     10,
-		NumWorkers:    1,
-		ParallelFetch: 1,
-		StartIndex:    0,
+		FetcherOptions: FetcherOptions{
+			BatchSize:     10,
+			ParallelFetch: 1,
+			StartIndex:    0,
+		},
+		Matcher:    &MatchSubjectRegex{regexp.MustCompile(".*\\.google\\.com"), nil},
+		NumWorkers: 1,
 	}
 	scanner := NewScanner(logClient, opts)
 


### PR DESCRIPTION
This PR factors out `Fetcher` which is responsible solely for loading entries from a CT log. `Scanner` now uses `Fetcher.Run` as a subroutine.
This change is a prerequisite for other uses of entry fetching, e.g. tracking a log in CT Mirror.