### PR TITLE
Fix preloader pre-cert submissions

### DIFF
--- a/preload/preloader/preloader.go
+++ b/preload/preloader/preloader.go
@@ -114,10 +114,10 @@ func precertSubmitter(ctx context.Context, addedCerts chan<- *preload.AddedCert,
 		sct, err := logClient.AddPreChain(ctx, chain)
 		if err != nil {
 			log.Printf("failed to add pre-chain with CN %s: %v", c.Precert.TBSCertificate.Subject.CommonName, err)
-			recordFailure(addedCerts, c.Chain[0], err)
+			recordFailure(addedCerts, chain[0], err)
 			continue
 		}
-		recordSct(addedCerts, c.Chain[0], sct)
+		recordSct(addedCerts, chain[0], sct)
 		if !*quiet {
 			log.Printf("Added precert chain for CN '%s', SCT: %s\n", c.Precert.TBSCertificate.Subject.CommonName, sct)
 		}

--- a/preload/preloader/preloader.go
+++ b/preload/preloader/preloader.go
@@ -108,7 +108,10 @@ func certSubmitter(ctx context.Context, addedCerts chan<- *preload.AddedCert, lo
 
 func precertSubmitter(ctx context.Context, addedCerts chan<- *preload.AddedCert, logClient client.AddLogClient, precerts <-chan *ct.LogEntry) {
 	for c := range precerts {
-		sct, err := logClient.AddPreChain(ctx, c.Chain)
+		chain := make([]ct.ASN1Cert, len(c.Chain)+1)
+		chain[0] = c.Precert.Submitted
+		copy(chain[1:], c.Chain)
+		sct, err := logClient.AddPreChain(ctx, chain)
 		if err != nil {
 			log.Printf("failed to add pre-chain with CN %s: %v", c.Precert.TBSCertificate.Subject.CommonName, err)
 			recordFailure(addedCerts, c.Chain[0], err)


### PR DESCRIPTION
Previously `preloader` would attempt to submit partial chains missing the actual precert.