### PR TITLE
*client: add BaseURI() method for convenience

### DIFF
--- a/client/ctclient/ctclient.go
+++ b/client/ctclient/ctclient.go
@@ -69,7 +69,7 @@ func getSTH(ctx context.Context, logClient client.CheckLogClient) {
 	}
 	// Display the STH
 	when := ct.TimestampToTime(sth.Timestamp)
-	fmt.Printf("%v (timestamp %d): Got STH for %v log (size=%d) at %v, hash %x\n", when, sth.Timestamp, sth.Version, sth.TreeSize, *logURI, sth.SHA256RootHash)
+	fmt.Printf("%v (timestamp %d): Got STH for %v log (size=%d) at %v, hash %x\n", when, sth.Timestamp, sth.Version, sth.TreeSize, logClient.BaseURI(), sth.SHA256RootHash)
 	fmt.Printf("%v\n", signatureToString(&sth.TreeHeadSignature))
 }
 
@@ -128,7 +128,7 @@ func addChain(ctx context.Context, logClient *client.LogClient) {
 
 	// Display the SCT
 	when := ct.TimestampToTime(sct.Timestamp)
-	fmt.Printf("Uploaded chain of %d certs to %v log at %v, timestamp: %d (%v)\n", len(chain), sct.SCTVersion, *logURI, sct.Timestamp, when)
+	fmt.Printf("Uploaded chain of %d certs to %v log at %v, timestamp: %d (%v)\n", len(chain), sct.SCTVersion, logClient.BaseURI(), sct.Timestamp, when)
 	fmt.Printf("LogID: %x\n", sct.LogID.KeyID[:])
 	fmt.Printf("LeafHash: %x\n", leafHash)
 	fmt.Printf("Signature: %v\n", signatureToString(&sct.Signature))

--- a/client/logclient.go
+++ b/client/logclient.go
@@ -37,6 +37,7 @@ type LogClient struct {
 
 // CheckLogClient is an interface that allows (just) checking of various log contents.
 type CheckLogClient interface {
+	BaseURI() string
 	GetSTH(context.Context) (*ct.SignedTreeHead, error)
 	GetSTHConsistency(ctx context.Context, first, second uint64) ([][]byte, error)
 	GetProofByHash(ctx context.Context, hash []byte, treeSize uint64) (*ct.GetProofByHashResponse, error)

--- a/dnsclient/dnsclient.go
+++ b/dnsclient/dnsclient.go
@@ -80,6 +80,11 @@ var (
 	sthTXT = regexp.MustCompile(`^(\d+)\.(\d+)\.(` + base64RE + `)\.(` + base64RE + `)`)
 )
 
+// BaseURI returns a base dns: URI (cf. RFC 4501) that DNS queries will be built on.
+func (c *DNSClient) BaseURI() string {
+	return fmt.Sprintf("dns:%s", c.base)
+}
+
 // GetSTH retrieves the current STH from the log.
 func (c *DNSClient) GetSTH(ctx context.Context) (*ct.SignedTreeHead, error) {
 	name := "sth." + c.base

--- a/jsonclient/client.go
+++ b/jsonclient/client.go
@@ -139,6 +139,11 @@ func New(uri string, hc *http.Client, opts Options) (*JSONClient, error) {
 	}, nil
 }
 
+// BaseURI returns the base URI that the JSONClient makes queries to.
+func (c *JSONClient) BaseURI() string {
+	return c.uri
+}
+
 // GetAndParse makes a HTTP GET call to the given path, and attempta to parse
 // the response as a JSON representation of the rsp structure.  Returns the
 // http.Response, the body of the response, and an error.  Note that the


### PR DESCRIPTION
Add BaseURI() to the CheckLogClient interface, and to its two
implementations (LogClient and DNSClient), so the base URI can
be retrieved after construction.