### PR TITLE
Add CORS handler to ct_server

### DIFF
--- a/trillian/ctfe/ct_server/main.go
+++ b/trillian/ctfe/ct_server/main.go
@@ -170,7 +170,13 @@ func main() {
 	}
 
 	// Return a 200 on the root, for GCE default health checking :/
-	corsMux.HandleFunc("/", func(resp http.ResponseWriter, req *http.Request) { resp.WriteHeader(http.StatusOK) })
+	corsMux.HandleFunc("/", func(resp http.ResponseWriter, req *http.Request) {
+		if req.URL.Path == "/" {
+			resp.WriteHeader(http.StatusOK)
+		} else {
+			resp.WriteHeader(http.StatusNotFound)
+		}
+	})
 
 	if metricsAt != *httpEndpoint {
 		// Run a separate handler for metrics.


### PR DESCRIPTION
This [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) handler will allow cross-origin requests. This is safe because CT logs are public and unauthenticated so cross-site scripting attacks are not a concern. It will enable Javascript clients
running in browsers to access CT logs.