### PR TITLE
Use https: URLs for logs throughout

### DIFF
--- a/client/ctclient/ctclient.go
+++ b/client/ctclient/ctclient.go
@@ -45,7 +45,7 @@ var (
 	useDNS    = flag.Bool("dns", false, "Use DNS access points for inclusion checking (requires --log_name or --dns_base)")
 	logName   = flag.String("log_name", "", "Name of log to retrieve information from --log_list for")
 	logList   = flag.String("log_list", loglist.LogListURL, "Location of master log list (URL or filename)")
-	logURI    = flag.String("log_uri", "http://ct.googleapis.com/rocketeer", "CT log base URI")
+	logURI    = flag.String("log_uri", "https://ct.googleapis.com/rocketeer", "CT log base URI")
 	logMMD    = flag.Duration("log_mmd", 24*time.Hour, "Log's maximum merge delay")
 	pubKey    = flag.String("pub_key", "", "Name of file containing log's public key")
 	certChain = flag.String("cert_chain", "", "Name of file containing certificate chain as concatenated PEM files")
@@ -361,7 +361,6 @@ func main() {
 			}
 			log.Fatalf("Multiple logs with name like %q found in loglist: %s", *logName, strings.Join(logNames, ","))
 		}
-		// TODO(drysdale): what if a log is http:// only?
 		uri = "https://" + logs[0].URL
 		if *useDNS {
 			dns = logs[0].DNSAPIEndpoint

--- a/client/logclient.go
+++ b/client/logclient.go
@@ -45,7 +45,7 @@ type CheckLogClient interface {
 
 // New constructs a new LogClient instance.
 // |uri| is the base URI of the CT log instance to interact with, e.g.
-// http://ct.googleapis.com/pilot
+// https://ct.googleapis.com/pilot
 // |hc| is the underlying client to be used for HTTP requests to the CT log.
 // |opts| can be used to provide a custom logger interface and a public key
 // for signature verification.

--- a/ctutil/sctscan/sctscan.go
+++ b/ctutil/sctscan/sctscan.go
@@ -35,7 +35,7 @@ import (
 )
 
 var (
-	logURI        = flag.String("log_uri", "http://ct.googleapis.com/pilot", "CT log base URI")
+	logURI        = flag.String("log_uri", "https://ct.googleapis.com/pilot", "CT log base URI")
 	logList       = flag.String("log_list", loglist.LogListURL, "Location of master CT log list (URL or filename)")
 	useDNS        = flag.Bool("dns", true, "Use DNS access points for inclusion checking")
 	inclusion     = flag.Bool("inclusion", false, "Whether to do inclusion checking")

--- a/jsonclient/client.go
+++ b/jsonclient/client.go
@@ -53,7 +53,7 @@ type backoffer interface {
 // JSONClient provides common functionality for interacting with a JSON server
 // that uses cryptographic signatures.
 type JSONClient struct {
-	uri        string                // the base URI of the server. e.g. http://ct.googleapis/pilot
+	uri        string                // the base URI of the server. e.g. https://ct.googleapis/pilot
 	httpClient *http.Client          // used to interact with the server via HTTP
 	Verifier   *ct.SignatureVerifier // nil for no verification (e.g. no public key available)
 	logger     Logger                // interface to use for logging warnings and errors

--- a/preload/preloader/preloader.go
+++ b/preload/preloader/preloader.go
@@ -35,8 +35,8 @@ import (
 )
 
 var (
-	sourceLogURI         = flag.String("source_log_uri", "http://ct.googleapis.com/aviator", "CT log base URI to fetch entries from")
-	targetLogURI         = flag.String("target_log_uri", "http://example.com/ct", "CT log base URI to add entries to")
+	sourceLogURI         = flag.String("source_log_uri", "https://ct.googleapis.com/aviator", "CT log base URI to fetch entries from")
+	targetLogURI         = flag.String("target_log_uri", "https://example.com/ct", "CT log base URI to add entries to")
 	targetTemporalLogCfg = flag.String("target_temporal_log_cfg", "", "File holding temporal log configuration")
 	batchSize            = flag.Int("batch_size", 1000, "Max number of entries to request at per call to get-entries")
 	numWorkers           = flag.Int("num_workers", 2, "Number of concurrent matchers")

--- a/scanner/scanlog/scanlog.go
+++ b/scanner/scanlog/scanlog.go
@@ -39,7 +39,7 @@ const (
 )
 
 var (
-	logURI = flag.String("log_uri", "http://ct.googleapis.com/aviator", "CT log base URI")
+	logURI = flag.String("log_uri", "https://ct.googleapis.com/aviator", "CT log base URI")
 
 	matchSubjectRegex = flag.String("match_subject_regex", ".*", "Regex to match CN/SAN")
 	matchIssuerRegex  = flag.String("match_issuer_regex", "", "Regex to match in issuer CN")

--- a/trillian/migrillian/main.go
+++ b/trillian/migrillian/main.go
@@ -32,7 +32,7 @@ import (
 )
 
 var (
-	ctLogURI    = flag.String("ct_log_uri", "http://ct.googleapis.com/aviator", "CT log base URI to fetch entries from")
+	ctLogURI    = flag.String("ct_log_uri", "https://ct.googleapis.com/aviator", "CT log base URI to fetch entries from")
 	trillianURI = flag.String("trillian_uri", "localhost:8090", "Trillian log server URI to add entries to")
 	logID       = flag.Int64("log_id", 0, "Trillian log tree ID to add entries to")
 


### PR DESCRIPTION
As per RFC6962 section 4:
  "Messages are sent as HTTPS GET or POST requests."
remove misleading http:// example URLs