### PR TITLE
[Migrillian] Verify Trillian tree before fetching

### DIFF
--- a/trillian/ctfe/handlers.go
+++ b/trillian/ctfe/handlers.go
@@ -723,10 +723,7 @@ func getRoots(ctx context.Context, c *LogContext, w http.ResponseWriter, r *http
 	return http.StatusOK, nil
 }
 
-// See RFC 6962 Section 4.8. This is mostly used for debug purposes rather than
-// by normal CT clients.
-// TODO(pavelkalinnikov): This is actually very useful for computing hash of a
-// log prefix.
+// See RFC 6962 Section 4.8.
 func getEntryAndProof(ctx context.Context, c *LogContext, w http.ResponseWriter, r *http.Request) (int, error) {
 	// Ensure both numeric params are present and look reasonable.
 	leafIndex, treeSize, err := parseGetEntryAndProofParams(r)

--- a/trillian/ctfe/handlers.go
+++ b/trillian/ctfe/handlers.go
@@ -723,8 +723,10 @@ func getRoots(ctx context.Context, c *LogContext, w http.ResponseWriter, r *http
 	return http.StatusOK, nil
 }
 
-// See RFC 6962 Section 4.8. This is mostly used for debug purposes rather than by normal
-// CT clients.
+// See RFC 6962 Section 4.8. This is mostly used for debug purposes rather than
+// by normal CT clients.
+// TODO(pavelkalinnikov): This is actually very useful for computing hash of a
+// log prefix.
 func getEntryAndProof(ctx context.Context, c *LogContext, w http.ResponseWriter, r *http.Request) (int, error) {
 	// Ensure both numeric params are present and look reasonable.
 	leafIndex, treeSize, err := parseGetEntryAndProofParams(r)

--- a/trillian/migrillian/core/controller.go
+++ b/trillian/migrillian/core/controller.go
@@ -71,8 +71,8 @@ func (c *Controller) Run(ctx context.Context) error {
 		// TODO(pavelkalinnikov): Restore fetching state from storage in a better
 		// way than "take the current tree size".
 		c.opts.StartIndex, c.opts.EndIndex = int64(root.TreeSize), 0
-		glog.Warningf("Migrating tree %d continuously: updated entry range to [%d, %d)",
-			c.trClient.tree.TreeId, c.opts.StartIndex, c.opts.EndIndex)
+		glog.Warningf("Tree %d: updated entry range to [%d, INF)",
+			c.trClient.tree.TreeId, c.opts.StartIndex)
 	}
 
 	fetcher := scanner.NewFetcher(c.ctClient, &c.opts.FetcherOptions)

--- a/trillian/migrillian/core/controller.go
+++ b/trillian/migrillian/core/controller.go
@@ -16,15 +16,18 @@
 package core
 
 import (
+	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"sync"
 
 	"github.com/golang/glog"
+	ct "github.com/google/certificate-transparency-go"
 	"github.com/google/certificate-transparency-go/client"
 	"github.com/google/certificate-transparency-go/scanner"
-	"github.com/google/trillian"
+	"github.com/google/trillian/merkle"
+	_ "github.com/google/trillian/merkle/rfc6962" // Register hasher.
+	"github.com/google/trillian/types"
 )
 
 // Options holds configuration for a Controller.
@@ -43,27 +46,52 @@ type Options struct {
 // - Store CT STHs in Trillian or make this tool stateful on its own.
 // - Make fetching stateful to reduce master resigning aftermath.
 type Controller struct {
-	opts    Options
-	batches chan scanner.EntryBatch
+	opts     Options
+	batches  chan scanner.EntryBatch
+	ctClient *client.LogClient
+	trClient *TrillianTreeClient
 }
 
 // NewController creates a Controller configured by the passed in options.
-func NewController(opts Options) *Controller {
+func NewController(opts Options, ctClient *client.LogClient, trClient *TrillianTreeClient) *Controller {
 	bufferSize := opts.Submitters * opts.BatchesPerSubmitter
 	batches := make(chan scanner.EntryBatch, bufferSize)
-	return &Controller{opts, batches}
+	return &Controller{opts: opts, batches: batches, ctClient: ctClient, trClient: trClient}
 }
 
 // Run transfers CT log entries obtained via the CT log client to a Trillian
 // log via the other client. If Options.Continuous is true then the migration
 // process runs continuously trying to keep up with the target CT log.
-func (c *Controller) Run(ctx context.Context, ctClient *client.LogClient, trClient *TrillianTreeClient) error {
+func (c *Controller) Run(ctx context.Context) error {
+	root, err := c.trClient.getVerifiedRoot(ctx)
+	if err != nil {
+		return err
+	}
+	if c.opts.Continuous { // Ignore range parameters in Continuous mode.
+		// TODO(pavelkalinnikov): Restore fetching state from storage in a better
+		// way than "take the current tree size".
+		c.opts.StartIndex, c.opts.EndIndex = int64(root.TreeSize), 0
+		glog.Warningf("Migrating tree %d continuously: updated entry range to [%d, %d)",
+			c.trClient.tree.TreeId, c.opts.StartIndex, c.opts.EndIndex)
+	}
+
+	fetcher := scanner.NewFetcher(c.ctClient, &c.opts.FetcherOptions)
+	sth, err := fetcher.Prepare(ctx)
+	// TODO(pavelkalinnikov): Verify STH (should happen behind the scenes if
+	// using the PublicKey option in LogClient).
+	if err != nil {
+		return err
+	}
+	if err := c.verifyConsistency(ctx, root, sth); err != nil {
+		return err
+	}
+
 	var wg sync.WaitGroup
 	for w, cnt := 0, c.opts.Submitters; w < cnt; w++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			c.runSubmitter(ctx, trClient)
+			c.runSubmitter(ctx)
 		}()
 	}
 	defer func() {
@@ -74,50 +102,51 @@ func (c *Controller) Run(ctx context.Context, ctClient *client.LogClient, trClie
 	handler := func(b scanner.EntryBatch) {
 		c.batches <- b
 	}
-	fetcher := scanner.NewFetcher(ctClient, &c.opts.FetcherOptions)
 	return fetcher.Run(ctx, handler)
+}
+
+// verifyConsistency checks that the provided verified Trillian root is
+// consistent with the CT log's STH.
+func (c *Controller) verifyConsistency(ctx context.Context, root *types.LogRootV1, sth *ct.SignedTreeHead) error {
+	h := c.trClient.verif.Hasher
+	if root.TreeSize == 0 {
+		if bytes.Equal(root.RootHash, h.EmptyRoot()) {
+			return nil
+		}
+		return errors.New("invalid empty tree")
+	}
+
+	resp, err := c.ctClient.GetEntryAndProof(ctx, root.TreeSize-1, sth.TreeSize)
+	if err != nil {
+		return err
+	}
+	leafHash, err := h.HashLeaf(resp.LeafInput)
+	if err != nil {
+		return err
+	}
+
+	hash, err := merkle.NewLogVerifier(h).VerifiedPrefixHashFromInclusionProof(
+		int64(root.TreeSize), int64(sth.TreeSize),
+		resp.AuditPath, sth.SHA256RootHash[:], leafHash)
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(hash, root.RootHash) {
+		return errors.New("inconsistent root")
+	}
+	return nil
 }
 
 // runSubmitter obtaines CT log entry batches from the controller's channel and
 // submits them through Trillian client. Returns when the channel is closed.
-func (c *Controller) runSubmitter(ctx context.Context, tr *TrillianTreeClient) {
+func (c *Controller) runSubmitter(ctx context.Context) {
 	for b := range c.batches {
 		end := b.Start + int64(len(b.Entries))
 		// TODO(pavelkalinnikov): Retry with backoff on errors.
-		if err := tr.addSequencedLeaves(ctx, &b); err != nil {
+		if err := c.trClient.addSequencedLeaves(ctx, &b); err != nil {
 			glog.Errorf("Failed to add batch [%d, %d): %v\n", b.Start, end, err)
 		} else {
 			glog.Infof("Added batch [%d, %d)\n", b.Start, end)
 		}
 	}
-}
-
-// TrillianTreeClient is a means of communicating with a Trillian log tree.
-type TrillianTreeClient struct {
-	Client    trillian.TrillianLogClient
-	LogID     int64
-	LogPrefix string
-}
-
-// addSequencedLeaves converts a batch of CT log entries into Trillian log
-// leaves and submits them to Trillian via AddSequencedLeaves API.
-func (c *TrillianTreeClient) addSequencedLeaves(ctx context.Context, b *scanner.EntryBatch) error {
-	// TODO(pavelkalinnikov): Verify range inclusion against the remote STH.
-	leaves := make([]*trillian.LogLeaf, len(b.Entries))
-	for i, e := range b.Entries {
-		var err error
-		if leaves[i], err = buildLogLeaf(c.LogPrefix, b.Start+int64(i), &e); err != nil {
-			return err
-		}
-	}
-
-	req := trillian.AddSequencedLeavesRequest{LogId: c.LogID, Leaves: leaves}
-	rsp, err := c.Client.AddSequencedLeaves(ctx, &req)
-	if err != nil {
-		return fmt.Errorf("AddSequencedLeaves(): %v", err)
-	} else if rsp == nil {
-		return errors.New("missing AddSequencedLeaves response")
-	}
-	// TODO(pavelkalinnikov): Check rsp.Results statuses.
-	return nil
 }

--- a/trillian/migrillian/core/trillian.go
+++ b/trillian/migrillian/core/trillian.go
@@ -1,0 +1,95 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/certificate-transparency-go/scanner"
+	"github.com/google/trillian"
+	"github.com/google/trillian/client"
+	"github.com/google/trillian/crypto"
+	"github.com/google/trillian/types"
+)
+
+// TrillianTreeClient is a means of communicating with a Trillian pre-ordered
+// log tree.
+type TrillianTreeClient struct {
+	cli    trillian.TrillianLogClient
+	verif  *client.LogVerifier
+	tree   *trillian.Tree
+	prefix string // TODO(pavelkalinnikov): Get rid of this.
+}
+
+// NewTrillianTreeClient creates and initializes a pre-ordered log client.
+func NewTrillianTreeClient(ctx context.Context,
+	admin trillian.TrillianAdminClient, log trillian.TrillianLogClient,
+	treeID int64, prefix string,
+) (*TrillianTreeClient, error) {
+	gt := trillian.GetTreeRequest{TreeId: treeID}
+	tree, err := admin.GetTree(ctx, &gt)
+	if err != nil {
+		return nil, err
+	} else if tree == nil {
+		return nil, errors.New("missing GetTree response")
+	}
+	if got, want := tree.TreeType, trillian.TreeType_PREORDERED_LOG; got != want {
+		return nil, fmt.Errorf("tree %d is %v, want %v", treeID, got, want)
+	}
+
+	v, err := client.NewLogVerifierFromTree(tree)
+	if err != nil {
+		return nil, err
+	}
+	return &TrillianTreeClient{cli: log, verif: v, tree: tree, prefix: prefix}, nil
+}
+
+// getVerifiedRoot returns the current root of the Trillian tree. Verifies the
+// log's signature.
+func (c *TrillianTreeClient) getVerifiedRoot(ctx context.Context) (*types.LogRootV1, error) {
+	req := trillian.GetLatestSignedLogRootRequest{LogId: c.tree.TreeId}
+	rsp, err := c.cli.GetLatestSignedLogRoot(ctx, &req)
+	if err != nil {
+		return nil, err
+	} else if rsp == nil || rsp.SignedLogRoot == nil {
+		return nil, errors.New("missing SignedLogRoot")
+	}
+	return crypto.VerifySignedLogRoot(c.verif.PubKey, c.verif.SigHash, rsp.SignedLogRoot)
+}
+
+// addSequencedLeaves converts a batch of CT log entries into Trillian log
+// leaves and submits them to Trillian via AddSequencedLeaves API.
+func (c *TrillianTreeClient) addSequencedLeaves(ctx context.Context, b *scanner.EntryBatch) error {
+	// TODO(pavelkalinnikov): Verify range inclusion against the remote STH.
+	leaves := make([]*trillian.LogLeaf, len(b.Entries))
+	for i, e := range b.Entries {
+		var err error
+		if leaves[i], err = buildLogLeaf(c.prefix, b.Start+int64(i), &e); err != nil {
+			return err
+		}
+	}
+
+	req := trillian.AddSequencedLeavesRequest{LogId: c.tree.TreeId, Leaves: leaves}
+	rsp, err := c.cli.AddSequencedLeaves(ctx, &req)
+	if err != nil {
+		return fmt.Errorf("AddSequencedLeaves(): %v", err)
+	} else if rsp == nil {
+		return errors.New("missing AddSequencedLeaves response")
+	}
+	// TODO(pavelkalinnikov): Check rsp.Results statuses.
+	return nil
+}


### PR DESCRIPTION
This PR makes Migrillian's `Controller` query Trillian tree state before putting any entries to it:
- Makes sure the `Tree` is a `PREORDERED_LOG`.
- Makes sure the tree head is correctly signed.
- Makes sure the tree head is consistent with the CT log's STH.
- Resets the `Fetcher` state so that it doesn't fetch entries already stored in Trillian.

The last two items are useful when `Controller` is run on a log which already has some entries, e.g. when a leader for the tree has been re-elected, or Migrillian was restarted after a fault.

Additionally, this PR moves Trillian-specific code to a separate file, places some TODOs and slightly restructures `main.go`.