### PR TITLE
Add explicit quota support to CTFE

### DIFF
--- a/trillian/ctfe/cert_quota.go
+++ b/trillian/ctfe/cert_quota.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package ctfe
 
 import (

--- a/trillian/ctfe/cert_quota.go
+++ b/trillian/ctfe/cert_quota.go
@@ -1,0 +1,39 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package ctfe
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/google/certificate-transparency-go/x509"
+)
+
+// CertificateQuotaUserPrefix is prepended to all User quota ids association
+// with intermediate certificates.
+const CertificateQuotaUserPrefix = "@intermediate"
+
+// QuotaUserForCert returns a User quota id string for the passed in
+// certificate.
+// This is intended to be used for quota limiting by intermediate certificates,
+// but the function does not enforce anything about the passed in cert.
+//
+// Format returned is:
+//   "CertificateQuotaUserPrefix Subject SHA256_hex(SubjectPublicKeyInfo[0:5])"
+// See tests for examples.
+func QuotaUserForCert(c *x509.Certificate) string {
+	spkiHash := sha256.Sum256(c.RawSubjectPublicKeyInfo)
+	return fmt.Sprintf("%s %s %s", CertificateQuotaUserPrefix, c.Subject.String(), hex.EncodeToString(spkiHash[0:5]))
+}

--- a/trillian/ctfe/cert_quota.go
+++ b/trillian/ctfe/cert_quota.go
@@ -32,7 +32,7 @@ const CertificateQuotaUserPrefix = "@intermediate"
 // but the function does not enforce anything about the passed in cert.
 //
 // Format returned is:
-//   "CertificateQuotaUserPrefix Subject SHA256_hex(SubjectPublicKeyInfo[0:5])"
+//   "CertificateQuotaUserPrefix Subject hex(SHA256(SubjectPublicKeyInfo)[0:5])"
 // See tests for examples.
 func QuotaUserForCert(c *x509.Certificate) string {
 	spkiHash := sha256.Sum256(c.RawSubjectPublicKeyInfo)

--- a/trillian/ctfe/cert_quota_test.go
+++ b/trillian/ctfe/cert_quota_test.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package ctfe
 
 import (

--- a/trillian/ctfe/cert_quota_test.go
+++ b/trillian/ctfe/cert_quota_test.go
@@ -48,8 +48,10 @@ func TestQuotaUserForCert(t *testing.T) {
 			want: "@intermediate CN=FakeIntermediateAuthority,OU=Eng,O=Google,L=London,ST=London,C=GB 6e62e56f67",
 		},
 	} {
-		if got := QuotaUserForCert(test.cert); got != test.want {
-			t.Errorf("%s: got %q, want %q", test.desc, got, test.want)
-		}
+		t.Run(test.desc, func(t *testing.T) {
+			if got := QuotaUserForCert(test.cert); got != test.want {
+				t.Fatalf("QuotaUserForCert() = %q, want %q", got, test.want)
+			}
+		})
 	}
 }

--- a/trillian/ctfe/cert_quota_test.go
+++ b/trillian/ctfe/cert_quota_test.go
@@ -1,0 +1,54 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package ctfe
+
+import (
+	"testing"
+
+	"github.com/google/certificate-transparency-go/trillian/ctfe/testonly"
+	"github.com/google/certificate-transparency-go/x509"
+	"github.com/google/certificate-transparency-go/x509util"
+)
+
+func mustDePEM(t *testing.T, pem string) *x509.Certificate {
+	t.Helper()
+	c, err := x509util.CertificateFromPEM([]byte(pem))
+	if err != nil {
+		t.Fatalf("Failed to parse PEM: %v", err)
+	}
+	return c
+}
+
+func TestQuotaUserForCert(t *testing.T) {
+	for _, test := range []struct {
+		desc string
+		cert *x509.Certificate
+		want string
+	}{
+		{
+			desc: "cacert",
+			cert: mustDePEM(t, testonly.CACertPEM),
+			want: "@intermediate O=Certificate Transparency CA,L=Erw Wen,ST=Wales,C=GB 02adddca08",
+		},
+		{
+			desc: "intermediate",
+			cert: mustDePEM(t, testonly.FakeIntermediateCertPEM),
+			want: "@intermediate CN=FakeIntermediateAuthority,OU=Eng,O=Google,L=London,ST=London,C=GB 6e62e56f67",
+		},
+	} {
+		if got := QuotaUserForCert(test.cert); got != test.want {
+			t.Errorf("%s: got %q, want %q", test.desc, got, test.want)
+		}
+	}
+}

--- a/trillian/ctfe/ct_server/main.go
+++ b/trillian/ctfe/ct_server/main.go
@@ -201,7 +201,7 @@ func main() {
 				glog.Infof("start internal get-sth operations on log %v (%d)", c.Prefix, c.LogId)
 				for t := range ticker.C {
 					glog.V(1).Infof("tick at %v: force internal get-sth for log %v (%d)", t, c.Prefix, c.LogId)
-					if _, err := ctfe.GetTreeHead(ctx, clientMap[c.LogBackendName], c.LogId, c.Prefix); err != nil {
+					if _, err := ctfe.GetTreeHead(ctx, clientMap[c.LogBackendName], c.LogId, c.Prefix, nil /*quota user*/); err != nil {
 						glog.Warningf("failed to retrieve tree head for log %v (%d): %v", c.Prefix, c.LogId, err)
 					}
 				}

--- a/trillian/ctfe/ct_server/main.go
+++ b/trillian/ctfe/ct_server/main.go
@@ -63,7 +63,7 @@ var (
 	tracingProjectID   = flag.String("tracing_project_id", "", "project ID to pass to stackdriver. Can be empty for GCP, consult docs for other platforms.")
 	tracingPercent     = flag.Int("tracing_percent", 0, "Percent of requests to be traced. Zero is a special case to use the DefaultSampler")
 	quotaRemote        = flag.Bool("quota_remote", true, "Enable requesting of quota for IP address sending incoming requests")
-	quotaIntermediate  = flag.Bool("quota_intermediate", true, "Enable requestion of quota for intermediate certificates in sumbmitted chains")
+	quotaIntermediate  = flag.Bool("quota_intermediate", true, "Enable requesting of quota for intermediate certificates in sumbmitted chains")
 )
 
 func main() {

--- a/trillian/ctfe/ct_server/main.go
+++ b/trillian/ctfe/ct_server/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/google/trillian/monitoring/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rs/cors"
+	"github.com/tomasen/realip"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/balancer/roundrobin"
 	"google.golang.org/grpc/naming"
@@ -244,7 +245,12 @@ func awaitSignal(doneFn func()) {
 }
 
 func setupAndRegister(ctx context.Context, client trillian.TrillianLogClient, deadline time.Duration, cfg *configpb.LogConfig, mux *http.ServeMux) error {
-	opts := ctfe.InstanceOptions{Deadline: deadline, MetricFactory: prometheus.MetricFactory{}, RequestLog: new(ctfe.DefaultRequestLog)}
+	opts := ctfe.InstanceOptions{
+		Deadline:        deadline,
+		MetricFactory:   prometheus.MetricFactory{},
+		RequestLog:      new(ctfe.DefaultRequestLog),
+		RemoteQuotaUser: realip.FromRequest,
+	}
 	handlers, err := ctfe.SetUpInstance(ctx, client, cfg, opts)
 	if err != nil {
 		return err

--- a/trillian/ctfe/ct_server/main.go
+++ b/trillian/ctfe/ct_server/main.go
@@ -246,10 +246,11 @@ func awaitSignal(doneFn func()) {
 
 func setupAndRegister(ctx context.Context, client trillian.TrillianLogClient, deadline time.Duration, cfg *configpb.LogConfig, mux *http.ServeMux) error {
 	opts := ctfe.InstanceOptions{
-		Deadline:        deadline,
-		MetricFactory:   prometheus.MetricFactory{},
-		RequestLog:      new(ctfe.DefaultRequestLog),
-		RemoteQuotaUser: realip.FromRequest,
+		Deadline:             deadline,
+		MetricFactory:        prometheus.MetricFactory{},
+		RequestLog:           new(ctfe.DefaultRequestLog),
+		RemoteQuotaUser:      realip.FromRequest,
+		CertificateQuotaUser: ctfe.QuotaUserForCert,
 	}
 	handlers, err := ctfe.SetUpInstance(ctx, client, cfg, opts)
 	if err != nil {

--- a/trillian/ctfe/handlers_test.go
+++ b/trillian/ctfe/handlers_test.go
@@ -128,19 +128,19 @@ func quotaUsersForChain(t *testing.T, pem ...string) []string {
 	return r
 }
 
-func (h *handlerTestInfo) setRemoteQuotaUser(u string) {
+func (info *handlerTestInfo) setRemoteQuotaUser(u string) {
 	if len(u) > 0 {
-		h.c.instanceOpts.RemoteQuotaUser = func(_ *http.Request) string { return u }
+		info.c.instanceOpts.RemoteQuotaUser = func(_ *http.Request) string { return u }
 	} else {
-		h.c.instanceOpts.RemoteQuotaUser = nil
+		info.c.instanceOpts.RemoteQuotaUser = nil
 	}
 }
 
-func (h *handlerTestInfo) enableCertQuota(e bool) {
+func (info *handlerTestInfo) enableCertQuota(e bool) {
 	if e {
-		h.c.instanceOpts.CertificateQuotaUser = quotaUserForCert
+		info.c.instanceOpts.CertificateQuotaUser = quotaUserForCert
 	} else {
-		h.c.instanceOpts.CertificateQuotaUser = nil
+		info.c.instanceOpts.CertificateQuotaUser = nil
 	}
 }
 

--- a/trillian/ctfe/instance.go
+++ b/trillian/ctfe/instance.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"time"
 
 	"github.com/golang/protobuf/proto"
@@ -93,6 +94,17 @@ type InstanceOptions struct {
 	// a boolean to indicate whether the conversion succeeded.
 	ErrorMapper func(error) (int, bool)
 	RequestLog  RequestLog
+	// RemoteUser returns a string representing the originating host for the
+	// given request. This string will be used as a User quota key.
+	// If unset, no quota will be requested for remote users.
+	RemoteQuotaUser func(*http.Request) string
+
+	// CertificateQuotaUser returns a string represeing the passed in
+	// intermediate certificate. This string will be user as a User quota key for
+	// the cert.  Quota will be requested for each intermediate in an add chain
+	// request so as to allow individual issers to be rate limited.
+	// If unset, no quota will be requested for intermediate certificates.
+	CertificateQuotaUser func(*x509.Certificate) string
 }
 
 // SetUpInstance sets up a log instance that uses the specified client to communicate

--- a/trillian/ctfe/instance.go
+++ b/trillian/ctfe/instance.go
@@ -101,9 +101,10 @@ type InstanceOptions struct {
 
 	// CertificateQuotaUser returns a string represeing the passed in
 	// intermediate certificate. This string will be user as a User quota key for
-	// the cert.  Quota will be requested for each intermediate in an add chain
-	// request so as to allow individual issers to be rate limited.
-	// If unset, no quota will be requested for intermediate certificates.
+	// the cert.  Quota will be requested for each intermediate in an
+	// add-[pre]-chain request so as to allow individual issers to be rate
+	// limited.  If unset, no quota will be requested for intermediate
+	// certificates.
 	CertificateQuotaUser func(*x509.Certificate) string
 }
 


### PR DESCRIPTION
This PR updates CTFE to use the new Trillian log API support for explicit request quotas (added in [Trillian #1143](https://github.com/google/trillian/pull/1143)).
CTFE will add `ChargeTo` entries for the IP making the incoming request, as well as entries for each intermediate certificate in submitted chains.

The new quota requests may be disabled with flags defined in `trillian/ctfe/ct_server/main.go`

Should help with #244 .