### PR TITLE
Remove spurious flag in ct package

### DIFF
--- a/signatures_test.go
+++ b/signatures_test.go
@@ -471,7 +471,7 @@ func TestNewSignatureVerifierFailsWithBadKeyParametersForRSA(t *testing.T) {
 }
 
 func TestWillAllowNonCompliantECKeyWithOverride(t *testing.T) {
-	*allowVerificationWithNonCompliantKeys = true
+	AllowVerificationWithNonCompliantKeys = true
 	k, err := ecdsa.GenerateKey(elliptic.P224(), rand.Reader)
 	if err != nil {
 		t.Fatalf("Failed to generate EC key on P224: %v", err)
@@ -482,7 +482,7 @@ func TestWillAllowNonCompliantECKeyWithOverride(t *testing.T) {
 }
 
 func TestWillAllowNonCompliantRSAKeyWithOverride(t *testing.T) {
-	*allowVerificationWithNonCompliantKeys = true
+	AllowVerificationWithNonCompliantKeys = true
 	k, err := rsa.GenerateKey(rand.Reader, 1024)
 	if err != nil {
 		t.Fatalf("Failed to generate 1024 bit RSA key: %v", err)


### PR DESCRIPTION
This PR removes the `allowVerificationWithNonCompliantKeys` flag and replaces it with an exported var `AllowVerificationWithNonCompliantKeys`.

Apps using this package which want to allow non-compliant keys should now have their own flags and set this var accordingly.

Addresses #250 .