### PR TITLE
types: Add JSON tags to `SignedCertificateTimestamp`.

### DIFF
--- a/types.go
+++ b/types.go
@@ -293,11 +293,11 @@ type TreeHeadSignature struct {
 // add-chain and add-pre-chain methods after base64 decoding; see sections
 // 3.2, 4.1 and 4.2.
 type SignedCertificateTimestamp struct {
-	SCTVersion Version `tls:"maxval:255"`
-	LogID      LogID
-	Timestamp  uint64
-	Extensions CTExtensions    `tls:"minlen:0,maxlen:65535"`
-	Signature  DigitallySigned // Signature over TLS-encoded CertificateTimestamp
+	SCTVersion Version         `tls:"maxval:255" json:"sct_version"`
+	LogID      LogID           `json:"id"`
+	Timestamp  uint64          `json:"timestamp"`
+	Extensions CTExtensions    `tls:"minlen:0,maxlen:65535" json:"extensions"`
+	Signature  DigitallySigned `json: "signature"` // Signature over TLS-encoded CertificateTimestamp
 }
 
 // CertificateTimestamp is the collection of data that the signature in an

--- a/types_test.go
+++ b/types_test.go
@@ -16,6 +16,7 @@ package ct
 
 import (
 	"encoding/hex"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -127,5 +128,39 @@ func TestToSignedTreeHead(t *testing.T) {
 				t.Errorf("GetSTHResponse.ToSignedTreeHead() = %+v, %v, want err? %t", sth, err, test.wantErr)
 			}
 		})
+	}
+}
+
+// TestSignedCertificateTimestampMarshal tests that a
+// SignedCertificateTimestamp object can be marshaled to JSON and produces the
+// expected JSON object.
+func TestSignedCertificateTimestampMarshal(t *testing.T) {
+	// Define a dummy SCT object with some fake information
+	sctObj := &SignedCertificateTimestamp{
+		SCTVersion: V1,
+		LogID: LogID{
+			KeyID: [32]byte{0xC0, 0xFF, 0xEE},
+		},
+		Timestamp:  uint64(12345678),
+		Extensions: CTExtensions{0x13, 0x37},
+		Signature: DigitallySigned{
+			Algorithm: tls.SignatureAndHashAlgorithm{
+				Hash:      tls.SHA256,
+				Signature: tls.ECDSA,
+			},
+		},
+	}
+
+	// The SCT object should marshal to JSON without any error
+	jsonBytes, err := json.Marshal(sctObj)
+	if err != nil {
+		t.Errorf("Failed to marshal SignedCertificateTransparency ob to JSON: %s", err.Error())
+	}
+
+	// The SCT object should marshal to the expected JSON
+	expectedJSON := `{"sct_version":0,"id":{"KeyID":[192,255,238,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]},"timestamp":12345678,"extensions":"Ezc=","Signature":"BAMAAA=="}`
+	if string(jsonBytes) != expectedJSON {
+		t.Errorf("Expected SignedCertificateTransparency ob to marshal to %q, got %q",
+			expectedJSON, string(jsonBytes))
 	}
 }


### PR DESCRIPTION
Prior to this PR the `ct.SignedCertificateTimestamp` object is missing `json` tags that would allow it to be marshaled to JSON. This is useful for (as one example) providing a `ct.SignedCertificateTimestamp` instance as the result of a call to the "add-chain" method of a CT server that (per RFC 6962, 4.1) should return a JSON encoded SCT.

This PR adds JSON tags to the `ct.SignedCertificateTimestamp` type and includes a small unit test to ensure the marshal works as expected. This saves users of the library from having to make their own throw-away SCT type in order to add JSON tags for marshaling.

Resolves https://github.com/google/certificate-transparency-go/issues/255