### PR TITLE
fixchain: create valid add-chain response

### DIFF
--- a/fixchain/roundtrip_test.go
+++ b/fixchain/roundtrip_test.go
@@ -104,7 +104,7 @@ func (rt testRoundTripper) RoundTrip(request *http.Request) (*http.Response, err
 			Proto:         request.Proto,
 			ProtoMajor:    request.ProtoMajor,
 			ProtoMinor:    request.ProtoMinor,
-			Body:          &bytesReadCloser{bytes.NewReader(validSCT())},
+			Body:          &bytesReadCloser{bytes.NewReader(validAddChainRsp())},
 			ContentLength: 0,
 			Request:       request,
 		}, nil
@@ -232,7 +232,7 @@ func (rt postTestRoundTripper) RoundTrip(request *http.Request) (*http.Response,
 
 	rspData := []byte("")
 	if strings.Contains(request.URL.Path, "/ct/v1/add-chain") {
-		rspData = validSCT()
+		rspData = validAddChainRsp()
 	}
 
 	// Return a response
@@ -248,13 +248,24 @@ func (rt postTestRoundTripper) RoundTrip(request *http.Request) (*http.Response,
 	}, nil
 }
 
-func validSCT() []byte {
+func validAddChainRsp() []byte {
 	var sct ct.SignedCertificateTimestamp
 	_, err := tls.Unmarshal(testdata.TestCertProof, &sct)
 	if err != nil {
 		panic(fmt.Sprintf("failed to tls-unmarshal test certificate proof: %v", err))
 	}
-	rspData, err := json.Marshal(sct)
+	sig, err := tls.Marshal(sct.Signature)
+	if err != nil {
+		panic(fmt.Sprintf("failed to marshal signature: %v", err))
+	}
+	rsp := ct.AddChainResponse{
+		SCTVersion: sct.SCTVersion,
+		Timestamp:  sct.Timestamp,
+		ID:         sct.LogID.KeyID[:],
+		Extensions: base64.StdEncoding.EncodeToString(sct.Extensions),
+		Signature:  sig,
+	}
+	rspData, err := json.Marshal(rsp)
 	if err != nil {
 		panic(fmt.Sprintf("failed to json-marshal test certificate proof: %v", err))
 	}
@@ -265,7 +276,7 @@ type newLoggerTestRoundTripper struct{}
 
 func (rt newLoggerTestRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
 	// Return a response
-	b := validSCT()
+	b := validAddChainRsp()
 	return &http.Response{
 		Status:        "200 OK",
 		StatusCode:    200,

--- a/trillian/ctfe/handlers.go
+++ b/trillian/ctfe/handlers.go
@@ -907,7 +907,7 @@ func marshalAndWriteAddChainResponse(sct *ct.SignedCertificateTimestamp, signer 
 	}
 
 	rsp := ct.AddChainResponse{
-		SCTVersion: ct.Version(sct.SCTVersion),
+		SCTVersion: sct.SCTVersion,
 		Timestamp:  sct.Timestamp,
 		ID:         logID[:],
 		Extensions: base64.StdEncoding.EncodeToString(sct.Extensions),


### PR DESCRIPTION
The previous validSCT() function was attempting to JSON-serialize
a ct.SignedCertificateTimestamp, which produced data with embedded
dicts rather than base64 data.