### PR TITLE
trillian/ctfe: Fix graceful shutdown

### DIFF
--- a/trillian/ctfe/ct_server/main.go
+++ b/trillian/ctfe/ct_server/main.go
@@ -228,8 +228,8 @@ func main() {
 	// Bring up the HTTP server and serve until we get a signal not to.
 	srv := http.Server{Addr: *httpEndpoint, Handler: handler}
 	shutdownWG := new(sync.WaitGroup)
-	shutdownWG.Add(1)
 	go awaitSignal(func() {
+		shutdownWG.Add(1)
 		defer shutdownWG.Done()
 		// Allow 60s for any pending requests to finish then terminate any stragglers
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)

--- a/trillian/ctfe/ct_server/main.go
+++ b/trillian/ctfe/ct_server/main.go
@@ -226,7 +226,7 @@ func main() {
 
 	// Bring up the HTTP server and serve until we get a signal not to.
 	srv := http.Server{Addr: *httpEndpoint, Handler: handler}
-	waitForShutdown := make(chan bool, 1)
+	waitForShutdown := make(chan struct{})
 	go awaitSignal(func() {
 		// Allow 60s for any pending requests to finish then terminate any stragglers
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
@@ -234,7 +234,7 @@ func main() {
 		glog.Info("Shutting down HTTP server...")
 		srv.Shutdown(ctx)
 		glog.Info("HTTP server shutdown")
-		waitForShutdown <- true
+		close(waitForShutdown)
 	})
 
 	err = srv.ListenAndServe()


### PR DESCRIPTION
As pointed out by @pavelkalinnikov we need to block on `Shutdown` finishing as `ListenAndServe` will immediately return on its invocation.