### PR TITLE
[Migrillian] Use Trillian's AwaitSignal

### DIFF
--- a/trillian/migrillian/core/util.go
+++ b/trillian/migrillian/core/util.go
@@ -15,13 +15,8 @@
 package core
 
 import (
-	"context"
 	"fmt"
-	"os"
-	"os/signal"
-	"syscall"
 
-	"github.com/golang/glog"
 	ct "github.com/google/certificate-transparency-go"
 	"github.com/google/certificate-transparency-go/trillian/util"
 	"github.com/google/certificate-transparency-go/x509"
@@ -52,26 +47,4 @@ func buildLogLeaf(logPrefix string, index int64, entry *ct.LeafEntry) (*trillian
 		return nil, fmt.Errorf("failed to build LogLeaf: %v", err)
 	}
 	return &leaf, nil
-}
-
-// WithSignalCancel acts like context.WithCancel(), but it also automatically
-// invokes cancel if a termination signal (SIGINT/SIGTERM) is received by the
-// process.
-func WithSignalCancel(ctx context.Context) (context.Context, context.CancelFunc) {
-	ctx, cancel := context.WithCancel(ctx)
-	go func() {
-		// Subscribe for the standard set of signals used to terminate a server.
-		sigs := make(chan os.Signal, 1)
-		signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
-		defer signal.Stop(sigs)
-
-		// Wait for a signal or explicit context cancellation.
-		select {
-		case sig := <-sigs:
-			glog.Warningf("Signal received: %v", sig)
-			cancel()
-		case <-ctx.Done():
-		}
-	}()
-	return ctx, cancel
 }

--- a/trillian/migrillian/main.go
+++ b/trillian/migrillian/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/google/certificate-transparency-go/scanner"
 	"github.com/google/certificate-transparency-go/trillian/migrillian/core"
 	"github.com/google/trillian"
+	"github.com/google/trillian/util"
 )
 
 var (
@@ -119,8 +120,10 @@ func main() {
 	}
 	ctrl := core.NewController(opts, ctClient, plClient)
 
-	cctx, cancel = core.WithSignalCancel(ctx)
+	cctx, cancel = context.WithCancel(ctx)
 	defer cancel()
+	go util.AwaitSignal(cctx, cancel)
+
 	if err := ctrl.Run(cctx); err != nil {
 		glog.Exitf("Controller.Run() returned error: %v", err)
 	}


### PR DESCRIPTION
Now that Trillian's `AwaitSignal` accepts `Context`, it can be used equivalently to `WithSignalCancel`.