### PR TITLE
 [Migrillian] Add master election

### DIFF
--- a/trillian/migrillian/core/controller.go
+++ b/trillian/migrillian/core/controller.go
@@ -87,11 +87,9 @@ func (c *Controller) RunWithElection(ctx context.Context) error {
 			return err
 		}
 		err = c.Run(mctx)
-		select {
-		case <-ctx.Done():
+		if ctx.Err() != nil {
 			return err
-		case <-mctx.Done():
-		default:
+		} else if mctx.Err() == nil {
 			return err
 		}
 	}

--- a/trillian/migrillian/core/controller.go
+++ b/trillian/migrillian/core/controller.go
@@ -22,14 +22,15 @@ import (
 	"sync"
 
 	"github.com/golang/glog"
+
 	ct "github.com/google/certificate-transparency-go"
 	"github.com/google/certificate-transparency-go/client"
 	"github.com/google/certificate-transparency-go/scanner"
+	"github.com/google/certificate-transparency-go/trillian/migrillian/election"
+
 	"github.com/google/trillian/merkle"
 	_ "github.com/google/trillian/merkle/rfc6962" // Register hasher.
 	"github.com/google/trillian/types"
-
-	"github.com/google/certificate-transparency-go/trillian/migrillian/election"
 )
 
 // Options holds configuration for a Controller.

--- a/trillian/migrillian/election/election.go
+++ b/trillian/migrillian/election/election.go
@@ -22,9 +22,12 @@ import "context"
 // Election controls an instance's participation in master election process.
 type Election interface {
 	// Await blocks until the instance captures mastership. Returns the "master
-	// context" which remains active until the instance stops believing to be the
-	// master, or the passed in context is canceled. Returns an error if
-	// capturing fails, or the passed in context is canceled before that.
+	// context" which remains active until the instance stops being the master,
+	// or the passed in context is canceled. Returns an error if capturing fails,
+	// or the passed in context is canceled before mastership is captured.
+	//
+	// Warning: It is not recommended to pass the returned master context to
+	// Election methods. A higher level context should be passed in instead.
 	Await(ctx context.Context) (context.Context, error)
 
 	// Resign cancels the master context and releases mastership for this

--- a/trillian/migrillian/election/election.go
+++ b/trillian/migrillian/election/election.go
@@ -30,14 +30,22 @@ type Election interface {
 	// Await is safe to be called again when the current mastership context is
 	// canceled, which might happen implicitly when mastership is overtaken, or
 	// explicitly when Resign is called.
+	//
+	// TODO(pavelkalinnikov): It makes sense to distinguish the ctx being passed
+	// in only for waiting, and a "master context" used to derive the mastership
+	// context from. This way, we could put a deadline on waiting for mastership,
+	// and not cancel mastership in case it gets acquired within the deadline.
 	Await(ctx context.Context) (context.Context, error)
 
-	// Resign cancels the mastership context and releases mastership for this
-	// instance. The instance can be elected again using Await.
+	// Resign releases mastership for this instance and cancels the mastership
+	// context. The instance can be elected again using Await.
 	//
 	// Mastership context cancelation is guaranteed, but the returned error can
 	// indicate that resigning has failed. In the latter case it might be helpful
 	// to retry, the call is idempotent.
+	//
+	// The caller is advised to tear down mastership-related work before invoking
+	// Resign to have best protection against double-master situations.
 	Resign(ctx context.Context) error
 
 	// Close cancels the mastership context, permanently stops participating in

--- a/trillian/migrillian/election/election.go
+++ b/trillian/migrillian/election/election.go
@@ -14,6 +14,7 @@
 
 // Package election provides master election tools, and interfaces for plugging
 // in a custom underlying mechanism.
+// TODO(pavelkalinnikov): Migrate this package to Trillian.
 package election
 
 import "context"

--- a/trillian/migrillian/election/election.go
+++ b/trillian/migrillian/election/election.go
@@ -22,21 +22,21 @@ import "context"
 // Election controls an instance's participation in master election process.
 // Note: Implementations are not intended to be thread-safe.
 type Election interface {
-	// Await blocks until the instance captures mastership. Returns the "master
+	// Await blocks until the instance captures mastership. Returns a "mastership
 	// context" which remains active until the instance stops being the master,
 	// or the passed in context is canceled. Returns an error if capturing fails,
 	// or the passed in context is canceled before mastership is captured.
 	Await(ctx context.Context) (context.Context, error)
 
-	// Resign cancels the master context and releases mastership for this
+	// Resign cancels the mastership context and releases mastership for this
 	// instance. The instance can be elected again using Await.
 	//
-	// Master context cancelation is guaranteed, but the returned error can
+	// Mastership context cancelation is guaranteed, but the returned error can
 	// indicate that resigning has failed. In the latter case it might be helpful
 	// to retry, the call is idempotent.
 	Resign(ctx context.Context) error
 
-	// Close cancels the master context, permanently stops participating in
+	// Close cancels the mastership context, permanently stops participating in
 	// election, and releases the resources. As a best effort, it might also try
 	// to explicitly Resign so that other instances can overtake mastership
 	// faster. No other method should be called after Close.

--- a/trillian/migrillian/election/election.go
+++ b/trillian/migrillian/election/election.go
@@ -25,13 +25,14 @@ type Election interface {
 	// context" which remains active until the instance stops being the master,
 	// or the passed in context is canceled. Returns an error if capturing fails,
 	// or the passed in context is canceled before mastership is captured.
-	//
-	// Warning: It is not recommended to pass the returned master context to
-	// Election methods. A higher level context should be passed in instead.
 	Await(ctx context.Context) (context.Context, error)
 
 	// Resign cancels the master context and releases mastership for this
 	// instance. The instance can be elected again using Await.
+	//
+	// Master context cancelation is guaranteed, but the returned error can
+	// indicate that resigning has failed. In the latter case it might be helpful
+	// to retry, the call is idempotent.
 	Resign(ctx context.Context) error
 
 	// Close cancels the master context, permanently stops participating in

--- a/trillian/migrillian/election/election.go
+++ b/trillian/migrillian/election/election.go
@@ -20,6 +20,7 @@ package election
 import "context"
 
 // Election controls an instance's participation in master election process.
+// Note: Implementations are not intended to be thread-safe.
 type Election interface {
 	// Await blocks until the instance captures mastership. Returns the "master
 	// context" which remains active until the instance stops being the master,

--- a/trillian/migrillian/election/election.go
+++ b/trillian/migrillian/election/election.go
@@ -26,6 +26,10 @@ type Election interface {
 	// context" which remains active until the instance stops being the master,
 	// or the passed in context is canceled. Returns an error if capturing fails,
 	// or the passed in context is canceled before mastership is captured.
+	//
+	// Await is safe to be called again when the current mastership context is
+	// canceled, which might happen implicitly when mastership is overtaken, or
+	// explicitly when Resign is called.
 	Await(ctx context.Context) (context.Context, error)
 
 	// Resign cancels the mastership context and releases mastership for this

--- a/trillian/migrillian/election/election.go
+++ b/trillian/migrillian/election/election.go
@@ -1,0 +1,43 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package election provides master election tools, and interfaces for plugging
+// in a custom underlying mechanism.
+package election
+
+import "context"
+
+// Election controls an instance's participation in master election process.
+type Election interface {
+	// Await blocks until the instance captures mastership. Returns the "master
+	// context" which remains active until the instance stops believing to be the
+	// master, or the passed in context is canceled. Returns an error if
+	// capturing fails, or the passed in context is canceled before that.
+	Await(ctx context.Context) (context.Context, error)
+
+	// Resign cancels the master context and releases mastership for this
+	// instance. The instance can be elected again using Await.
+	Resign(ctx context.Context) error
+
+	// Close cancels the master context, permanently stops participating in
+	// election, and releases the resources. As a best effort, it might also try
+	// to explicitly Resign so that other instances can overtake mastership
+	// faster. No other method should be called after Close.
+	Close(ctx context.Context) error
+}
+
+// Factory encapsulates the creation of an Election instance for a treeID.
+type Factory interface {
+	NewElection(ctx context.Context, treeID int64) (Election, error)
+}

--- a/trillian/migrillian/election/etcd/election.go
+++ b/trillian/migrillian/election/etcd/election.go
@@ -95,10 +95,12 @@ func (e *Election) Await(ctx context.Context) (context.Context, error) {
 // Resign cancels the master context and releases mastership for this instance.
 // The instance can be elected again using Await.
 func (e *Election) Resign(ctx context.Context) error {
+	err := e.election.Resign(ctx)
+	// Cancel after Resign to tolerate situations when ctx is the master context.
 	if e.cancel != nil {
 		e.cancel()
 	}
-	return e.election.Resign(ctx)
+	return err
 }
 
 // Close cancels the master context, permanently stops participating in

--- a/trillian/migrillian/election/etcd/election.go
+++ b/trillian/migrillian/election/etcd/election.go
@@ -47,7 +47,7 @@ type Election struct {
 	cancel context.CancelFunc
 }
 
-// Await blocks until the instance captures mastership. Returns the "master
+// Await blocks until the instance captures mastership. Returns a "mastership
 // context" which remains active until the instance stops being the master, or
 // the passed in context is canceled. Returns an error if capturing fails, or
 // the passed in context is canceled before mastership is captured.
@@ -91,7 +91,7 @@ func (e *Election) Await(ctx context.Context) (context.Context, error) {
 				break
 			}
 		}
-		glog.Infof("%d: canceling master context", e.treeID)
+		glog.Infof("%d: canceling mastership context", e.treeID)
 		cancel()
 	}()
 
@@ -99,18 +99,18 @@ func (e *Election) Await(ctx context.Context) (context.Context, error) {
 	return cctx, nil
 }
 
-// Resign cancels the master context and releases mastership for this instance.
-// The instance can be elected again using Await.
+// Resign cancels the mastership context and releases mastership for this
+// instance. The instance can be elected again using Await.
 func (e *Election) Resign(ctx context.Context) error {
 	err := e.election.Resign(ctx)
-	// Cancel after Resign to tolerate situations when ctx is the master context.
+	// Cancel after Resign to tolerate ctx being the mastership context.
 	if e.cancel != nil {
 		e.cancel()
 	}
 	return err
 }
 
-// Close cancels the master context, permanently stops participating in
+// Close cancels the mastership context, permanently stops participating in
 // election, and releases the resources. It does best effort on resigning
 // despite potential cancelation of the passed in context. No other method
 // should be called after Close.

--- a/trillian/migrillian/election/etcd/election.go
+++ b/trillian/migrillian/election/etcd/election.go
@@ -1,0 +1,148 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package etcd provides implementation master election based on etcd.
+package etcd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/clientv3/concurrency"
+	"github.com/golang/glog"
+	"github.com/google/certificate-transparency-go/trillian/migrillian/election"
+)
+
+// Election is an implementation of election.Election based on etcd.
+type Election struct {
+	treeID     int64
+	instanceID string
+	lockFile   string
+
+	client   *clientv3.Client
+	session  *concurrency.Session
+	election *concurrency.Election
+
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+// Await blocks until the instance captures mastership. Returns the context
+// which remains active until the instance stops believing to be the master,
+// or the passed in context is canceled. Returns an error if capturing fails
+// or the passed in context is canceled before that.
+func (e *Election) Await(ctx context.Context) (context.Context, error) {
+	if e.ctx != nil && e.ctx.Err() == nil {
+		return e.ctx, nil
+	}
+
+	if err := e.election.Campaign(ctx, e.instanceID); err != nil {
+		return nil, err
+	}
+
+	cctx, cancel := context.WithCancel(ctx)
+	ch := e.election.Observe(cctx)
+
+	select {
+	case <-ctx.Done():
+		cancel()
+		return nil, ctx.Err()
+	case rsp, ok := <-ch:
+		if !ok {
+			cancel()
+			return nil, errors.New("mastership unconfirmed")
+		}
+		if string(rsp.Kvs[0].Value) != e.instanceID {
+			cancel()
+			return nil, errors.New("mastership overtaken")
+		}
+	}
+
+	go func() {
+		defer cancel()
+		for rsp := range ch {
+			if string(rsp.Kvs[0].Value) != e.instanceID {
+				glog.Warning("Election: observed another master")
+				return
+			}
+		}
+		glog.Warning("Election: observe channel closed")
+	}()
+
+	e.ctx, e.cancel = cctx, cancel
+	return cctx, nil
+}
+
+// Resign releases mastership for this instance. The instance is still ready
+// to be elected again using the Await method.
+func (e *Election) Resign(ctx context.Context) error {
+	if e.cancel != nil {
+		e.cancel()
+	}
+	return e.election.Resign(ctx)
+}
+
+// Close permanently stops the instance's participation in election and
+// releases its resources. As a best effort, it might also try to explicitly
+// resign. No other method should be called after Close.
+func (e *Election) Close(ctx context.Context) error {
+	if e.cancel != nil {
+		e.cancel()
+	}
+	return e.election.Resign(ctx)
+}
+
+// Factory creates Election instances.
+type Factory struct {
+	client     *clientv3.Client
+	instanceID string
+	lockDir    string
+}
+
+// NewFactory builds an election factory that uses the given parameters. The
+// passed in etcd client should remain valid for the lifetime of the object.
+func NewFactory(instanceID string, client *clientv3.Client, lockDir string) *Factory {
+	return &Factory{
+		client:     client,
+		instanceID: instanceID,
+		lockDir:    lockDir,
+	}
+}
+
+// NewElection creates a specific Election instance.
+func (f *Factory) NewElection(ctx context.Context, treeID int64) (election.Election, error) {
+	// TODO(pavelkalinnikov): Re-create the session if it expires.
+	// TODO(pavelkalinnikov): Share the same session between Election instances.
+	session, err := concurrency.NewSession(f.client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create etcd session: %v", err)
+	}
+	lockFile := fmt.Sprintf("%s/%d", strings.TrimRight(f.lockDir, "/"), treeID)
+	election := concurrency.NewElection(session, lockFile)
+
+	el := Election{
+		treeID:     treeID,
+		instanceID: f.instanceID,
+		lockFile:   lockFile,
+		client:     f.client,
+		session:    session,
+		election:   election,
+	}
+	glog.Infof("Election created: %+v", el)
+
+	return &el, nil
+}

--- a/trillian/migrillian/election/etcd/election.go
+++ b/trillian/migrillian/election/etcd/election.go
@@ -52,11 +52,11 @@ type Election struct {
 // the passed in context is canceled. Returns an error if capturing fails, or
 // the passed in context is canceled before mastership is captured.
 func (e *Election) Await(ctx context.Context) (context.Context, error) {
-	// Return an error if the Election already maintains mastership context.
 	if e.done != nil {
+		// There was a previous monitoring goroutine, so check its completion.
 		select {
-		case <-e.done:
-		default:
+		case <-e.done: // Completed OK.
+		default: // Still running.
 			return nil, errAlreadyRunning
 		}
 	}
@@ -92,7 +92,7 @@ func (e *Election) Await(ctx context.Context) (context.Context, error) {
 	go func() {
 		defer func() {
 			glog.Infof("%d: canceling mastership context", e.treeID)
-			// Note: Close comes before context cancelation, so that Await can be
+			// Note: close comes before context cancelation, so that Await can be
 			// invoked immediately after the cancelation without an error.
 			close(done)
 			cancel()

--- a/trillian/migrillian/election/etcd/election.go
+++ b/trillian/migrillian/election/etcd/election.go
@@ -28,9 +28,9 @@ import (
 )
 
 var (
-	masterAlready     = errors.New("already master")
-	masterUnconfirmed = errors.New("mastership unconfirmed")
-	masterOvertaken   = errors.New("mastership overtaken")
+	errMasterAlready     = errors.New("already master")
+	errMasterUnconfirmed = errors.New("mastership unconfirmed")
+	errMasterOvertaken   = errors.New("mastership overtaken")
 )
 
 // Election is an implementation of election.Election based on etcd.
@@ -54,7 +54,7 @@ type Election struct {
 func (e *Election) Await(ctx context.Context) (context.Context, error) {
 	// Return an error if the Election already maintains mastership context.
 	if e.ctx != nil && e.ctx.Err() == nil {
-		return nil, masterAlready
+		return nil, errMasterAlready
 	}
 
 	if err := e.election.Campaign(ctx, e.instanceID); err != nil {
@@ -74,11 +74,11 @@ func (e *Election) Await(ctx context.Context) (context.Context, error) {
 	case rsp, ok := <-ch:
 		if !ok {
 			cancel()
-			return nil, masterUnconfirmed
+			return nil, errMasterUnconfirmed
 		}
 		if string(rsp.Kvs[0].Value) != e.instanceID {
 			cancel()
-			return nil, masterOvertaken
+			return nil, errMasterOvertaken
 		}
 	}
 

--- a/trillian/migrillian/election/etcd/election.go
+++ b/trillian/migrillian/election/etcd/election.go
@@ -103,7 +103,10 @@ func (e *Election) Close(ctx context.Context) error {
 	if e.cancel != nil {
 		e.cancel()
 	}
-	return e.election.Resign(ctx)
+	_ = e.Resign(ctx)
+	// In case ctx is canceled, session.Close should do best effort on revoking
+	// the lease, which in turn will remove the election-related keys.
+	return e.session.Close()
 }
 
 // Factory creates Election instances.

--- a/trillian/migrillian/election/noop.go
+++ b/trillian/migrillian/election/noop.go
@@ -1,0 +1,43 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package election
+
+import "context"
+
+// NoopElection is a stub Election that always believes to be the master.
+type NoopElection int64
+
+// Await returns the passed in context as a master context.
+func (ne NoopElection) Await(ctx context.Context) (context.Context, error) {
+	return ctx, nil
+}
+
+// Resign releases mastership for this instance.
+func (ne NoopElection) Resign(ctx context.Context) error {
+	return nil
+}
+
+// Close permanently stops the instance's participation in election.
+func (ne NoopElection) Close(ctx context.Context) error {
+	return nil
+}
+
+// NoopFactory creates NoopElection instances.
+type NoopFactory struct{}
+
+// NewElection creates a specific NoopElection instance.
+func (nf NoopFactory) NewElection(ctx context.Context, treeID int64) (Election, error) {
+	return NoopElection(treeID), nil
+}

--- a/trillian/migrillian/election/noop.go
+++ b/trillian/migrillian/election/noop.go
@@ -24,12 +24,12 @@ func (ne NoopElection) Await(ctx context.Context) (context.Context, error) {
 	return ctx, nil
 }
 
-// Resign releases mastership for this instance.
+// Resign does nothing because NoopElection is always the master.
 func (ne NoopElection) Resign(ctx context.Context) error {
 	return nil
 }
 
-// Close permanently stops the instance's participation in election.
+// Close does nothing because NoopElection is always the master.
 func (ne NoopElection) Close(ctx context.Context) error {
 	return nil
 }

--- a/trillian/migrillian/election/noop.go
+++ b/trillian/migrillian/election/noop.go
@@ -19,7 +19,7 @@ import "context"
 // NoopElection is a stub Election that always believes to be the master.
 type NoopElection int64
 
-// Await returns the passed in context as a master context.
+// Await returns the passed in context as a mastership context.
 func (ne NoopElection) Await(ctx context.Context) (context.Context, error) {
 	return ctx, nil
 }


### PR DESCRIPTION
This PR introduces master election abstractions and the corresponding `etcd` implementation in Migrillian.

The interface is a distilled version of Trillian's [util.election](https://github.com/google/trillian/tree/master/util/election) with some advantages:
- does not enforce the client code to perform busy waiting, instead allows passively waiting implementations (like the `etcd` one in this PR)
- allows to put more flexible code under the hood

Eventually this code will migrate to Trillian (which currently needs to undergo a major refactoring to be able to take advantage of the new interface).