### PR TITLE
Switch ct-go travis build to latest protoc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ install:
   - |
     (
       cd ../protoc
-      wget https://github.com/google/protobuf/releases/download/v3.2.0/protoc-3.2.0-${TRAVIS_OS_NAME}-x86_64.zip
-      unzip protoc-3.2.0-${TRAVIS_OS_NAME}-x86_64.zip
+      wget https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-${TRAVIS_OS_NAME}-x86_64.zip
+      unzip protoc-3.5.1-${TRAVIS_OS_NAME}-x86_64.zip
     )
   - export PATH=$(pwd)/../protoc/bin:$PATH
   - go get -d -t ./...


### PR DESCRIPTION
There is a known vulnerability in 3.2 and it's rather old.