### PR TITLE
[Migrillian] Decouple Observe from Election.Await

### DIFF
--- a/trillian/migrillian/core/controller.go
+++ b/trillian/migrillian/core/controller.go
@@ -82,11 +82,16 @@ func (c *Controller) RunWhenMaster(ctx context.Context) error {
 	}(ctx)
 
 	for {
-		mctx, err := el.Await(ctx)
-		if err != nil {
+		if err := el.Await(ctx); err != nil {
 			glog.Errorf("Await(): %v", err)
 			return err
 		}
+		mctx, err := el.Observe(ctx)
+		if err != nil {
+			glog.Errorf("Observe(): %v", err)
+			return err
+		}
+
 		glog.Infof("Running as master for log %d", logID)
 
 		// Run while still master (or until an error).

--- a/trillian/migrillian/election/etcd/election.go
+++ b/trillian/migrillian/election/etcd/election.go
@@ -28,9 +28,7 @@ import (
 )
 
 var (
-	errAlreadyRunning    = errors.New("already running")
 	errMasterUnconfirmed = errors.New("mastership unconfirmed")
-	errMasterOvertaken   = errors.New("mastership overtaken")
 )
 
 // Election is an implementation of election.Election based on etcd.
@@ -42,29 +40,16 @@ type Election struct {
 	client   *clientv3.Client
 	session  *concurrency.Session
 	election *concurrency.Election
-
-	cancel context.CancelFunc
-	done   chan struct{}
 }
 
-// Await blocks until the instance captures mastership. Returns a "mastership
-// context" which remains active until the instance stops being the master, or
-// the passed in context is canceled. Returns an error if capturing fails, or
-// the passed in context is canceled before mastership is captured.
-func (e *Election) Await(ctx context.Context) (context.Context, error) {
-	if e.done != nil {
-		// There was a previous monitoring goroutine, so check its completion.
-		select {
-		case <-e.done: // Completed OK.
-		default: // Still running.
-			return nil, errAlreadyRunning
-		}
-	}
+// Await blocks until the instance captures mastership.
+func (e *Election) Await(ctx context.Context) error {
+	return e.election.Campaign(ctx, e.instanceID)
+}
 
-	if err := e.election.Campaign(ctx, e.instanceID); err != nil {
-		return nil, err
-	}
-
+// Observe returns a "mastership context" which remains active until the
+// instance stops being the master, or the passed in context is canceled.
+func (e *Election) Observe(ctx context.Context) (context.Context, error) {
 	// Get a channel for notifications of election status (using the cancelable
 	// context so that the monitoring goroutine below and the goroutine started
 	// by Observe will reliably terminate).
@@ -81,22 +66,16 @@ func (e *Election) Await(ctx context.Context) (context.Context, error) {
 			return nil, errMasterUnconfirmed
 		}
 		if string(rsp.Kvs[0].Value) != e.instanceID {
-			cancel()
-			return nil, errMasterOvertaken
+			cancel() // Mastership has been overtaken in the meantime.
+			return cctx, nil
 		}
 	}
 
 	// At this point we have observed confirmation that we are the master; start
 	// a goroutine to monitor for anyone else overtaking us.
-	done := make(chan struct{})
 	go func() {
-		defer func() {
-			glog.Infof("%d: canceling mastership context", e.treeID)
-			// Note: close comes before context cancelation, so that Await can be
-			// invoked immediately after the cancelation without an error.
-			close(done)
-			cancel()
-		}()
+		defer cancel()
+		defer glog.Infof("%d: canceling mastership context", e.treeID)
 		for rsp := range ch {
 			if string(rsp.Kvs[0].Value) != e.instanceID {
 				glog.Warningf("%d: mastership overtaken", e.treeID)
@@ -105,28 +84,19 @@ func (e *Election) Await(ctx context.Context) (context.Context, error) {
 		}
 	}()
 
-	e.cancel, e.done = cancel, done
 	return cctx, nil
 }
 
-// Resign releases mastership for this instance and cancels the mastership
-// context. The instance can be elected again using Await.
+// Resign releases mastership for this instance. The instance can be elected
+// again using Await. Idempotent, might be useful to retry if fails.
 func (e *Election) Resign(ctx context.Context) error {
-	err := e.election.Resign(ctx)
-	// Cancel after Resign to tolerate ctx being the mastership context.
-	if e.cancel != nil {
-		e.cancel()
-		// Ignore cxt.Done() while waiting for e.done, to tolerate ctx being the
-		// canceled mastership context. This wait will reliably terminate anyway.
-		<-e.done
-	}
-	return err
+	return e.election.Resign(ctx)
 }
 
-// Close cancels the mastership context, permanently stops participating in
-// election, and releases the resources. It does best effort on resigning
-// despite potential cancelation of the passed in context. No other method
-// should be called after Close.
+// Close permanently stops participating in election, and releases the
+// resources. It does best effort on resigning despite potential cancelation of
+// the passed in context, so that other instances can overtake mastership
+// faster. No other method should be called after Close.
 func (e *Election) Close(ctx context.Context) error {
 	if err := e.Resign(ctx); err != nil {
 		glog.Errorf("%d: Resign(): %v", e.treeID, err)

--- a/trillian/migrillian/election/noop.go
+++ b/trillian/migrillian/election/noop.go
@@ -19,8 +19,13 @@ import "context"
 // NoopElection is a stub Election that always believes to be the master.
 type NoopElection int64
 
-// Await returns the passed in context as a mastership context.
-func (ne NoopElection) Await(ctx context.Context) (context.Context, error) {
+// Await returns immediately, as the instance is always the master.
+func (ne NoopElection) Await(ctx context.Context) error {
+	return nil
+}
+
+// Observe returns the passed in context as a mastership context.
+func (ne NoopElection) Observe(ctx context.Context) (context.Context, error) {
 	return ctx, nil
 }
 


### PR DESCRIPTION
This change introduces a separate Observe method in Election for
watching mastership status.

Advantages:
- The context passed in to Await can now have a deadline, and not cancel
  mastership if it expires *after* mastership is captured. Previuously,
  capturing mastership and watching its status shared the same context.
- Multiple watchers are possible, with independent contexts.
- etcd.Election now doesn't store watching status.
- Simplified Election's contract regarding mastership context
  cancelation.