### PR TITLE
Add config for creating Docker images for tagged releases automatically

### DIFF
--- a/cloudbuild_tag.yaml
+++ b/cloudbuild_tag.yaml
@@ -1,0 +1,10 @@
+steps:
+- id: build_ctfe
+  name: gcr.io/cloud-builders/docker
+  args:
+  - build
+  - --file=trillian/examples/deployment/docker/ctfe/Dockerfile
+  - --tag=gcr.io/${PROJECT_ID}/ctfe:${TAG_NAME}
+  - .
+images:
+- gcr.io/${PROJECT_ID}/ctfe:${TAG_NAME}


### PR DESCRIPTION
Google Container Registry can be configured to use this file to build
Docker images automatically whenever a new tag is pushed to the repo.
This reduces the amount of work a human needs to do to create a release.

Contributes to issue #160.