### PR TITLE
Fix golang 1.11 compatibility on Windows

### DIFF
--- a/x509/go111_windows.go
+++ b/x509/go111_windows.go
@@ -1,0 +1,9 @@
+// +build go-1.11
+
+package x509
+
+import (
+	"syscall"
+)
+
+type syscallPtr = syscall.Pointer

--- a/x509/pre_go111_windows.go
+++ b/x509/pre_go111_windows.go
@@ -1,0 +1,5 @@
+// +build !go-1.11
+
+package x509
+
+type syscallPtr = uintptr

--- a/x509/root_windows.go
+++ b/x509/root_windows.go
@@ -109,7 +109,7 @@ func checkChainSSLServerPolicy(c *Certificate, chainCtx *syscall.CertChainContex
 	sslPara.Size = uint32(unsafe.Sizeof(*sslPara))
 
 	para := &syscall.CertChainPolicyPara{
-		ExtraPolicyPara: uintptr(unsafe.Pointer(sslPara)),
+		ExtraPolicyPara: (syscallPtr)(unsafe.Pointer(sslPara)),
 	}
 	para.Size = uint32(unsafe.Sizeof(*para))
 


### PR DESCRIPTION
Go 1.11beta1 introduces an incompatible change to the type of
CertChainPolicyPara.ExtraPolicyPara field [1], which results
in the following compile error on Windows:

> x509\root_windows.go:112:3: cannot use
> uintptr(unsafe.Pointer(sslPara)) (type uintptr) as type
> syscall.Pointer in field value

The fix, maintaining backward compatibility with Go 1.10 and 1.9,
is to use type alias. Unfortunately it won't work with go < 1.9
as those earlier versions lack the type alias feature.

This should fix issue #284.

[1] https://github.com/golang/go/commit/4869ec00e87ef