### PR TITLE
x509: make Windows policy parameter type version-specific

### DIFF
--- a/x509/ptr_sysptr_windows.go
+++ b/x509/ptr_sysptr_windows.go
@@ -1,0 +1,20 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build go1.11
+
+package x509
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+// For Go versions >= 1.11, the ExtraPolicyPara field in
+// syscall.CertChainPolicyPara is of type syscall.Pointer.  See:
+//   https://github.com/golang/go/commit/4869ec00e87ef
+
+func convertToPolicyParaType(p unsafe.Pointer) syscall.Pointer {
+	return (syscall.Pointer)(p)
+}

--- a/x509/ptr_uint_windows.go
+++ b/x509/ptr_uint_windows.go
@@ -1,0 +1,17 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !go1.11
+
+package x509
+
+import "unsafe"
+
+// For Go versions before 1.11, the ExtraPolicyPara field in
+// syscall.CertChainPolicyPara was of type uintptr.  See:
+//   https://github.com/golang/go/commit/4869ec00e87ef
+
+func convertToPolicyParaType(p unsafe.Pointer) uintptr {
+	return uintptr(p)
+}

--- a/x509/root_windows.go
+++ b/x509/root_windows.go
@@ -109,7 +109,7 @@ func checkChainSSLServerPolicy(c *Certificate, chainCtx *syscall.CertChainContex
 	sslPara.Size = uint32(unsafe.Sizeof(*sslPara))
 
 	para := &syscall.CertChainPolicyPara{
-		ExtraPolicyPara: uintptr(unsafe.Pointer(sslPara)),
+		ExtraPolicyPara: convertToPolicyParaType(unsafe.Pointer(sslPara)),
 	}
 	para.Size = uint32(unsafe.Sizeof(*para))
 


### PR DESCRIPTION
Go 1.11 needs syscall.CertChainPolicyPara.ExtraPolicyPara to
have type syscall.Pointer, but in previous versions of Go this
had type uintptr.

As we have a fork of crypto/x509, our source code for x509 can be
a different version than the current compiler.

To allow our code to work with both 1.11 and earlier versions,
encapsulate the cast into a version-specific function.

Fixes #284