### PR TITLE
Decouple signature cache from logInfo

### DIFF
--- a/trillian/ctfe/handlers.go
+++ b/trillian/ctfe/handlers.go
@@ -15,7 +15,6 @@
 package ctfe
 
 import (
-	"bytes"
 	"context"
 	"crypto"
 	"crypto/sha256"
@@ -234,12 +233,10 @@ type logInfo struct {
 	// signer signs objects
 	signer crypto.Signer
 
-	// Cache the last signature generated for an STH, to reduce re-signing
-	// and slightly reduce the chances of being able to fingerprint get-sth
-	// users by their STH signature value.
-	lastSTHMu        sync.RWMutex
-	lastSTHBytes     []byte
-	lastSTHSignature ct.DigitallySigned
+	// Cache the last signature generated for an STH, to reduce re-signing and
+	// slightly reduce the chances of being able to fingerprint get-sth users by
+	// their STH signature value.
+	sthSigCache SignatureCache
 }
 
 // newLogInfo creates a new instance of logInfo.
@@ -259,22 +256,6 @@ func newLogInfo(logID int64, prefix string, validationOpts CertValidationOpts, r
 	knownLogs.Set(1.0, strconv.FormatInt(logID, 10))
 
 	return ctx
-}
-
-func (li *logInfo) setLastSTHSignature(sthBytes []byte, sig ct.DigitallySigned) {
-	li.lastSTHMu.Lock()
-	defer li.lastSTHMu.Unlock()
-	li.lastSTHBytes = sthBytes
-	li.lastSTHSignature = sig
-}
-
-func (li *logInfo) getLastSTHSignature(sthBytes []byte) (ct.DigitallySigned, bool) {
-	li.lastSTHMu.RLock()
-	defer li.lastSTHMu.RUnlock()
-	if !bytes.Equal(sthBytes, li.lastSTHBytes) {
-		return ct.DigitallySigned{}, false
-	}
-	return li.lastSTHSignature, true
 }
 
 // Handlers returns a map from URL paths (with the given prefix) and AppHandler instances
@@ -515,7 +496,7 @@ func getSTH(ctx context.Context, li *logInfo, w http.ResponseWriter, r *http.Req
 	}
 
 	// Add the signature over the STH contents.
-	err = li.signV1TreeHead(li.signer, sth)
+	err = signV1TreeHead(li.signer, sth, &li.sthSigCache)
 	if err != nil || len(sth.TreeHeadSignature.Signature) == 0 {
 		return http.StatusInternalServerError, fmt.Errorf("failed to sign tree head: %v", err)
 	}

--- a/trillian/ctfe/serialize.go
+++ b/trillian/ctfe/serialize.go
@@ -27,10 +27,10 @@ import (
 	ct "github.com/google/certificate-transparency-go"
 )
 
-// SignatureCache stores the last generated signature for a given bytes input.
-// It helps to reduce the number of signing operations, and the number of
-// distinct signatures produced for the same input (some signing methods are
-// non-deterministic).
+// SignatureCache is a one-entry cache that stores the last generated signature
+// for a given bytes input. It helps to reduce the number of signing
+// operations, and the number of distinct signatures produced for the same
+// input (some signing methods are non-deterministic).
 type SignatureCache struct {
 	mu    sync.RWMutex
 	input []byte

--- a/trillian/ctfe/serialize.go
+++ b/trillian/ctfe/serialize.go
@@ -15,24 +15,54 @@
 package ctfe
 
 import (
+	"bytes"
 	"crypto"
 	"crypto/rand"
 	"crypto/sha256"
 	"fmt"
+	"sync"
 
 	"github.com/google/certificate-transparency-go/tls"
 
 	ct "github.com/google/certificate-transparency-go"
 )
 
-// signV1TreeHead signs a tree head for CT. The input STH should have been built from a
-// backend response and already checked for validity.
-func (li *logInfo) signV1TreeHead(signer crypto.Signer, sth *ct.SignedTreeHead) error {
+// SignatureCache stores the last generated signature for a given bytes input.
+// It helps to reduce the number of signing operations, and the number of
+// distinct signatures produced for the same input (some signing methods are
+// non-deterministic).
+type SignatureCache struct {
+	mu    sync.RWMutex
+	input []byte
+	sig   ct.DigitallySigned
+}
+
+// GetSignature returns the latest signature for the given bytes input. If the
+// input is not in the cache, it returns (_, false).
+func (sc *SignatureCache) GetSignature(input []byte) (ct.DigitallySigned, bool) {
+	sc.mu.RLock()
+	defer sc.mu.RUnlock()
+	if !bytes.Equal(input, sc.input) {
+		return ct.DigitallySigned{}, false
+	}
+	return sc.sig, true
+}
+
+// SetSignature associates the signature with the given bytes input.
+func (sc *SignatureCache) SetSignature(input []byte, sig ct.DigitallySigned) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	sc.input, sc.sig = input, sig
+}
+
+// signV1TreeHead signs a tree head for CT. The input STH should have been
+// built from a backend response and already checked for validity.
+func signV1TreeHead(signer crypto.Signer, sth *ct.SignedTreeHead, cache *SignatureCache) error {
 	sthBytes, err := ct.SerializeSTHSignatureInput(*sth)
 	if err != nil {
 		return err
 	}
-	if sig, ok := li.getLastSTHSignature(sthBytes); ok {
+	if sig, ok := cache.GetSignature(sthBytes); ok {
 		sth.TreeHeadSignature = sig
 		return nil
 	}
@@ -51,7 +81,7 @@ func (li *logInfo) signV1TreeHead(signer crypto.Signer, sth *ct.SignedTreeHead) 
 		},
 		Signature: signature,
 	}
-	li.setLastSTHSignature(sthBytes, sth.TreeHeadSignature)
+	cache.SetSignature(sthBytes, sth.TreeHeadSignature)
 	return nil
 }
 


### PR DESCRIPTION
This is a preparatory change for #289. It enables us to hide STH signing behind an interface decoupled from `logInfo`.