### PR TITLE
jsonclient: increase backoff test leeway

### DIFF
--- a/jsonclient/backoff_test.go
+++ b/jsonclient/backoff_test.go
@@ -20,7 +20,7 @@ import (
 	"time"
 )
 
-const testLeeway = 25 * time.Microsecond
+const testLeeway = 25 * time.Millisecond
 
 func fuzzyTimeEquals(a, b time.Time, leeway time.Duration) bool {
 	diff := math.Abs(float64(a.Sub(b).Nanoseconds()))


### PR DESCRIPTION
There has been an occasional flake like:
  backoff_test.go:114: backoff.set(30m0s)=59m59.999970667s; want 1h0m0s