### PR TITLE
Allow matching on SCT timestamp

### DIFF
--- a/scanner/matcher.go
+++ b/scanner/matcher.go
@@ -138,6 +138,8 @@ type MatchSCTTimestamp struct {
 	Timestamp uint64
 }
 
+// Matches returns true if the timestamp embedded in the leaf matches the one
+// specified by this matcher.
 func (m MatchSCTTimestamp) Matches(leaf *ct.LeafEntry) bool {
 	entry, _ := ct.LogEntryFromLeaf(1, leaf)
 	if entry == nil {

--- a/scanner/matcher.go
+++ b/scanner/matcher.go
@@ -133,6 +133,20 @@ func (m MatchIssuerRegex) PrecertificateMatches(p *ct.Precertificate) bool {
 	return m.PrecertificateIssuerRegex.FindStringIndex(p.TBSCertificate.Issuer.CommonName) != nil
 }
 
+// MatchSCTTimestamp is a matcher which matches leaf entries with the specified Timestamp.
+type MatchSCTTimestamp struct {
+	Timestamp uint64
+}
+
+func (m MatchSCTTimestamp) Matches(leaf *ct.LeafEntry) bool {
+	entry, _ := ct.LogEntryFromLeaf(1, leaf)
+	if entry == nil {
+		// Can't validate if we can't parse
+		return false
+	}
+	return entry.Leaf.TimestampedEntry.Timestamp == m.Timestamp
+}
+
 // LeafMatcher describes how to match log entries, based on the Log LeafEntry
 // (which includes the unparsed [pre-]certificate; clients should implement this
 // interface to perform their own match criteria.

--- a/scanner/scanlog/scanlog.go
+++ b/scanner/scanlog/scanlog.go
@@ -45,7 +45,7 @@ var (
 	matchIssuerRegex  = flag.String("match_issuer_regex", "", "Regex to match in issuer CN")
 	precertsOnly      = flag.Bool("precerts_only", false, "Only match precerts")
 	serialNumber      = flag.String("serial_number", "", "Serial number of certificate of interest")
-	sctTimestamp      = flag.Uint64("sct_timestamp", 0, "Timestamp of logged SCT")
+	sctTimestamp      = flag.Uint64("sct_timestamp_ms", 0, "Timestamp of logged SCT")
 
 	parseErrors    = flag.Bool("parse_errors", false, "Only match certificates with parse errors")
 	nfParseErrors  = flag.Bool("non_fatal_errors", false, "Treat non-fatal parse errors as also matching (with --parse_errors)")

--- a/scanner/scanlog/scanlog.go
+++ b/scanner/scanlog/scanlog.go
@@ -45,6 +45,7 @@ var (
 	matchIssuerRegex  = flag.String("match_issuer_regex", "", "Regex to match in issuer CN")
 	precertsOnly      = flag.Bool("precerts_only", false, "Only match precerts")
 	serialNumber      = flag.String("serial_number", "", "Serial number of certificate of interest")
+	sctTimestamp      = flag.Uint64("sct_timestamp", 0, "Timestamp of logged SCT")
 
 	parseErrors    = flag.Bool("parse_errors", false, "Only match certificates with parse errors")
 	nfParseErrors  = flag.Bool("non_fatal_errors", false, "Treat non-fatal parse errors as also matching (with --parse_errors)")
@@ -175,6 +176,10 @@ func createMatcherFromFlags(logClient *client.LogClient) (interface{}, error) {
 			return nil, fmt.Errorf("Invalid serialNumber %s", *serialNumber)
 		}
 		return scanner.MatchSerialNumber{SerialNumber: sn}, nil
+	}
+	if *sctTimestamp != 0 {
+		log.Printf("Using SCT Timestamp matcher on %d (%v)", *sctTimestamp, time.Unix(0, int64(*sctTimestamp*1000000)))
+		return scanner.MatchSCTTimestamp{Timestamp: *sctTimestamp}, nil
 	}
 	certRegex, precertRegex := createRegexes(*matchSubjectRegex)
 	return scanner.MatchSubjectRegex{


### PR DESCRIPTION
This PR allows the scanner tool to search for entries with a specific timestamp, useful if all you have is an SCT.