### PR TITLE
Slightly reformat TestToMultiLogConfig

### DIFF
--- a/trillian/ctfe/config_test.go
+++ b/trillian/ctfe/config_test.go
@@ -351,13 +351,13 @@ func TestValidateLogMultiConfig(t *testing.T) {
 }
 
 func TestToMultiLogConfig(t *testing.T) {
-	var tests = []struct {
+	for _, tc := range []struct {
 		desc string
 		cfg  []*configpb.LogConfig
 		want *configpb.LogMultiConfig
 	}{
 		{
-			desc: "one valid log config",
+			desc: "ok-one-config",
 			cfg: []*configpb.LogConfig{
 				{LogId: 1, Prefix: "test"},
 			},
@@ -366,12 +366,14 @@ func TestToMultiLogConfig(t *testing.T) {
 					Backend: []*configpb.LogBackend{{Name: "default", BackendSpec: "spec"}},
 				},
 				LogConfigs: &configpb.LogConfigSet{
-					Config: []*configpb.LogConfig{{Prefix: "test", LogId: 1, LogBackendName: "default"}},
+					Config: []*configpb.LogConfig{
+						{LogId: 1, Prefix: "test", LogBackendName: "default"},
+					},
 				},
 			},
 		},
 		{
-			desc: "three valid log configs",
+			desc: "ok-three-configs",
 			cfg: []*configpb.LogConfig{
 				{LogId: 1, Prefix: "test1"},
 				{LogId: 2, Prefix: "test2"},
@@ -383,20 +385,18 @@ func TestToMultiLogConfig(t *testing.T) {
 				},
 				LogConfigs: &configpb.LogConfigSet{
 					Config: []*configpb.LogConfig{
-						{Prefix: "test1", LogId: 1, LogBackendName: "default"},
-						{Prefix: "test2", LogId: 2, LogBackendName: "default"},
-						{Prefix: "test3", LogId: 3, LogBackendName: "default"},
+						{LogId: 1, Prefix: "test1", LogBackendName: "default"},
+						{LogId: 2, Prefix: "test2", LogBackendName: "default"},
+						{LogId: 3, Prefix: "test3", LogBackendName: "default"},
 					},
 				},
 			},
 		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.desc, func(t *testing.T) {
-			got := ToMultiLogConfig(test.cfg, "spec")
-			if !proto.Equal(got, test.want) {
-				t.Errorf("TestToMultiLogConfig() got: %v, want: %v", got, test.want)
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := ToMultiLogConfig(tc.cfg, "spec")
+			if !proto.Equal(got, tc.want) {
+				t.Errorf("TestToMultiLogConfig() got: %v, want: %v", got, tc.want)
 			}
 		})
 	}

--- a/trillian/ctfe/config_test.go
+++ b/trillian/ctfe/config_test.go
@@ -435,7 +435,7 @@ func TestToMultiLogConfig(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			got := ToMultiLogConfig(tc.cfg, "spec")
 			if !proto.Equal(got, tc.want) {
-				t.Errorf("TestToMultiLogConfig()=%v, want %v", got, test.want)
+				t.Errorf("TestToMultiLogConfig()=%v, want %v", got, tc.want)
 			}
 		})
 	}

--- a/trillian/ctfe/config_test.go
+++ b/trillian/ctfe/config_test.go
@@ -386,6 +386,10 @@ func TestValidateLogMultiConfig(t *testing.T) {
 }
 
 func TestToMultiLogConfig(t *testing.T) {
+	// TODO(pavelkalinnikov): Log configs in this test are not valid (they don't
+	// have keys etc). In addition, we should have tests to ensure that valid log
+	// configs result in valid MultiLogConfig.
+
 	for _, tc := range []struct {
 		desc string
 		cfg  []*configpb.LogConfig
@@ -431,7 +435,7 @@ func TestToMultiLogConfig(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			got := ToMultiLogConfig(tc.cfg, "spec")
 			if !proto.Equal(got, tc.want) {
-        t.Errorf("TestToMultiLogConfig()=%v, want %v", got, test.want)
+				t.Errorf("TestToMultiLogConfig()=%v, want %v", got, test.want)
 			}
 		})
 	}


### PR DESCRIPTION
This PR complements #306 so that the tests are formatted similarly.