### PR TITLE
Improvements to scripts/update_changelog.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ Published 2018-06-01 14:20:32 +0000 UTC
 
 Facilities were added to the `x509` package to control whether verification checks are applied.
 
-Log server requests are now balanced using `gRPClb`. 
+Log server requests are now balanced using `gRPClb`.
 
 For Kubernetes, metrics can be published to Stackdriver monitoring.
 

--- a/scripts/update_changelog.sh
+++ b/scripts/update_changelog.sh
@@ -2,16 +2,16 @@
 #
 # Run this script from the top level directory of the ct-go repo e.g.
 # with scripts/update_changelog.sh.
-#
-# GOPATH must be set.
 
 set +e
-d=${GOPATH[0]}
 
 # Get and build the correct branch that includes markdown output
 # TODO(Martin2112): replace with upstream repo if/when aktau/github-release#81 is merged
 go get -u github.com/Martin2112/github-release
 
-# Generate the changelog
-${d}/bin/github-release info -r certificate-transparency-go -u google --markdown > CHANGELOG.md
+# Generate the changelog.
+github-release info \
+  -r certificate-transparency-go \
+  -u google \
+  --markdown > CHANGELOG.md
 

--- a/scripts/update_changelog.sh
+++ b/scripts/update_changelog.sh
@@ -10,7 +10,7 @@ d=${GOPATH[0]}
 
 # Get and build the correct branch that includes markdown output
 # TODO(Martin2112): replace with upstream repo if/when aktau/github-release#81 is merged
-go install github.com/Martin2112/github-release
+go get -u github.com/Martin2112/github-release
 
 # Generate the changelog
 ${d}/bin/github-release info -r certificate-transparency-go -u google --markdown > CHANGELOG.md

--- a/scripts/update_changelog.sh
+++ b/scripts/update_changelog.sh
@@ -1,10 +1,11 @@
-#! /bin/bash
+#!/bin/bash
 #
 # Run this script from the top level directory of the ct-go repo e.g.
 # with scripts/update_changelog.sh.
 
-# Get and build the correct branch that includes markdown output
-# TODO(Martin2112): replace with upstream repo if/when aktau/github-release#81 is merged
+# Get and build the correct fork that includes markdown output.
+# TODO(Martin2112): replace with upstream repo if/when aktau/github-release#81
+# is merged.
 go get -u github.com/Martin2112/github-release
 
 # Generate the changelog.

--- a/scripts/update_changelog.sh
+++ b/scripts/update_changelog.sh
@@ -3,8 +3,6 @@
 # Run this script from the top level directory of the ct-go repo e.g.
 # with scripts/update_changelog.sh.
 
-set +e
-
 # Get and build the correct branch that includes markdown output
 # TODO(Martin2112): replace with upstream repo if/when aktau/github-release#81 is merged
 go get -u github.com/Martin2112/github-release


### PR DESCRIPTION
- `go install` only works if you already have the source code on your machine. `go get` will work regardless.
  - I've added `-u` so that it updates to the latest version.
- Rely on `$PATH` containing `$GOPATH/bin` to find Go binaries.
  - Not an unreasonable expectation.
- Remove `set +e` from update_changelog.sh.
  - There's no need to continue running the script when an error occurs.
- Format update_changelog.sh.
- Regenerate CHANGELOG.md with the latest version of github.com/Martin2112/github-release.