### PR TITLE
[Migrillian] Make admission control laxer

### DIFF
--- a/serialization.go
+++ b/serialization.go
@@ -250,7 +250,7 @@ func IsPreIssuer(issuer *x509.Certificate) bool {
 
 // RawLogEntryFromLeaf converts a LeafEntry object (which has the raw leaf data
 // after JSON parsing) into a RawLogEntry object (i.e. a TLS-parsed structure).
-func RawLogEntryFromLeaf(entry *LeafEntry, index int64) (*RawLogEntry, error) {
+func RawLogEntryFromLeaf(index int64, entry *LeafEntry) (*RawLogEntry, error) {
 	ret := RawLogEntry{Index: index}
 	if rest, err := tls.Unmarshal(entry.LeafInput, &ret.Leaf); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal MerkleTreeLeaf: %v", err)
@@ -331,7 +331,7 @@ func (rle *RawLogEntry) ToLogEntry() (*LogEntry, error) {
 // Note that this function may return a valid LogEntry object and a non-nil
 // error value, when the error indicates a non-fatal parsing error.
 func LogEntryFromLeaf(index int64, leaf *LeafEntry) (*LogEntry, error) {
-	rle, err := RawLogEntryFromLeaf(leaf, index)
+	rle, err := RawLogEntryFromLeaf(index, leaf)
 	if err != nil {
 		return nil, err
 	}

--- a/trillian/migrillian/core/util.go
+++ b/trillian/migrillian/core/util.go
@@ -15,14 +15,15 @@
 package core
 
 import (
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"io/ioutil"
 
+	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
 	ct "github.com/google/certificate-transparency-go"
 	"github.com/google/certificate-transparency-go/trillian/migrillian/configpb"
-	"github.com/google/certificate-transparency-go/trillian/util"
 	"github.com/google/certificate-transparency-go/x509"
 	"github.com/google/trillian"
 )
@@ -59,27 +60,25 @@ func ValidateConfig(cfg *configpb.MigrationConfig) error {
 }
 
 func buildLogLeaf(logPrefix string, index int64, entry *ct.LeafEntry) (*trillian.LogLeaf, error) {
-	logEntry, err := ct.LogEntryFromLeaf(index, entry)
-	if x509.IsFatal(err) {
-		return nil, fmt.Errorf("failed to build LogEntry[%d]: %v", index, err)
-	}
-	// TODO(pavelkalinnikov): Verify the cert chain.
-
-	var cert ct.ASN1Cert
-	isPrecert := false
-	switch {
-	case logEntry.X509Cert != nil:
-		cert = ct.ASN1Cert{Data: logEntry.X509Cert.Raw}
-	case logEntry.Precert != nil:
-		isPrecert = true
-		cert = logEntry.Precert.Submitted
-	default:
-		return nil, fmt.Errorf("entry at %d is neither cert nor pre-cert", index)
-	}
-
-	leaf, err := util.BuildLogLeaf(logPrefix, logEntry.Leaf, logEntry.Index, cert, logEntry.Chain, isPrecert)
+	rle, err := ct.RawLogEntryFromLeaf(entry, index)
 	if err != nil {
-		return nil, fmt.Errorf("failed to build LogLeaf: %v", err)
+		return nil, err
 	}
-	return &leaf, nil
+
+	// Don't return on x509 parsing errors because we want to migrate this log
+	// entry as is. But log the error so that it can be flagged by monitoring.
+	if _, err = rle.ToLogEntry(); x509.IsFatal(err) {
+		glog.Errorf("%s: index=%d: x509 fatal error: %v", logPrefix, err)
+	} else if err != nil {
+		glog.Infof("%s: index=%d: x509 non-fatal error: %v", logPrefix, err)
+	}
+	// TODO(pavelkalinnikov): Verify cert chain if error is nil or non-fatal.
+
+	leafIDHash := sha256.Sum256(rle.Cert.Data)
+	return &trillian.LogLeaf{
+		LeafValue:        entry.LeafInput,
+		ExtraData:        entry.ExtraData,
+		LeafIndex:        index,
+		LeafIdentityHash: leafIDHash[:],
+	}, nil
 }

--- a/trillian/migrillian/core/util.go
+++ b/trillian/migrillian/core/util.go
@@ -68,9 +68,9 @@ func buildLogLeaf(logPrefix string, index int64, entry *ct.LeafEntry) (*trillian
 	// Don't return on x509 parsing errors because we want to migrate this log
 	// entry as is. But log the error so that it can be flagged by monitoring.
 	if _, err = rle.ToLogEntry(); x509.IsFatal(err) {
-		glog.Errorf("%s: index=%d: x509 fatal error: %v", logPrefix, err)
+		glog.Errorf("%s: index=%d: x509 fatal error: %v", logPrefix, index, err)
 	} else if err != nil {
-		glog.Infof("%s: index=%d: x509 non-fatal error: %v", logPrefix, err)
+		glog.Infof("%s: index=%d: x509 non-fatal error: %v", logPrefix, index, err)
 	}
 	// TODO(pavelkalinnikov): Verify cert chain if error is nil or non-fatal.
 

--- a/trillian/migrillian/core/util.go
+++ b/trillian/migrillian/core/util.go
@@ -60,7 +60,7 @@ func ValidateConfig(cfg *configpb.MigrationConfig) error {
 }
 
 func buildLogLeaf(logPrefix string, index int64, entry *ct.LeafEntry) (*trillian.LogLeaf, error) {
-	rle, err := ct.RawLogEntryFromLeaf(entry, index)
+	rle, err := ct.RawLogEntryFromLeaf(index, entry)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Different logs use different x509 parsers, so when Migrillian populates a mirror
it might encounter a certificate/chain that it can't parse. This change makes
admission control in this case laxer: Migrillian only requires that the TLS
encoding of the entry complies with RFC6962.