### PR TITLE
scanner: work with unparsed log entries

### DIFF
--- a/ctutil/sctscan/sctscan.go
+++ b/ctutil/sctscan/sctscan.go
@@ -128,7 +128,7 @@ func (e EmbeddedSCTMatcher) PrecertificateMatches(*ct.Precertificate) bool {
 func checkCertWithEmbeddedSCT(ctx context.Context, logsByKey map[[sha256.Size]byte]*ctutil.LogInfo, checkInclusion bool, rawEntry *ct.RawLogEntry) {
 	entry, err := rawEntry.ToLogEntry()
 	if x509.IsFatal(err) {
-		glog.Errorf("[%d] Internal error: failed to parse cert in entry: %v", entry.Index, err)
+		glog.Errorf("[%d] Internal error: failed to parse cert in entry: %v", rawEntry.Index, err)
 		return
 	}
 

--- a/ctutil/sctscan/sctscan.go
+++ b/ctutil/sctscan/sctscan.go
@@ -127,7 +127,7 @@ func (e EmbeddedSCTMatcher) PrecertificateMatches(*ct.Precertificate) bool {
 // Here, we only expect to get certificates that have embedded SCT lists.
 func checkCertWithEmbeddedSCT(ctx context.Context, logsByKey map[[sha256.Size]byte]*ctutil.LogInfo, checkInclusion bool, rawEntry *ct.RawLogEntry) {
 	entry, err := rawEntry.ToLogEntry()
-	if err != nil {
+	if x509.IsFatal(err) {
 		glog.Errorf("[%d] Internal error: failed to parse cert in entry: %v", entry.Index, err)
 		return
 	}

--- a/gossip/minimal/goshawk.go
+++ b/gossip/minimal/goshawk.go
@@ -182,7 +182,13 @@ func (hawk *Goshawk) Scanner(ctx context.Context) {
 	}
 }
 
-func (hawk *Goshawk) foundCert(entry *ct.LogEntry) {
+func (hawk *Goshawk) foundCert(rawEntry *ct.RawLogEntry) {
+	entry, err := rawEntry.ToLogEntry()
+	if err != nil {
+		glog.Errorf("Scanner(%s): failed to parse cert from entry at %d: %v", hawk.dest.Name, entry.Index, err)
+		return
+	}
+
 	if entry.X509Cert == nil {
 		glog.Errorf("Internal error: no X509Cert entry in %+v", entry)
 		return
@@ -203,7 +209,7 @@ func (hawk *Goshawk) foundCert(entry *ct.LogEntry) {
 	origin.sths <- sthInfo
 }
 
-func foundPrecert(entry *ct.LogEntry) {
+func foundPrecert(entry *ct.RawLogEntry) {
 	glog.Errorf("Internal error: found pre-cert! %+v", entry)
 }
 

--- a/gossip/minimal/goshawk.go
+++ b/gossip/minimal/goshawk.go
@@ -184,7 +184,7 @@ func (hawk *Goshawk) Scanner(ctx context.Context) {
 
 func (hawk *Goshawk) foundCert(rawEntry *ct.RawLogEntry) {
 	entry, err := rawEntry.ToLogEntry()
-	if err != nil {
+	if x509.IsFatal(err) {
 		glog.Errorf("Scanner(%s): failed to parse cert from entry at %d: %v", hawk.dest.Name, entry.Index, err)
 		return
 	}

--- a/gossip/minimal/goshawk.go
+++ b/gossip/minimal/goshawk.go
@@ -185,7 +185,7 @@ func (hawk *Goshawk) Scanner(ctx context.Context) {
 func (hawk *Goshawk) foundCert(rawEntry *ct.RawLogEntry) {
 	entry, err := rawEntry.ToLogEntry()
 	if x509.IsFatal(err) {
-		glog.Errorf("Scanner(%s): failed to parse cert from entry at %d: %v", hawk.dest.Name, entry.Index, err)
+		glog.Errorf("Scanner(%s): failed to parse cert from entry at %d: %v", hawk.dest.Name, rawEntry.Index, err)
 		return
 	}
 

--- a/preload/preloader/preloader.go
+++ b/preload/preloader/preloader.go
@@ -32,6 +32,7 @@ import (
 	"github.com/google/certificate-transparency-go/jsonclient"
 	"github.com/google/certificate-transparency-go/preload"
 	"github.com/google/certificate-transparency-go/scanner"
+	"github.com/google/certificate-transparency-go/x509"
 )
 
 var (
@@ -226,7 +227,7 @@ func main() {
 
 	addChainFunc := func(rawEntry *ct.RawLogEntry) {
 		entry, err := rawEntry.ToLogEntry()
-		if err != nil {
+		if x509.IsFatal(err) {
 			glog.Errorf("Failed to parse cert at %d: %v", rawEntry.Index, err)
 			return
 		}
@@ -234,7 +235,7 @@ func main() {
 	}
 	addPreChainFunc := func(rawEntry *ct.RawLogEntry) {
 		entry, err := rawEntry.ToLogEntry()
-		if err != nil {
+		if x509.IsFatal(err) {
 			glog.Errorf("Failed to parse precert at %d: %v", rawEntry.Index, err)
 			return
 		}

--- a/preload/preloader/preloader.go
+++ b/preload/preloader/preloader.go
@@ -224,10 +224,20 @@ func main() {
 		}()
 	}
 
-	addChainFunc := func(entry *ct.LogEntry) {
+	addChainFunc := func(rawEntry *ct.RawLogEntry) {
+		entry, err := rawEntry.ToLogEntry()
+		if err != nil {
+			glog.Errorf("Failed to parse cert at %d: %v", rawEntry.Index, err)
+			return
+		}
 		certs <- entry
 	}
-	addPreChainFunc := func(entry *ct.LogEntry) {
+	addPreChainFunc := func(rawEntry *ct.RawLogEntry) {
+		entry, err := rawEntry.ToLogEntry()
+		if err != nil {
+			glog.Errorf("Failed to parse precert at %d: %v", rawEntry.Index, err)
+			return
+		}
 		precerts <- entry
 	}
 	scanner.Scan(ctx, addChainFunc, addPreChainFunc)

--- a/scanner/scanlog/scanlog.go
+++ b/scanner/scanlog/scanlog.go
@@ -61,13 +61,14 @@ var (
 	dumpDir     = flag.String("dump_dir", "", "Directory to store matched certificates in")
 )
 
-func dumpData(entry *ct.LogEntry) {
+func dumpData(entry *ct.RawLogEntry) {
 	if *dumpDir == "" {
 		return
 	}
 	chainFrom := 0
 	prefix := "unknown"
-	if entry.Leaf.TimestampedEntry.EntryType == ct.X509LogEntryType {
+	switch entry.Leaf.TimestampedEntry.EntryType {
+	case ct.X509LogEntryType:
 		prefix = "cert"
 		name := fmt.Sprintf("%s-%014d-leaf.der", prefix, entry.Index)
 		filename := path.Join(*dumpDir, name)
@@ -75,7 +76,7 @@ func dumpData(entry *ct.LogEntry) {
 		if err != nil {
 			log.Printf("Failed to dump data for %s at index %d: %v", prefix, entry.Index, err)
 		}
-	} else if entry.Leaf.TimestampedEntry.EntryType == ct.PrecertLogEntryType {
+	case ct.PrecertLogEntryType:
 		prefix = "precert"
 		// For a pre-certificate the TimestampedEntry only holds the TBSCertificate, but
 		// the Chain data has the full pre-certificate as the first entry.
@@ -89,7 +90,7 @@ func dumpData(entry *ct.LogEntry) {
 			log.Printf("Failed to dump data for %s at index %d: %v", prefix, entry.Index, err)
 		}
 		chainFrom = 1
-	} else {
+	default:
 		log.Printf("Unknown log entry type %d", entry.Leaf.TimestampedEntry.EntryType)
 	}
 	for ii := chainFrom; ii < len(entry.Chain); ii++ {
@@ -104,25 +105,26 @@ func dumpData(entry *ct.LogEntry) {
 
 // Prints out a short bit of info about |cert|, found at |index| in the
 // specified log
-func logCertInfo(entry *ct.LogEntry) {
-	if entry.X509Cert != nil {
-		log.Printf("Process cert at index %d: CN: '%s'", entry.Index, entry.X509Cert.Subject.CommonName)
-		dumpData(entry)
+func logCertInfo(entry *ct.RawLogEntry) {
+	parsedEntry, err := entry.ToLogEntry()
+	if err != nil || parsedEntry.X509Cert == nil {
+		log.Printf("Process cert at index %d: <unparsed: %v>", entry.Index, err)
 	} else {
-		log.Printf("Process cert at index %d: <unparsed>", entry.Index)
+		log.Printf("Process cert at index %d: CN: '%s'", entry.Index, parsedEntry.X509Cert.Subject.CommonName)
 	}
+	dumpData(entry)
 }
 
 // Prints out a short bit of info about |precert|, found at |index| in the
 // specified log
-func logPrecertInfo(entry *ct.LogEntry) {
-	if entry.Precert != nil {
-		log.Printf("Process precert at index %d: CN: '%s' Issuer: %s", entry.Index,
-			entry.Precert.TBSCertificate.Subject.CommonName, entry.Precert.TBSCertificate.Issuer.CommonName)
-		dumpData(entry)
+func logPrecertInfo(entry *ct.RawLogEntry) {
+	parsedEntry, err := entry.ToLogEntry()
+	if err != nil || parsedEntry.Precert == nil {
+		log.Printf("Process precert at index %d: <unparsed: %v>", entry.Index, err)
 	} else {
-		log.Printf("Process precert at index %d: <unparsed>", entry.Index)
+		log.Printf("Process precert at index %d: CN: '%s' Issuer: %s", entry.Index, parsedEntry.Precert.TBSCertificate.Subject.CommonName, parsedEntry.Precert.TBSCertificate.Issuer.CommonName)
 	}
+	dumpData(entry)
 }
 
 func chainToString(certs []ct.ASN1Cert) string {
@@ -135,7 +137,7 @@ func chainToString(certs []ct.ASN1Cert) string {
 	return base64.StdEncoding.EncodeToString(output)
 }
 
-func logFullChain(entry *ct.LogEntry) {
+func logFullChain(entry *ct.RawLogEntry) {
 	log.Printf("Index %d: Chain: %s", entry.Index, chainToString(entry.Chain))
 }
 

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -118,7 +118,7 @@ func (s *Scanner) processEntry(info entryInfo, foundCert func(*ct.RawLogEntry), 
 }
 
 func (s *Scanner) processMatcherEntry(matcher Matcher, info entryInfo, foundCert func(*ct.RawLogEntry), foundPrecert func(*ct.RawLogEntry)) error {
-	rawLogEntry, err := ct.RawLogEntryFromLeaf(&info.entry, info.index)
+	rawLogEntry, err := ct.RawLogEntryFromLeaf(info.index, &info.entry)
 	if err != nil {
 		return fmt.Errorf("failed to build raw log entry %d: %v", info.index, err)
 	}
@@ -155,7 +155,7 @@ func (s *Scanner) processMatcherLeafEntry(matcher LeafMatcher, info entryInfo, f
 		return nil
 	}
 
-	rawLogEntry, err := ct.RawLogEntryFromLeaf(&info.entry, info.index)
+	rawLogEntry, err := ct.RawLogEntryFromLeaf(info.index, &info.entry)
 	if rawLogEntry == nil {
 		return fmt.Errorf("failed to build raw log entry %d: %v", info.index, err)
 	}

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -159,7 +159,7 @@ func (s *Scanner) processMatcherLeafEntry(matcher LeafMatcher, info entryInfo, f
 	if rawLogEntry == nil {
 		return fmt.Errorf("failed to build raw log entry %d: %v", info.index, err)
 	}
-	switch rawLogEntry.Leaf.TimestampedEntry.EntryType {
+	switch eType := rawLogEntry.Leaf.TimestampedEntry.EntryType; eType {
 	case ct.X509LogEntryType:
 		if s.opts.PrecertOnly {
 			// Only interested in precerts and this is an X.509 cert, early-out.
@@ -170,7 +170,7 @@ func (s *Scanner) processMatcherLeafEntry(matcher LeafMatcher, info entryInfo, f
 		foundPrecert(rawLogEntry)
 		atomic.AddInt64(&s.precertsSeen, 1)
 	default:
-		return fmt.Errorf("saw unknown entry type: %v", rawLogEntry.Leaf.TimestampedEntry.EntryType)
+		return fmt.Errorf("saw unknown entry type: %v", eType)
 	}
 	return nil
 }

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -104,7 +104,7 @@ func (s *Scanner) isCertErrorFatal(err error, logEntry *ct.LogEntry, index int64
 }
 
 // Processes the given entry in the specified log.
-func (s *Scanner) processEntry(info entryInfo, foundCert func(*ct.LogEntry), foundPrecert func(*ct.LogEntry)) error {
+func (s *Scanner) processEntry(info entryInfo, foundCert func(*ct.RawLogEntry), foundPrecert func(*ct.RawLogEntry)) error {
 	atomic.AddInt64(&s.certsProcessed, 1)
 
 	switch matcher := s.opts.Matcher.(type) {
@@ -117,8 +117,13 @@ func (s *Scanner) processEntry(info entryInfo, foundCert func(*ct.LogEntry), fou
 	}
 }
 
-func (s *Scanner) processMatcherEntry(matcher Matcher, info entryInfo, foundCert func(*ct.LogEntry), foundPrecert func(*ct.LogEntry)) error {
-	logEntry, err := ct.LogEntryFromLeaf(info.index, &info.entry)
+func (s *Scanner) processMatcherEntry(matcher Matcher, info entryInfo, foundCert func(*ct.RawLogEntry), foundPrecert func(*ct.RawLogEntry)) error {
+	rawLogEntry, err := ct.RawLogEntryFromLeaf(&info.entry, info.index)
+	if err != nil {
+		return fmt.Errorf("failed to build raw log entry %d: %v", info.index, err)
+	}
+	// Matcher instances need the parsed [pre-]certificate.
+	logEntry, err := rawLogEntry.ToLogEntry()
 	if s.isCertErrorFatal(err, logEntry, info.index) {
 		return fmt.Errorf("failed to parse [pre-]certificate in MerkleTreeLeaf[%d]: %v", info.index, err)
 	}
@@ -131,12 +136,12 @@ func (s *Scanner) processMatcherEntry(matcher Matcher, info entryInfo, foundCert
 		}
 		if matcher.CertificateMatches(logEntry.X509Cert) {
 			atomic.AddInt64(&s.certsMatched, 1)
-			foundCert(logEntry)
+			foundCert(rawLogEntry)
 		}
 	case logEntry.Precert != nil:
 		if matcher.PrecertificateMatches(logEntry.Precert) {
 			atomic.AddInt64(&s.certsMatched, 1)
-			foundPrecert(logEntry)
+			foundPrecert(rawLogEntry)
 		}
 		atomic.AddInt64(&s.precertsSeen, 1)
 	default:
@@ -145,27 +150,27 @@ func (s *Scanner) processMatcherEntry(matcher Matcher, info entryInfo, foundCert
 	return nil
 }
 
-func (s *Scanner) processMatcherLeafEntry(matcher LeafMatcher, info entryInfo, foundCert func(*ct.LogEntry), foundPrecert func(*ct.LogEntry)) error {
+func (s *Scanner) processMatcherLeafEntry(matcher LeafMatcher, info entryInfo, foundCert func(*ct.RawLogEntry), foundPrecert func(*ct.RawLogEntry)) error {
 	if !matcher.Matches(&info.entry) {
 		return nil
 	}
 
-	logEntry, err := ct.LogEntryFromLeaf(info.index, &info.entry)
-	if logEntry == nil {
-		return fmt.Errorf("failed to build log entry %d: %v", info.index, err)
+	rawLogEntry, err := ct.RawLogEntryFromLeaf(&info.entry, info.index)
+	if rawLogEntry == nil {
+		return fmt.Errorf("failed to build raw log entry %d: %v", info.index, err)
 	}
-	switch {
-	case logEntry.X509Cert != nil:
+	switch rawLogEntry.Leaf.TimestampedEntry.EntryType {
+	case ct.X509LogEntryType:
 		if s.opts.PrecertOnly {
 			// Only interested in precerts and this is an X.509 cert, early-out.
 			return nil
 		}
-		foundCert(logEntry)
-	case logEntry.Precert != nil:
-		foundPrecert(logEntry)
+		foundCert(rawLogEntry)
+	case ct.PrecertLogEntryType:
+		foundPrecert(rawLogEntry)
 		atomic.AddInt64(&s.precertsSeen, 1)
 	default:
-		return fmt.Errorf("saw unknown entry type: %v", logEntry.Leaf.TimestampedEntry.EntryType)
+		return fmt.Errorf("saw unknown entry type: %v", rawLogEntry.Leaf.TimestampedEntry.EntryType)
 	}
 	return nil
 }
@@ -173,7 +178,7 @@ func (s *Scanner) processMatcherLeafEntry(matcher LeafMatcher, info entryInfo, f
 // Worker function to match certs.
 // Accepts MatcherJobs over the entries channel, and processes them.
 // Returns true over the done channel when the entries channel is closed.
-func (s *Scanner) matcherJob(entries <-chan entryInfo, foundCert func(*ct.LogEntry), foundPrecert func(*ct.LogEntry)) {
+func (s *Scanner) matcherJob(entries <-chan entryInfo, foundCert func(*ct.RawLogEntry), foundPrecert func(*ct.RawLogEntry)) {
 	for e := range entries {
 		if err := s.processEntry(e, foundCert, foundPrecert); err != nil {
 			atomic.AddInt64(&s.unparsableEntries, 1)
@@ -244,13 +249,13 @@ func (s *Scanner) logThroughput(treeSize int64, stop <-chan bool) {
 // LogEntry, which includes the index of the entry and the certificate.
 // For each precert found, calls foundPrecert with the corresponding LogEntry,
 // which includes the index of the entry and the precert.
-func (s *Scanner) Scan(ctx context.Context, foundCert func(*ct.LogEntry), foundPrecert func(*ct.LogEntry)) error {
+func (s *Scanner) Scan(ctx context.Context, foundCert func(*ct.RawLogEntry), foundPrecert func(*ct.RawLogEntry)) error {
 	_, err := s.ScanLog(ctx, foundCert, foundPrecert)
 	return err
 }
 
 // ScanLog performs a scan against the Log, returning the count of scanned entries.
-func (s *Scanner) ScanLog(ctx context.Context, foundCert func(*ct.LogEntry), foundPrecert func(*ct.LogEntry)) (int64, error) {
+func (s *Scanner) ScanLog(ctx context.Context, foundCert func(*ct.RawLogEntry), foundPrecert func(*ct.RawLogEntry)) (int64, error) {
 	glog.V(1).Infof("Starting up Scanner...")
 	s.certsProcessed = 0
 	s.certsMatched = 0

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -210,11 +210,19 @@ func TestScannerEndToEnd(t *testing.T) {
 	var matchedPrecerts list.List
 
 	ctx := context.Background()
-	err = scanner.Scan(ctx, func(e *ct.LogEntry) {
+	err = scanner.Scan(ctx, func(re *ct.RawLogEntry) {
 		// Annoyingly we can't t.Fatal() in here, as this is run in another go
 		// routine
+		e, _ := re.ToLogEntry()
+		if e.X509Cert == nil {
+			return
+		}
 		matchedCerts.PushBack(*e.X509Cert)
-	}, func(e *ct.LogEntry) {
+	}, func(re *ct.RawLogEntry) {
+		e, _ := re.ToLogEntry()
+		if e.X509Cert == nil {
+			return
+		}
 		matchedPrecerts.PushBack(*e.Precert)
 	})
 


### PR DESCRIPTION
This allows entries that don't parse to be processed
and dumped out for analysis.

Use RawLogEntry throughout, and only convert to LogEntry
in places that need the X.509 certificate details.