### PR TITLE
Add Pool of executors

### DIFF
--- a/util/exepool/client.go
+++ b/util/exepool/client.go
@@ -1,0 +1,107 @@
+package exepool
+
+import (
+	"context"
+	"sync"
+
+	"golang.org/x/sync/semaphore"
+)
+
+// Client can be used to submit Jobs to a Pool safely and concurrently.
+type Client struct {
+	pool *Pool
+	done bool
+}
+
+// Add submits the Job to the Pool which created this Client. It is safe to run
+// multiple Adds concurrently. Once submitted, the Job is guaranteed to be run.
+//
+// It is the caller's responsibility to make sure that the Job doesn't block
+// Pool when it Stops (for example, the caller might bake Context into its
+// Jobs, and cancel it if they need to terminate the Pool quickly).
+//
+// Warning: Never call Add after Close, as it can panic.
+func (c *Client) Add(ctx context.Context, job Job) error {
+	select {
+	// Note: This write will panic if the channel is closed. However, this won't
+	// happen as soon as there is at least one non-closed Client (including c).
+	case c.pool.jobs <- job:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// Close detaches this Client from the Pool. The call is idempotent. The Client
+// must not be used after Close.
+func (c *Client) Close() {
+	c.pool.closeClient(c)
+}
+
+// SyncClient is a wrapper around Client that in addition:
+//  - limits the number of simultaneously submitted Jobs
+//  - tracks completion of the Jobs, and allows to wait for them
+type SyncClient struct {
+	c   *Client
+	sem *semaphore.Weighted
+	wg  sync.WaitGroup
+}
+
+// NewSyncClient creates a SyncClient based on the lightweight Client. The
+// resulting client limits the number of simultaneously submitted Jobs to
+// maxInFlight (but there is no limit if maxInFlight <= 0).
+func NewSyncClient(client *Client, maxInFlight int) *SyncClient {
+	sc := SyncClient{c: client}
+	if maxInFlight > 0 {
+		sc.sem = semaphore.NewWeighted(int64(maxInFlight))
+	}
+	return &sc
+}
+
+// Add is like Client.Add, but in addition it will first wait until the number
+// of Jobs submitted by this client is below maxInFlight.
+func (sc *SyncClient) Add(ctx context.Context, job Job) error {
+	if err := sc.acquire(ctx); err != nil {
+		return err
+	}
+
+	wrapped := Job(func() {
+		defer sc.release()
+		job()
+	})
+
+	err := sc.c.Add(ctx, wrapped)
+	if err != nil {
+		sc.release()
+	}
+	return err
+}
+
+func (sc *SyncClient) acquire(ctx context.Context) error {
+	if sem := sc.sem; sem != nil {
+		if err := sem.Acquire(ctx, 1); err != nil {
+			return err
+		}
+	}
+	sc.wg.Add(1)
+	return nil
+}
+
+func (sc *SyncClient) release() {
+	if sem := sc.sem; sem != nil {
+		sc.sem.Release(1)
+	}
+	sc.wg.Done()
+}
+
+// Wait blocks until there is no Jobs in flight.
+func (sc *SyncClient) Wait() {
+	sc.wg.Wait()
+}
+
+// Close is like Client.Close, but in addition it waits until the Pool
+// completes all the Jobs that this client has submitted to it.
+func (sc *SyncClient) Close() {
+	sc.c.Close()
+	sc.Wait()
+}

--- a/util/exepool/client.go
+++ b/util/exepool/client.go
@@ -1,3 +1,17 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package exepool
 
 import (

--- a/util/exepool/pool.go
+++ b/util/exepool/pool.go
@@ -1,3 +1,17 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package exepool provides a pool of parallel executors.
 // TODO(pavelkalinnikov): Move it to Trillian repo, and also use there.
 package exepool

--- a/util/exepool/pool.go
+++ b/util/exepool/pool.go
@@ -1,0 +1,105 @@
+// Package exepool provides a pool of parallel executors.
+// TODO(pavelkalinnikov): Move it to Trillian repo, and also use there.
+package exepool
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+)
+
+// Errors that the Pool API might return.
+var (
+	ErrPoolStopped   = errors.New("pool stopped")
+	ErrActiveClients = errors.New("there are active clients")
+)
+
+// Job is an arbitrary function that can be run by executors.
+type Job func()
+
+// Pool is a collection of parallel executors that can run arbitrary Jobs.
+type Pool struct {
+	execs int
+	jobs  chan Job
+	wg    sync.WaitGroup
+
+	mu         sync.Mutex
+	clients    int
+	chanClosed bool
+}
+
+// New creates a new Pool which consists of execs parallel executor goroutines,
+// and has a buffer of buf incoming jobs. Note that if buf == 0 then there is
+// no buffer, and the Jobs get directly to executors (possibly after waiting).
+func New(execs, buf int) (*Pool, error) {
+	if execs <= 0 {
+		return nil, fmt.Errorf("Num of executors %d <= 0, want > 0", execs)
+	} else if buf < 0 {
+		return nil, fmt.Errorf("Buffer size %d < 0, want >= 0", buf)
+	}
+	jobs := make(chan Job, buf)
+	return &Pool{execs: execs, jobs: jobs}, nil
+}
+
+// NewClient creates a new Client submitting Jobs to this Pool.
+func (p *Pool) NewClient() (*Client, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.chanClosed {
+		return nil, ErrPoolStopped
+	}
+	p.clients++
+	return &Client{pool: p}, nil
+}
+
+// closeClient closes a Client created by the NewClient method.
+func (p *Pool) closeClient(c *Client) {
+	if c.done { // Prevent decreasing the counter twice.
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	c.done = true
+	p.clients--
+}
+
+// Start starts processing the Jobs, and returns.
+func (p *Pool) Start() {
+	for i, e := 0, p.execs; i < e; i++ {
+		p.wg.Add(1)
+		go func() {
+			defer p.wg.Done()
+			for job := range p.jobs {
+				job()
+			}
+		}()
+	}
+}
+
+// Stop waits until all pending Jobs are executed, and permanently stops the
+// execution. Stop can only be called if all Clients of this Pool are closed,
+// otherwise it will return ErrActiveClients. The Pool must not be used after a
+// successful Stop (except for maybe calling Stop again, it is idempotent).
+func (p *Pool) Stop() error {
+	if err := p.closeIfNoClients(); err != nil {
+		return err
+	}
+	// Now the jobs channel is closed, but the executors might still be running
+	// some Jobs, and there might be pending ones if buffer size is > 0. Wait
+	// until all the Jobs are drained.
+	p.wg.Wait()
+	return nil
+}
+
+func (p *Pool) closeIfNoClients() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.chanClosed {
+		return nil
+	} else if p.clients != 0 {
+		return ErrActiveClients
+	}
+	p.chanClosed = true
+	close(p.jobs)
+	return nil
+}

--- a/util/exepool/pool_test.go
+++ b/util/exepool/pool_test.go
@@ -1,3 +1,17 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package exepool
 
 import (

--- a/util/exepool/pool_test.go
+++ b/util/exepool/pool_test.go
@@ -1,0 +1,195 @@
+package exepool
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestNewPool(t *testing.T) {
+	for _, tc := range []struct {
+		desc    string
+		execs   int
+		buf     int
+		wantErr string
+	}{
+		{desc: "neg-execs", execs: -10, wantErr: "Num of executors -10 <= 0"},
+		{desc: "zero-execs", execs: 0, wantErr: "Num of executors 0 <= 0"},
+		{desc: "neg-buf", execs: 1, buf: -10, wantErr: "Buffer size -10 < 0"},
+		{desc: "ok-no-buf", execs: 3},
+		{desc: "ok-buf", execs: 2, buf: 10},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			pool, err := New(tc.execs, tc.buf)
+			if len(tc.wantErr) > 0 && (err == nil || !strings.Contains(err.Error(), tc.wantErr)) {
+				t.Errorf("New(): err=%v, want err containing %v", err, tc.wantErr)
+			} else if len(tc.wantErr) == 0 && err != nil {
+				t.Errorf("New(): err=%v, want nil", err)
+			}
+			if err != nil {
+				return
+			}
+			if pool == nil {
+				t.Fatalf("Pool is nil")
+			}
+
+			pool.Start()
+			if err := pool.Stop(); err != nil {
+				t.Errorf("Stop(): %v", err)
+			}
+		})
+	}
+}
+
+func TestPoolStop(t *testing.T) {
+	for _, tc := range []struct {
+		desc    string
+		clients int
+		closed  int
+		wantErr error
+	}{
+		{desc: "no-clients"},
+		{desc: "1-not-closed", clients: 1, wantErr: ErrActiveClients},
+		{desc: "many-not-closed", clients: 20, wantErr: ErrActiveClients},
+		{desc: "1-closed", clients: 1, closed: 1},
+		{desc: "some-not-closed", clients: 20, closed: 11, wantErr: ErrActiveClients},
+		{desc: "almost-all-closed", clients: 20, closed: 19, wantErr: ErrActiveClients},
+		{desc: "all-closed", clients: 20, closed: 20},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			pool, err := New(5, 0)
+			if err != nil {
+				t.Fatalf("pool.New(): %v", err)
+			}
+			pool.Start()
+
+			clients := make([]*Client, tc.clients)
+			for i := 0; i < tc.clients; i++ {
+				var err error
+				clients[i], err = pool.NewClient()
+				if err != nil {
+					t.Fatalf("NewClient(): %v", err)
+				}
+			}
+
+			for i := 0; i < tc.closed; i++ {
+				clients[i].Close()
+				clients[i].Close()
+				clients[i].Close() // Also test idempotence.
+			}
+			if err, want := pool.Stop(), tc.wantErr; err != want {
+				t.Errorf("Stop(): err=%v, want %v", err, want)
+			}
+
+			// Now close the rest of the clients, the Pool should become stoppable.
+			for i := tc.closed; i < tc.clients; i++ {
+				clients[i].Close()
+			}
+			if err := pool.Stop(); err != nil {
+				t.Errorf("Stop(): err=%v, want nil", err)
+			}
+
+			// Make sure we can't add clients after stopping the Pool.
+			if _, err := pool.NewClient(); err != ErrPoolStopped {
+				t.Errorf("NewClient(): err=%v, want %v", err, ErrPoolStopped)
+			}
+		})
+	}
+}
+
+func TestClient(t *testing.T) {
+	ctx := context.Background()
+	pool, err := New(10, 0)
+	if err != nil {
+		t.Fatalf("New(): %v", err)
+	}
+	pool.Start()
+
+	cli, err := pool.NewClient()
+	if err != nil {
+		t.Fatalf("NewClient(): %v", err)
+	}
+
+	var sum int32
+	for i := int32(1); i <= 20; i++ {
+		i := i
+		cli.Add(ctx, Job(func() {
+			atomic.AddInt32(&sum, i)
+		}))
+	}
+	cli.Close()
+	if err := pool.Stop(); err != nil {
+		t.Errorf("Stop(): %v", err)
+	}
+
+	if got, want := sum, int32(210); got != want {
+		t.Errorf("sum=%d, want %d", got, want)
+	}
+}
+
+func TestSyncClient(t *testing.T) {
+	for _, tc := range []struct {
+		desc        string
+		execs       int
+		buf         int
+		maxInFlight int
+		blockedJobs int
+	}{
+		{desc: "no-in-flight-limit", execs: 10, buf: 0, maxInFlight: 0, blockedJobs: 10},
+		{desc: "no-in-flight-limit-buf", execs: 10, buf: 7, maxInFlight: 0, blockedJobs: 17},
+		{desc: "max-in-flight-5", execs: 10, buf: 0, maxInFlight: 5, blockedJobs: 5},
+		{desc: "max-in-flight-5-buf", execs: 3, buf: 7, maxInFlight: 5, blockedJobs: 5},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			ctx := context.Background()
+			pool, err := New(tc.execs, tc.buf)
+			if err != nil {
+				t.Fatalf("New(): %v", err)
+			}
+			pool.Start()
+			defer pool.Stop()
+
+			cli, err := pool.NewClient()
+			if err != nil {
+				t.Fatalf("NewClient(): %v", err)
+			}
+			scli := NewSyncClient(cli, tc.maxInFlight)
+
+			// Run max allowed number of blocking jobs.
+			ctx1, cancel1 := context.WithCancel(ctx)
+			for i := 0; i < tc.blockedJobs; i++ {
+				scli.Add(ctx, Job(func() {
+					<-ctx1.Done()
+				}))
+			}
+
+			// At this point there is no quota/executors/buffer for accepting a new
+			// Job, so Add should block and return with timeout.
+			done := false
+			ctx2, cancel2 := context.WithTimeout(ctx, 5*time.Millisecond)
+			job := Job(func() { done = true })
+			if err := scli.Add(ctx2, job); err != context.DeadlineExceeded {
+				t.Errorf("err=%v, want %v", err, context.DeadlineExceeded)
+			}
+			if done {
+				t.Error("Unexepected Job completion")
+			}
+			cancel2()
+
+			cancel1()
+			// Now all the blocking Jobs should exit pretty quickly, and we'll be
+			// able to submit the same Job.
+			if err := scli.Add(ctx, job); err != nil {
+				t.Errorf("err=%v, want nil", err)
+			}
+			// But we don't know whether it is completed util we wait for it.
+			scli.Close()
+
+			if !done {
+				t.Error("Exepected Job completion")
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change introduces a Pool type which can be used to run arbitrary
Jobs in a set of parallel executors.

Pool provides two types of clients:
- Client is a thin client which can submit Jobs to the Pool efficiently.
- SyncClient is a Client wrapper that adds support for in-flight Jobs
  limiting, and allows to wait for Jobs termination.

This change also adds usage of the new Pool type in Fetcher/Scanner
and Migrillian. This change is necessary to support multi-tenancy in
Migrillian: it requires multiple Controlllers/Fetchers share the same pool
of workers.

This code will likely migrate to Trillian, as it has a similar use-case: a
multi-tenant setup over a set of shared database workers.