### PR TITLE
[Fetcher] Add graceful shutdown

### DIFF
--- a/scanner/fetcher.go
+++ b/scanner/fetcher.go
@@ -66,6 +66,10 @@ type Fetcher struct {
 	sth *ct.SignedTreeHead
 	// The STH retrieval backoff state. Used only in Continuous fetch mode.
 	sthBackoff *backoff.Backoff
+
+	// Stops range generator, which causes the Fetcher terminate gracefully.
+	cancel context.CancelFunc
+	mu     sync.Mutex
 }
 
 // EntryBatch represents a contiguous range of entries of the Log.
@@ -83,7 +87,8 @@ type fetchRange struct {
 // NewFetcher creates a Fetcher instance using client to talk to the log,
 // taking configuration options from opts.
 func NewFetcher(client *client.LogClient, opts *FetcherOptions) *Fetcher {
-	return &Fetcher{client: client, opts: opts}
+	cancel := func() {} // Protect against calling Stop before Run.
+	return &Fetcher{client: client, opts: opts, cancel: cancel}
 }
 
 // Prepare caches the latest Log's STH if not present and returns it. It also
@@ -108,16 +113,23 @@ func (f *Fetcher) Prepare(ctx context.Context) (*ct.SignedTreeHead, error) {
 	return sth, nil
 }
 
-// Run performs fetching of the Log. Blocks until scanning is complete or
-// context is cancelled. For each successfully fetched batch, runs the fn
-// callback.
+// Run performs fetching of the Log. Blocks until scanning is complete, the
+// passed in context is canceled, or Stop is called. For each successfully
+// fetched batch, runs the fn callback.
 func (f *Fetcher) Run(ctx context.Context, fn func(EntryBatch)) error {
 	glog.V(1).Info("Starting up Fetcher...")
 	if _, err := f.Prepare(ctx); err != nil {
 		return err
 	}
 
-	ranges := f.genRanges(ctx)
+	cctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	f.mu.Lock()
+	f.cancel = cancel
+	f.mu.Unlock()
+
+	ranges := f.genRanges(cctx)
 
 	// Run fetcher workers.
 	var wg sync.WaitGroup
@@ -134,6 +146,15 @@ func (f *Fetcher) Run(ctx context.Context, fn func(EntryBatch)) error {
 
 	glog.V(1).Info("Fetcher terminated")
 	return nil
+}
+
+// Stop causes the Fetcher terminate gracefully. After this call Run will try
+// to finish all the started fetches, and then return. Does nothing if there
+// was no preceding Run invocation.
+func (f *Fetcher) Stop() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.cancel()
 }
 
 // genRanges returns a channel of ranges to fetch, and starts a goroutine that


### PR DESCRIPTION
This change makes it possible to shut down `Fetcher` gracefully, i.e. let it finish all the scheduled fetching jobs before it terminates.

This capability will be used in Migrillian in 2 cases:
1. When it decides to resign mastership voluntarily. In this case there is no point in canceling the jobs too early.
2. When the server is shutting down. `Stop` will be called to initiate graceful shutdown, but the main `Run` context will be canceled after the grace period expires (in case the shutdown takes too long).

Finishing fetching gracefully in Migrillian will drastically increase the chance that there will be no gaps among the migrated entries, which minimizes recovery cost (a newly elected master simply starts from the current tree size).