### PR TITLE
[Hammer] Make out-of-range offset unrealistically big

### DIFF
--- a/trillian/integration/hammer.go
+++ b/trillian/integration/hammer.go
@@ -47,7 +47,7 @@ const (
 	sctCount = 10
 
 	// How far beyond current tree size to request for invalid requests.
-	invalidStretch = int64(1000000)
+	invalidStretch = int64(1000000000)
 )
 
 var (


### PR DESCRIPTION
This change prevents hammer alerting on mirror logs which have entries
beyond their current tree size.