### PR TITLE
gossip: drain channel during shutdown

### DIFF
--- a/gossip/minimal/gosmin/main.go
+++ b/gossip/minimal/gosmin/main.go
@@ -45,6 +45,7 @@ func main() {
 	glog.Info("**** Gossiper Starting ****")
 
 	go awaitSignal(func() {
+		glog.Warning("Cancelling master context")
 		cancel()
 	})
 

--- a/gossip/minimal/gossip.go
+++ b/gossip/minimal/gossip.go
@@ -164,7 +164,7 @@ func (g *Gossiper) Run(ctx context.Context) {
 	g.Submitter(ctx, sths)
 	glog.Info("finished Submitter")
 
-	// Drain the sthInfo channel during shutdown.
+	// Drain the sthInfo channel during shutdown so the Retrievers don't block on it.
 	go func() {
 		for info := range sths {
 			glog.V(1).Infof("discard STH from %s", info.name)


### PR DESCRIPTION
If there are more source logs than the STH channel buffer size,
then shutting down the Submitter could block Retriever instances
and prevent overall shutdown.

Instead, run the Submitter in the main goroutine and when it
finishes, spin up a draining goroutine to keep the channel cleared.