### PR TITLE
[Migrillian] Fix early submitter context cancelation

### DIFF
--- a/trillian/migrillian/core/controller.go
+++ b/trillian/migrillian/core/controller.go
@@ -211,6 +211,10 @@ func (c *Controller) Run(ctx context.Context) error {
 		return err
 	}
 
+	// Note: An error in one submitter cancels the other submitters.
+	cctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	var wg sync.WaitGroup
 	c.batches = make(chan scanner.EntryBatch, c.opts.ChannelSize)
 	defer func() {
@@ -218,8 +222,6 @@ func (c *Controller) Run(ctx context.Context) error {
 		wg.Wait()
 	}()
 
-	cctx, cancel := context.WithCancel(ctx)
-	defer cancel()
 	// TODO(pavelkalinnikov): Share the submitters pool between multiple trees.
 	for w, cnt := 0, c.opts.Submitters; w < cnt; w++ {
 		wg.Add(1)

--- a/trillian/migrillian/core/controller.go
+++ b/trillian/migrillian/core/controller.go
@@ -211,16 +211,10 @@ func (c *Controller) Run(ctx context.Context) error {
 		return err
 	}
 
-	// Note: An error in one submitter cancels the other submitters.
-	cctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	var wg sync.WaitGroup
 	c.batches = make(chan scanner.EntryBatch, c.opts.ChannelSize)
-	defer func() {
-		close(c.batches)
-		wg.Wait()
-	}()
+	cctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 
 	// TODO(pavelkalinnikov): Share the submitters pool between multiple trees.
 	for w, cnt := 0, c.opts.Submitters; w < cnt; w++ {
@@ -238,7 +232,10 @@ func (c *Controller) Run(ctx context.Context) error {
 		metrics.entriesFetched.Add(float64(len(b.Entries)), c.label)
 		c.batches <- b
 	}
-	return fetcher.Run(cctx, handler)
+	result := fetcher.Run(cctx, handler)
+	close(c.batches)
+	wg.Wait()
+	return result
 }
 
 // verifyConsistency checks that the provided verified Trillian root is


### PR DESCRIPTION
This change fixes the following bug: In non-continuous mode, when the
Fetcher is done, the context which all submitters use is canceled in race
with their termination. As a result, some of the tail AddSequencedLeaves
requests get canceled, and the tree is not fully migrated.