### PR TITLE
[CTFE] Clean up mirror instance creation

### DIFF
--- a/trillian/ctfe/ct_server/main.go
+++ b/trillian/ctfe/ct_server/main.go
@@ -17,7 +17,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"net/http"
 	"os"
@@ -271,10 +270,6 @@ func awaitSignal(doneFn func()) {
 }
 
 func setupAndRegister(ctx context.Context, client trillian.TrillianLogClient, deadline time.Duration, cfg *configpb.LogConfig, mux *http.ServeMux, globalHandlerPrefix string) error {
-	if cfg.IsMirror {
-		return errors.New("mirrors are not supported")
-	}
-
 	vCfg, err := ctfe.ValidateLogConfig(cfg)
 	if err != nil {
 		return err

--- a/trillian/ctfe/handlers.go
+++ b/trillian/ctfe/handlers.go
@@ -264,7 +264,11 @@ func newLogInfo(
 	case vCfg.FrozenSTH != nil:
 		li.sthGetter = &FrozenSTHGetter{sth: vCfg.FrozenSTH}
 	case cfg.IsMirror:
-		li.sthGetter = &MirrorSTHGetter{li: li, st: DefaultMirrorSTHStorage{}}
+		st := instanceOpts.STHStorage
+		if st == nil {
+			st = DefaultMirrorSTHStorage{}
+		}
+		li.sthGetter = &MirrorSTHGetter{li: li, st: st}
 	default:
 		li.sthGetter = &LogSTHGetter{li: li}
 	}

--- a/trillian/ctfe/instance.go
+++ b/trillian/ctfe/instance.go
@@ -56,28 +56,20 @@ type InstanceOptions struct {
 	// limited. If unset, no quota will be requested for intermediate
 	// certificates.
 	CertificateQuotaUser func(*x509.Certificate) string
+	// STHStorage provides STHs of a source log for the mirror. Only mirror
+	// instances will use it, i.e. when IsMirror == true in the config. If it is
+	// empty then the DefaultMirrorSTHStorage will be used.
+	STHStorage MirrorSTHStorage
 }
 
-// SetUpInstance sets up a log instance using the provided configuration, and
-// returns a set of handlers for this log.
+// SetUpInstance sets up a log (or log mirror) instance using the provided
+// configuration, and returns a set of handlers for this log.
 func SetUpInstance(ctx context.Context, opts InstanceOptions) (*PathHandlers, error) {
 	logInfo, err := setUpLogInfo(ctx, opts)
 	if err != nil {
 		return nil, err
 	}
 	// TODO(pavelkalinnikov): Handlers can take the prefix from logInfo's opts.
-	handlers := logInfo.Handlers(opts.Validated.Config.Prefix)
-	return &handlers, nil
-}
-
-// SetUpMirrorInstance sets up a log mirror instance using the provided
-// configuration, and returns a set of handlers for it.
-func SetUpMirrorInstance(ctx context.Context, opts InstanceOptions, stor MirrorSTHStorage) (*PathHandlers, error) {
-	logInfo, err := setUpLogInfo(ctx, opts)
-	if err != nil {
-		return nil, err
-	}
-	logInfo.sthGetter = &MirrorSTHGetter{li: logInfo, st: stor}
 	handlers := logInfo.Handlers(opts.Validated.Config.Prefix)
 	return &handlers, nil
 }


### PR DESCRIPTION
This change adds mirror STH storage to the instance parameters, and
eliminates a copy-pasted SetUpMirrorInstance function.

It also fixes a bug: frozen STH option was effectively ignored by mirror
instances because SetUpMirrorInstance overrided the frozen STH getter.

Finally, this change enables partial mirrors support in open-source.
Previously any mirror log would be rejected. Now they are accepted, but
get-sth calls will return an error because the STH getter is not
implemented (however, other methods like getting entries and proofs
should work).