### PR TITLE
x509: drop OS X version macro

### DIFF
--- a/x509/nilref_nil_darwin.go
+++ b/x509/nilref_nil_darwin.go
@@ -7,7 +7,7 @@
 package x509
 
 /*
-#cgo CFLAGS: -mmacosx-version-min=10.6 -D__MAC_OS_X_VERSION_MAX_ALLOWED=1080
+#cgo CFLAGS: -mmacosx-version-min=10.6
 #cgo LDFLAGS: -framework CoreFoundation -framework Security
 
 #include <CoreFoundation/CoreFoundation.h>

--- a/x509/nilref_zero_darwin.go
+++ b/x509/nilref_zero_darwin.go
@@ -7,7 +7,7 @@
 package x509
 
 /*
-#cgo CFLAGS: -mmacosx-version-min=10.6 -D__MAC_OS_X_VERSION_MAX_ALLOWED=1080
+#cgo CFLAGS: -mmacosx-version-min=10.6
 #cgo LDFLAGS: -framework CoreFoundation -framework Security
 
 #include <CoreFoundation/CoreFoundation.h>


### PR DESCRIPTION
This seems to give duplicate symbol definition warnings.