### PR TITLE
Set User-Agent strings on tools

### DIFF
--- a/client/ctclient/ctclient.go
+++ b/client/ctclient/ctclient.go
@@ -404,7 +404,7 @@ func main() {
 			TLSClientConfig:       tlsCfg,
 		},
 	}
-	var opts jsonclient.Options
+	opts := jsonclient.Options{UserAgent: "ct-go-ctclient/1.0"}
 	if *pubKey != "" {
 		pubkey, err := ioutil.ReadFile(*pubKey)
 		if err != nil {

--- a/client/multilog.go
+++ b/client/multilog.go
@@ -106,7 +106,7 @@ func NewTemporalLogClient(cfg configpb.TemporalLogConfig, hc *http.Client) (*Tem
 	}
 	clients := make([]*LogClient, 0, len(cfg.Shard))
 	for i, shard := range cfg.Shard {
-		opts := jsonclient.Options{}
+		opts := jsonclient.Options{UserAgent: "ct-go-multilog/1.0"}
 		opts.PublicKeyDER = shard.GetPublicKeyDer()
 		c, err := New(shard.Uri, hc, opts)
 		if err != nil {

--- a/ctutil/loginfo.go
+++ b/ctutil/loginfo.go
@@ -52,7 +52,7 @@ func NewLogInfo(log *loglist.Log, hc *http.Client) (*LogInfo, error) {
 	if !strings.HasPrefix(url, "https://") {
 		url = "https://" + url
 	}
-	lc, err := client.New(url, hc, jsonclient.Options{PublicKeyDER: log.Key})
+	lc, err := client.New(url, hc, jsonclient.Options{PublicKeyDER: log.Key, UserAgent: "ct-go-logclient"})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create client for log %q: %v", log.Description, err)
 	}

--- a/ctutil/sctscan/sctscan.go
+++ b/ctutil/sctscan/sctscan.go
@@ -63,7 +63,7 @@ func main() {
 			ExpectContinueTimeout: 1 * time.Second,
 		},
 	}
-	logClient, err := client.New(*logURI, hc, jsonclient.Options{})
+	logClient, err := client.New(*logURI, hc, jsonclient.Options{UserAgent: "ct-go-sctscan/1.0"})
 	if err != nil {
 		glog.Exitf("Failed to create log client: %v", err)
 	}

--- a/fixchain/chainfix/chainfix.go
+++ b/fixchain/chainfix/chainfix.go
@@ -119,7 +119,7 @@ func main() {
 
 	limiter := ratelimiter.NewLimiter(1000)
 	c := &http.Client{}
-	logClient, err := client.New(logURL, c, jsonclient.Options{})
+	logClient, err := client.New(logURL, c, jsonclient.Options{UserAgent: "ct-go-fixchain/1.0"})
 	if err != nil {
 		log.Fatalf("failed to create log client: %v", err)
 	}

--- a/gossip/minimal/instance.go
+++ b/gossip/minimal/instance.go
@@ -146,7 +146,7 @@ func logConfigFromProto(cfg *configpb.LogConfig, hc *http.Client) (*logConfig, e
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse MinReqInterval: %v", err)
 	}
-	opts := jsonclient.Options{PublicKeyDER: cfg.PublicKey.GetDer()}
+	opts := jsonclient.Options{PublicKeyDER: cfg.PublicKey.GetDer(), UserAgent: "ct-go-gossip-client/1.0"}
 	client, err := logclient.New(cfg.Url, hc, opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create log client for %q: %v", cfg.Name, err)
@@ -171,7 +171,7 @@ func hubFromProto(cfg *configpb.HubConfig, hc *http.Client) (*destHub, error) {
 		return nil, fmt.Errorf("failed to parse MinReqInterval: %v", err)
 	}
 	var submitter hubSubmitter
-	opts := jsonclient.Options{PublicKeyDER: cfg.PublicKey.GetDer()}
+	opts := jsonclient.Options{PublicKeyDER: cfg.PublicKey.GetDer(), UserAgent: "ct-go-gossip-hub/1.0"}
 	if cfg.IsHub {
 		cl, err := hubclient.New(cfg.Url, hc, opts)
 		if err != nil {
@@ -208,7 +208,7 @@ func hubScannerFromProto(cfg *configpb.HubConfig, hc *http.Client) (*hubScanner,
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse MinReqInterval: %v", err)
 	}
-	opts := jsonclient.Options{PublicKeyDER: cfg.PublicKey.GetDer()}
+	opts := jsonclient.Options{PublicKeyDER: cfg.PublicKey.GetDer(), UserAgent: "ct-go-gossip-scanner/1.0"}
 	if cfg.IsHub {
 		return nil, errors.New("Pure Gossip Hubs not yet supported")
 	}

--- a/jsonclient/client.go
+++ b/jsonclient/client.go
@@ -58,6 +58,7 @@ type JSONClient struct {
 	Verifier   *ct.SignatureVerifier // nil for no verification (e.g. no public key available)
 	logger     Logger                // interface to use for logging warnings and errors
 	backoff    backoffer             // object used to store and calculate backoff information
+	userAgent  string                // If set, this is sent as the UserAgent header.
 }
 
 // Logger is a simple logging interface used to log internal errors and warnings
@@ -75,6 +76,8 @@ type Options struct {
 	PublicKey string
 	// DER format public key to use for signature verification.
 	PublicKeyDER []byte
+	// UserAgent, if set, will be sent as the User-Agent header with each request.
+	UserAgent string
 }
 
 // ParsePublicKey parses and returns the public key contained in opts.
@@ -149,6 +152,7 @@ func New(uri string, hc *http.Client, opts Options) (*JSONClient, error) {
 		Verifier:   verifier,
 		logger:     logger,
 		backoff:    &backoff{},
+		userAgent:  opts.UserAgent,
 	}, nil
 }
 
@@ -174,6 +178,9 @@ func (c *JSONClient) GetAndParse(ctx context.Context, path string, params map[st
 	httpReq, err := http.NewRequest(http.MethodGet, fullURI, nil)
 	if err != nil {
 		return nil, nil, err
+	}
+	if len(c.userAgent) != 0 {
+		httpReq.Header.Set("User-Agent", c.userAgent)
 	}
 
 	httpRsp, err := ctxhttp.Do(ctx, c.httpClient, httpReq)
@@ -216,6 +223,9 @@ func (c *JSONClient) PostAndParse(ctx context.Context, path string, req, rsp int
 	httpReq, err := http.NewRequest(http.MethodPost, fullURI, bytes.NewReader(postBody))
 	if err != nil {
 		return nil, nil, err
+	}
+	if len(c.userAgent) != 0 {
+		httpReq.Header.Set("User-Agent", c.userAgent)
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 

--- a/preload/preloader/preloader.go
+++ b/preload/preloader/preloader.go
@@ -165,7 +165,7 @@ func main() {
 	fetchLogClient, err := client.New(*sourceLogURI, &http.Client{
 		Timeout:   10 * time.Second,
 		Transport: transport,
-	}, jsonclient.Options{})
+	}, jsonclient.Options{UserAgent: "ct-go-preloader/1.0"})
 	if err != nil {
 		glog.Exitf("Failed to create client for source log: %v", err)
 	}
@@ -205,7 +205,7 @@ func main() {
 			glog.Exitf("Failed to create client for destination temporal log: %v", err)
 		}
 	} else {
-		submitLogClient, err = client.New(*targetLogURI, &http.Client{Transport: transport}, jsonclient.Options{})
+		submitLogClient, err = client.New(*targetLogURI, &http.Client{Transport: transport}, jsonclient.Options{UserAgent: "ct-go-preloader/1.0"})
 		if err != nil {
 			glog.Exitf("Failed to create client for destination log: %v", err)
 		}

--- a/scanner/scanlog/scanlog.go
+++ b/scanner/scanlog/scanlog.go
@@ -196,7 +196,7 @@ func main() {
 			IdleConnTimeout:       90 * time.Second,
 			ExpectContinueTimeout: 1 * time.Second,
 		},
-	}, jsonclient.Options{})
+	}, jsonclient.Options{UserAgent: "ct-go-scanlog/1.0"})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/trillian/integration/ct_integration.go
+++ b/trillian/integration/ct_integration.go
@@ -109,6 +109,7 @@ func (p RandomPool) Next() *client.LogClient {
 func NewRandomPool(servers string, pubKey *keyspb.PublicKey, prefix string) (ClientPool, error) {
 	opts := jsonclient.Options{
 		PublicKeyDER: pubKey.GetDer(),
+		UserAgent:    "ct-go-integrationtest/1.0",
 	}
 
 	hc := &http.Client{Transport: DefaultTransport}

--- a/trillian/migrillian/main.go
+++ b/trillian/migrillian/main.go
@@ -127,7 +127,7 @@ func getController(
 	ef election2.Factory,
 	conn *grpc.ClientConn,
 ) (*core.Controller, error) {
-	ctOpts := jsonclient.Options{PublicKeyDER: cfg.PublicKey.Der}
+	ctOpts := jsonclient.Options{PublicKeyDER: cfg.PublicKey.Der, UserAgent: "ct-go-migrillian/1.0"}
 	ctClient, err := client.New(cfg.SourceUri, httpClient, ctOpts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create CT client: %v", err)


### PR DESCRIPTION
This PR allows users of the ctclient to specify a user agent string which should be sent with all requests, and sets identifying strings on the tools contained in the repo.