### PR TITLE
Consistently use $PROJECT_ID instead of $PROJECT_NAME

### DIFF
--- a/scripts/deploy_gce_ci.sh
+++ b/scripts/deploy_gce_ci.sh
@@ -6,7 +6,7 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-export PROJECT_NAME=trillian-opensource-ci
+export PROJECT_ID=trillian-opensource-ci
 export CLUSTER_NAME=trillian-opensource-ci
 export MASTER_ZONE=us-central1-a
 

--- a/trillian/examples/deployment/kubernetes/ctfe-deployment.yaml
+++ b/trillian/examples/deployment/kubernetes/ctfe-deployment.yaml
@@ -22,7 +22,7 @@ spec:
           "--log_config=/ctfe-config/ct_server.cfg",
           "--alsologtostderr"
           ]
-          image: gcr.io/${PROJECT_NAME}/ctfe:latest
+          image: gcr.io/${PROJECT_ID}/ctfe:latest
           imagePullPolicy: Always
           resources:
             limits:


### PR DESCRIPTION
The trillian/examples/deployment/scripts/deploy.sh script uses $PROJECT_ID, and Google Cloud Build also uses $PROJECT_ID. Right now, CI pushes via Travis are (silently) failing because of this inconsistency.