### PR TITLE
Make ctfe Docker image consistent with Trillian images

### DIFF
--- a/trillian/examples/deployment/docker/ctfe/Dockerfile
+++ b/trillian/examples/deployment/docker/ctfe/Dockerfile
@@ -1,25 +1,13 @@
-FROM golang:1.9
-
-ENV TRILLIAN_LOG_HOST=1.2.3.4 \
-    TRILLIAN_LOG_PORT=9999 \
-    ETCD_SERVERS=""
-
-ENV HOST=0.0.0.0 \
-    HTTP_PORT=6962
+FROM golang:1.10 as build
 
 ADD . /go/src/github.com/google/certificate-transparency-go
 WORKDIR /go/src/github.com/google/certificate-transparency-go
 
-RUN go get -v ./trillian/ctfe/ct_server
+ARG GOFLAGS=""
+RUN go get ${GOFLAGS} ./trillian/ctfe/ct_server
 
-ENTRYPOINT /go/bin/ct_server \
-  --log_rpc_server="$TRILLIAN_LOG_HOST:$TRILLIAN_LOG_PORT" \
-  --log_config="$LOG_CONFIG" \
-  --etc_servers="$ETCD_SERVERS" \
-  --http_endpoint="$HOST:$HTTP_PORT" \
-  --alsologtostderr
+FROM gcr.io/distroless/base
 
-EXPOSE $HTTP_PORT
+COPY --from=build /go/bin/ct_server /
 
-HEALTHCHECK --interval=5m --timeout=3s \
-  CMD curl -f http://localhost:$HTTP_PORT/debug/vars || exit 1
+ENTRYPOINT ["/ct_server"]


### PR DESCRIPTION
- Use the distroless base image and Go 1.10.
- Provide a $GOFLAGS argument to build ct_server with specific flags,
  e.g. -race.
- Remove EXPOSE and HEALTHCHECK directives - leave this to Kubernetes.
- Remove ENTRYPOINT flags - leave this to the user.