### PR TITLE
PostAndParseWithRetry: Return RspError for status mismatch.

### DIFF
--- a/jsonclient/client.go
+++ b/jsonclient/client.go
@@ -307,7 +307,10 @@ func (c *JSONClient) PostAndParseWithRetry(ctx context.Context, path string, req
 				wait := c.backoff.set(backoff)
 				c.logger.Printf("Request failed, backing-off for %s: got HTTP status %s", wait, httpRsp.Status)
 			default:
-				return httpRsp, body, fmt.Errorf("got HTTP Status %q", httpRsp.Status)
+				return nil, nil, RspError{
+					StatusCode: httpRsp.StatusCode,
+					Body:       body,
+					Err:        fmt.Errorf("got HTTP status %q", httpRsp.Status)}
 			}
 		}
 		if err := c.waitForBackoff(ctx); err != nil {

--- a/jsonclient/client_test.go
+++ b/jsonclient/client_test.go
@@ -437,6 +437,10 @@ func TestPostAndParseWithRetry(t *testing.T) {
 				t.Errorf("PostAndParseWithRetry()=%+v,nil; want error %q", got, test.wantErr)
 			} else if !strings.Contains(err.Error(), test.wantErr) {
 				t.Errorf("PostAndParseWithRetry()=nil,%q; want error %q", err.Error(), test.wantErr)
+			} else if _, isRspError := err.(RspError); !isRspError && err != context.DeadlineExceeded {
+				// We expect all non-nil errors to be either a RspError instance or to
+				// be the context DeadlineExceeded error.
+				t.Errorf("PostAndParseWithRetry()=%T; want jsonClient.RspError or context.DeadlineExceeded", err)
 			}
 			continue
 		}


### PR DESCRIPTION
Prior to 5b1f90945db965133564fdfbe129c018e6150742 `logclient.addChainWithRetry` when calling `jsonclient.PostAndParseWithRetry` would convert a non-nil `err` response into a `RspError` when the `httpRsp` was also non-nil:
https://github.com/google/certificate-transparency-go/blob/032a3a5d79c921e92c8d5636f10790e13975754b/client/logclient.go#L72-L78
 After the refactor the result from `PostAndParseWithRetry` is returned directly and it is assumed that function will return a `RspError` in all cases:
https://github.com/google/certificate-transparency-go/blob/f840c15c5e89724c8db71732d703ebadb155479b/client/logclient.go#L72-L75

However the default case in `PostAndParseWithRetry` returns a bare error instead of a `RspError`, breaking this assumption and masking the HTTP response body from interested callers to `PostAndParseWithRetry`: https://github.com/google/certificate-transparency-go/blob/f840c15c5e89724c8db71732d703ebadb155479b/jsonclient/client.go#L309-L310

For example, in Boulder we specifically [look for `RspError` instances so we can log the response body](https://github.com/letsencrypt/boulder/blob/965acf381b24a16dffefba6135d308c4ee42e32c/publisher/publisher.go#L245-L247) of CT submission errors. This logic breaks after 5b1f90945db965133564fdfbe129c018e6150742 because `client.Add[Pre]Chain` return a bare error string for HTTP status mismatches.

This commit updates the `PostAndParseWithRetry` unit test to ensure when  a non-nil error is returned it is always a `RspError` instance or `context.DeadlineExceeded`. Without the fix to `PostAndParseWithRetry` the updated test fails as expected:

```
go test --test.run TestPostAndParseWithRetry ./jsonclient/...
2018/11/26 14:19:13 Request failed, backing-off on http://127.0.0.1:39638 for 0s: parse http://127.0.0.1:39638/short%: invalid URL escape "%"
2018/11/26 14:19:13 Request timed out, retrying immediately
2018/11/26 14:19:13 Request failed, backing-off for 0s: got HTTP status 503 Service Unavailable
2018/11/26 14:19:13 Request failed, backing-off for 0s: got HTTP status 503 Service Unavailable
--- FAIL: TestPostAndParseWithRetry (0.00s)
    client_test.go:441: PostAndParseWithRetry()=*errors.errorString; want jsonClient.RspError
    FAIL
    FAIL  github.com/google/certificate-transparency-go/jsonclient  0.005s
```

After the fix to `PostAndParseWithRetry` the updated test passes.