### PR TITLE
gossip: cope with STH for untracked log

### DIFF
--- a/gossip/minimal/goshawk.go
+++ b/gossip/minimal/goshawk.go
@@ -231,6 +231,7 @@ func (dest *hubScanner) foundCert(rawEntry *ct.RawLogEntry) {
 	origin, ok := dest.hawk.origins[url]
 	if !ok {
 		glog.Warningf("Scanner(%s): found STH info for unrecognized log at %q in entry at %d", dest.Name, url, entry.Index)
+		return
 	}
 	origin.sths <- sthInfo
 }


### PR DESCRIPTION
If an encoded-STH for an untracked log is encountered, early exit.