### PR TITLE
Fix issues with CTFE Kubernetes config

### DIFF
--- a/trillian/examples/deployment/kubernetes/ctfe-deployment.yaml
+++ b/trillian/examples/deployment/kubernetes/ctfe-deployment.yaml
@@ -18,7 +18,7 @@ spec:
           args: [
             "--http_endpoint=0.0.0.0:6962",
             "--metrics_endpoint=0.0.0.0:6963",
-            "--log_rpc_server=dns:///trillian-log-service",
+            "--log_rpc_server=dns:///trillian-log-service:8090",
             "--log_config=/ctfe-config/ct_server.cfg",
             "--alsologtostderr"
           ]

--- a/trillian/examples/deployment/kubernetes/ctfe-deployment.yaml
+++ b/trillian/examples/deployment/kubernetes/ctfe-deployment.yaml
@@ -33,12 +33,6 @@ spec:
             httpGet:
               path: /metrics
               port: metrics
-          readinessProbe:
-            exec:
-              command:
-              - curl
-              - -f
-              - http://localhost:6963/metrics
             failureThreshold: 3
             periodSeconds: 30
             timeoutSeconds: 30

--- a/trillian/examples/deployment/kubernetes/ctfe-deployment.yaml
+++ b/trillian/examples/deployment/kubernetes/ctfe-deployment.yaml
@@ -15,12 +15,12 @@ spec:
     spec:
       containers:
         - name: trillian-ctfe
-          command: ["/go/bin/ct_server",
-          "--http_endpoint=0.0.0.0:6962",
-          "--metrics_endpoint=0.0.0.0:6963",
-          "--log_rpc_server=dns:///trillian-log-service",
-          "--log_config=/ctfe-config/ct_server.cfg",
-          "--alsologtostderr"
+          args: [
+            "--http_endpoint=0.0.0.0:6962",
+            "--metrics_endpoint=0.0.0.0:6963",
+            "--log_rpc_server=dns:///trillian-log-service",
+            "--log_config=/ctfe-config/ct_server.cfg",
+            "--alsologtostderr"
           ]
           image: gcr.io/${PROJECT_ID}/ctfe:${IMAGE_TAG}
           imagePullPolicy: Always


### PR DESCRIPTION
The command no longer works, as of f840c15c5e89724c8db71732d703ebadb155479b, because the location of the ct_server binary in the image changed. The Kubernetes config should not specify the binary path; just the arguments.

Also removes a redundant readinessProbe.