### PR TITLE
Migrillian: Retry failed entry fetches

### DIFF
--- a/trillian/migrillian/core/controller.go
+++ b/trillian/migrillian/core/controller.go
@@ -83,6 +83,7 @@ func OptionsFromConfig(cfg *configpb.MigrationConfig) Options {
 			StartIndex:    cfg.StartIndex,
 			EndIndex:      cfg.EndIndex,
 			Continuous:    cfg.IsContinuous,
+			EnableRetries: true,
 		},
 		Submitters:  int(cfg.NumSubmitters),
 		ChannelSize: int(cfg.ChannelSize),


### PR DESCRIPTION
This change enables Migrillian to tolerate occasional get-entries hiccups from CT servers.