### PR TITLE
Adding empty-cert-chain mode for log compatibility filtering

### DIFF
--- a/loglist/logfilter.go
+++ b/loglist/logfilter.go
@@ -17,6 +17,7 @@ package loglist
 import (
 	"time"
 
+	"github.com/golang/glog"
 	"github.com/google/certificate-transparency-go/x509"
 )
 
@@ -38,11 +39,12 @@ func (ll *LogList) ActiveLogs() LogList {
 	return active
 }
 
-// Compatible creates a new LogList containing only logs of original LogList
-// compatible with cert-chain provided. Treat Logs as compatible when their
-// root info is missing.
-// Cert-chain is expected to be full or empty: ending with CA-cert or have
-// len 0.
+// Compatible creates a new LogList containing only the logs of original
+// LogList that are compatible with the provided cert-chain, according to
+// the passed in collection of per-log roots. Logs that are missing from
+// the collection are treated as always compatible and included, even if
+// an empty cert chain is passed in.
+// Cert-chain when provided is expected to be full: ending with CA-cert.
 func (ll *LogList) Compatible(rootedChain []*x509.Certificate, roots LogRoots) LogList {
 	var compatible LogList
 	// Keep all the operators.
@@ -54,6 +56,7 @@ func (ll *LogList) Compatible(rootedChain []*x509.Certificate, roots LogRoots) L
 
 	// Check whether chain is ending with CA-cert.
 	if !chainIsEmpty && !rootedChain[len(rootedChain)-1].IsCA {
+		glog.Warningf("Compatibale method expects fully rooted chain, while last cert of the chain provided is not root")
 		return compatible
 	}
 

--- a/loglist/logfilter.go
+++ b/loglist/logfilter.go
@@ -56,7 +56,7 @@ func (ll *LogList) Compatible(rootedChain []*x509.Certificate, roots LogRoots) L
 
 	// Check whether chain is ending with CA-cert.
 	if !chainIsEmpty && !rootedChain[len(rootedChain)-1].IsCA {
-		glog.Warningf("Compatibale method expects fully rooted chain, while last cert of the chain provided is not root")
+		glog.Warningf("Compatible method expects fully rooted chain, while last cert of the chain provided is not root")
 		return compatible
 	}
 

--- a/loglist/logfilter_test.go
+++ b/loglist/logfilter_test.go
@@ -107,6 +107,13 @@ func TestCompatible(t *testing.T) {
 			roots: artificialRoots(testdata.CACertPEM),
 			want:  subLogList(map[string]bool{}),
 		},
+		{
+			name:  "EmptyChain",
+			in:    sampleLogList,
+			chain: []*x509.Certificate{},
+			roots: artificialRoots(testdata.CACertPEM),
+			want:  subLogList(map[string]bool{"ct.googleapis.com/icarus/": true}), // icarus has no root info.
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Method 'Compatible' of a LogList extracts Logs that are root-compatible for cert-chain provided.
For situations with incomplete information (roots for Log unknown), Logs are treated as (possibly-)compatible.

This PR adds logic for incomplete info on cert-chain side. 
