### PR TITLE
Moving to ctfe-certpools for root-inclusion checking.

### DIFF
--- a/loglist/logfilter.go
+++ b/loglist/logfilter.go
@@ -18,12 +18,13 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	"github.com/google/certificate-transparency-go/trillian/ctfe"
 	"github.com/google/certificate-transparency-go/x509"
 )
 
-// LogRoots maps Log-URLs (stated at LogList) to the list of their accepted
+// LogRoots maps Log-URLs (stated at LogList) to the pools of their accepted
 // root-certificates.
-type LogRoots map[string][]*x509.Certificate
+type LogRoots map[string]*ctfe.PEMCertPool
 
 // ActiveLogs creates a new LogList containing only non-disqualified non-frozen
 // logs from the original.
@@ -72,11 +73,8 @@ func (ll *LogList) Compatible(rootedChain []*x509.Certificate, roots LogRoots) L
 		}
 
 		// Check root is accepted.
-		for _, r := range roots[l.URL] {
-			if r.Equal(rootedChain[len(rootedChain)-1]) {
-				compatible.Logs = append(compatible.Logs, l)
-				break
-			}
+		if roots[l.URL].Included(rootedChain[len(rootedChain)-1]) {
+			compatible.Logs = append(compatible.Logs, l)
 		}
 	}
 	return compatible

--- a/loglist/logfilter_test.go
+++ b/loglist/logfilter_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/google/certificate-transparency-go/testdata"
+	"github.com/google/certificate-transparency-go/trillian/ctfe"
 	"github.com/google/certificate-transparency-go/x509"
 	"github.com/google/certificate-transparency-go/x509util"
 
@@ -69,13 +70,14 @@ func singleCert() []*x509.Certificate {
 }
 
 func artificialRoots(source string) LogRoots {
-	rootCert, _ := x509util.CertificateFromPEM([]byte(source))
-	return LogRoots{
-		"log.bob.io":                   []*x509.Certificate{rootCert},
-		"ct.googleapis.com/racketeer/": []*x509.Certificate{},
-		"ct.googleapis.com/rocketeer/": []*x509.Certificate{},
-		"ct.googleapis.com/aviator/":   []*x509.Certificate{},
+	roots := LogRoots{
+		"log.bob.io":                   ctfe.NewPEMCertPool(),
+		"ct.googleapis.com/racketeer/": ctfe.NewPEMCertPool(),
+		"ct.googleapis.com/rocketeer/": ctfe.NewPEMCertPool(),
+		"ct.googleapis.com/aviator/":   ctfe.NewPEMCertPool(),
 	}
+	roots["log.bob.io"].AppendCertsFromPEM([]byte(source))
+	return roots
 }
 
 func TestCompatible(t *testing.T) {

--- a/submission/distributor_test.go
+++ b/submission/distributor_test.go
@@ -213,7 +213,7 @@ func TestNewDistributorRootPools(t *testing.T) {
 			for logURL, wantNum := range tc.rootNum {
 				gotNum := 0
 				if roots, ok := dist.logRoots[logURL]; ok {
-					gotNum = len(roots)
+					gotNum = len(roots.RawCertificates())
 				}
 				if wantNum != gotNum {
 					t.Errorf("Expected %d root(s) for Log %s, got %d", wantNum, logURL, gotNum)


### PR DESCRIPTION
Using CertPools instead of cert-lists. Propagating to schema-1 filtration and its only caller -- proxy.