### PR TITLE
Reorder Scanner fields to fix alignment issues

### DIFF
--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -59,10 +59,8 @@ func DefaultScannerOptions() *ScannerOptions {
 
 // Scanner is a tool to scan all the entries in a CT Log.
 type Scanner struct {
-	fetcher *Fetcher
-
-	// Configuration options for this Scanner instance.
-	opts ScannerOptions
+	// N.B. 64-bit fields must be first due to
+	// https://golang.org/pkg/sync/atomic/#pkg-note-BUG
 
 	// Counters of the number of certificates scanned and matched.
 	certsProcessed int64
@@ -73,6 +71,11 @@ type Scanner struct {
 
 	unparsableEntries         int64
 	entriesWithNonFatalErrors int64
+
+	fetcher *Fetcher
+
+	// Configuration options for this Scanner instance.
+	opts ScannerOptions
 }
 
 // entryInfo represents information about a log entry.


### PR DESCRIPTION
Go doesn't always guarantee 64-bit alignment of 64-bit integer, which leads to crashes when atomic operations are used on them on certain platforms (e.g. ARM).

This problem is described here: https://golang.org/pkg/sync/atomic/#pkg-note-BUG

By putting these fields first, proper alignment will be guaranteed.

https://github.com/golang/go/issues/599
https://github.com/golang/go/issues/23345

This is how crash looks like:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x4 pc=0x11f70]

goroutine 37 [running]:
github.com/google/certificate-transparency-go/scanner.(*Scanner).processEntry(0xfb2120, 0x1fb09886, 0x0, 0xf06000, 0x62e, 0x630, 0x10de000, 0xbda, 0xbdc, 0x3570f0, ...)
        /home/wgh/go/src/github.com/google/certificate-transparency-go/scanner/scanner.go:108 +0x34
github.com/google/certificate-transparency-go/scanner.(*Scanner).matcherJob(0xfb2120, 0xd4e2c0, 0x3570f0, 0x3570f0)
        /home/wgh/go/src/github.com/google/certificate-transparency-go/scanner/scanner.go:183 +0x80
github.com/google/certificate-transparency-go/scanner.(*Scanner).ScanLog.func2(0xc105e0, 0xfb2120, 0xd4e2c0, 0x3570f0, 0x3570f0, 0x1)
        /home/wgh/go/src/github.com/google/certificate-transparency-go/scanner/scanner.go:287 +0xd0
created by github.com/google/certificate-transparency-go/scanner.(*Scanner).ScanLog
        /home/wgh/go/src/github.com/google/certificate-transparency-go/scanner/scanner.go:284 +0x200
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x4 pc=0x11f70]
```