### PR TITLE
trillian/ctfe: add misbehaving log mode

### DIFF
--- a/trillian/ctfe/ct_server/main.go
+++ b/trillian/ctfe/ct_server/main.go
@@ -67,6 +67,8 @@ var (
 	quotaRemote        = flag.Bool("quota_remote", true, "Enable requesting of quota for IP address sending incoming requests")
 	quotaIntermediate  = flag.Bool("quota_intermediate", true, "Enable requesting of quota for intermediate certificates in sumbmitted chains")
 	handlerPrefix      = flag.String("handler_prefix", "", "If set e.g. to '/logs' will prefix all handlers that don't define a custom prefix")
+
+	badLog = flag.Bool("aim_to_misbehave", false, "Whether to deliberately perform invalid actions")
 )
 
 // nolint:staticcheck
@@ -267,6 +269,7 @@ func setupAndRegister(ctx context.Context, client trillian.TrillianLogClient, de
 		MetricFactory:      prometheus.MetricFactory{},
 		RequestLog:         new(ctfe.DefaultRequestLog),
 		MaskInternalErrors: maskInternalErrors,
+		Misbehave:          *badLog,
 	}
 	if *quotaRemote {
 		glog.Info("Enabling quota for requesting IP")

--- a/trillian/ctfe/instance.go
+++ b/trillian/ctfe/instance.go
@@ -65,6 +65,10 @@ type InstanceOptions struct {
 	// MaskInternalErrors indicates if internal server errors should be masked
 	// or returned to the user containing the full error message.
 	MaskInternalErrors bool
+	// Misbehave indicates whether the CT personality should deliberately
+	// introduce errors in its processing.  This flag is only intended for
+	// testing (particularly of monitors, mirrors and auditors).
+	Misbehave bool
 }
 
 // Instance is a set up log/mirror instance. It must be created with the

--- a/trillian/ctfe/serialize.go
+++ b/trillian/ctfe/serialize.go
@@ -86,9 +86,13 @@ func signV1TreeHead(signer crypto.Signer, sth *ct.SignedTreeHead, cache *Signatu
 }
 
 func buildV1SCT(signer crypto.Signer, leaf *ct.MerkleTreeLeaf) (*ct.SignedCertificateTimestamp, error) {
+	return buildSCT(signer, leaf, ct.V1)
+}
+
+func buildSCT(signer crypto.Signer, leaf *ct.MerkleTreeLeaf, ver ct.Version) (*ct.SignedCertificateTimestamp, error) {
 	// Serialize SCT signature input to get the bytes that need to be signed
 	sctInput := ct.SignedCertificateTimestamp{
-		SCTVersion: ct.V1,
+		SCTVersion: ver,
 		Timestamp:  leaf.TimestampedEntry.Timestamp,
 		Extensions: leaf.TimestampedEntry.Extensions,
 	}


### PR DESCRIPTION
Only intended for testing, should never be turned on.

Add a variety of misbehaviours in the CTFE's behaviour, each
occuring with a 1% chance.