### PR TITLE
Switching signature for root-compatibility LogList filtering methods.

### DIFF
--- a/loglist/logfilter_test.go
+++ b/loglist/logfilter_test.go
@@ -58,16 +58,6 @@ func TestActiveLogs(t *testing.T) {
 	}
 }
 
-func cert() *x509.Certificate {
-	cert, _ := x509util.CertificateFromPEM([]byte(testdata.TestPreCertPEM))
-	return cert
-}
-
-func caCert() *x509.Certificate {
-	cert, _ := x509util.CertificateFromPEM([]byte(testdata.CACertPEM))
-	return cert
-}
-
 func artificialRoots(source string) LogRoots {
 	roots := LogRoots{
 		"log.bob.io":                   ctfe.NewPEMCertPool(),
@@ -80,6 +70,9 @@ func artificialRoots(source string) LogRoots {
 }
 
 func TestCompatible(t *testing.T) {
+	cert, _ := x509util.CertificateFromPEM([]byte(testdata.TestPreCertPEM))
+	caCert, _ := x509util.CertificateFromPEM([]byte(testdata.CACertPEM))
+
 	tests := []struct {
 		name     string
 		in       LogList
@@ -91,24 +84,24 @@ func TestCompatible(t *testing.T) {
 		{
 			name:     "RootedChain",
 			in:       sampleLogList,
-			cert:     cert(),
-			certRoot: caCert(),
+			cert:     cert,
+			certRoot: caCert,
 			roots:    artificialRoots(testdata.CACertPEM),
 			want:     subLogList(map[string]bool{"log.bob.io": true, "ct.googleapis.com/icarus/": true}), // icarus has no root info.
 		},
 		{
 			name:     "RootedChainNoRootAccepted",
 			in:       sampleLogList,
-			cert:     cert(),
-			certRoot: caCert(),
+			cert:     cert,
+			certRoot: caCert,
 			roots:    artificialRoots(testdata.TestPreCertPEM),
 			want:     subLogList(map[string]bool{"ct.googleapis.com/icarus/": true}), // icarus has no root info.
 		},
 		{
 			name:     "UnRootedChain",
 			in:       sampleLogList,
-			cert:     cert(),
-			certRoot: cert(),
+			cert:     cert,
+			certRoot: cert,
 			roots:    artificialRoots(testdata.CACertPEM),
 			want:     subLogList(map[string]bool{}),
 		},

--- a/loglist2/logfilter.go
+++ b/loglist2/logfilter.go
@@ -44,20 +44,16 @@ func (ll *LogList) SelectUsable() LogList {
 }
 
 // RootCompatible creates a new LogList containing only the logs of original
-// LogList that are compatible with the provided cert-chain, according to
+// LogList that are compatible with the provided cert, according to
 // the passed in collection of per-log roots. Logs that are missing from
 // the collection are treated as always compatible and included, even if
-// an empty cert chain is passed in.
-// Cert-chain when provided is expected to be full: ending with CA-cert.
-func (ll *LogList) RootCompatible(rootedChain []*x509.Certificate, roots LogRoots) LogList {
+// an empty cert root is passed in.
+// Cert-root when provided is expected to be CA-cert.
+func (ll *LogList) RootCompatible(cert *x509.Certificate, certRoot *x509.Certificate, roots LogRoots) LogList {
 	var compatible LogList
 
-	// When chain info is not available, collect Logs with no root info as
-	// compatible.
-	chainIsEmpty := len(rootedChain) == 0
-
-	// Check whether chain is ending with CA-cert.
-	if !chainIsEmpty && !rootedChain[len(rootedChain)-1].IsCA {
+	// Check whether root is a CA-cert.
+	if certRoot != nil && !certRoot.IsCA {
 		glog.Warningf("Compatible method expects fully rooted chain, while last cert of the chain provided is not root")
 		return compatible
 	}
@@ -73,12 +69,12 @@ func (ll *LogList) RootCompatible(rootedChain []*x509.Certificate, roots LogRoot
 				continue
 			}
 
-			if chainIsEmpty {
+			if certRoot == nil {
 				continue
 			}
 
 			// Check root is accepted.
-			if roots[l.URL].Included(rootedChain[len(rootedChain)-1]) {
+			if roots[l.URL].Included(certRoot) {
 				compatibleOp.Logs = append(compatibleOp.Logs, l)
 			}
 		}

--- a/loglist2/logfilter_test.go
+++ b/loglist2/logfilter_test.go
@@ -64,16 +64,6 @@ func TestSelectUsable(t *testing.T) {
 	}
 }
 
-func cert() *x509.Certificate {
-	cert, _ := x509util.CertificateFromPEM([]byte(testdata.TestPreCertPEM))
-	return cert
-}
-
-func caCert() *x509.Certificate {
-	cert, _ := x509util.CertificateFromPEM([]byte(testdata.CACertPEM))
-	return cert
-}
-
 func artificialRoots(source string) LogRoots {
 	roots := LogRoots{
 		"https://log.bob.io":                   ctfe.NewPEMCertPool(),
@@ -86,6 +76,9 @@ func artificialRoots(source string) LogRoots {
 }
 
 func TestRootCompatible(t *testing.T) {
+	cert, _ := x509util.CertificateFromPEM([]byte(testdata.TestPreCertPEM))
+	caCert, _ := x509util.CertificateFromPEM([]byte(testdata.CACertPEM))
+
 	tests := []struct {
 		name     string
 		in       LogList
@@ -97,24 +90,24 @@ func TestRootCompatible(t *testing.T) {
 		{
 			name:     "RootedChain",
 			in:       sampleLogList,
-			cert:     cert(),
-			rootCert: caCert(),
+			cert:     cert,
+			rootCert: caCert,
 			roots:    artificialRoots(testdata.CACertPEM),
 			want:     subLogList(map[string]bool{"https://log.bob.io": true, "https://ct.googleapis.com/icarus/": true}), // icarus has no root info.
 		},
 		{
 			name:     "RootedChainNoRootAccepted",
 			in:       sampleLogList,
-			cert:     cert(),
-			rootCert: caCert(),
+			cert:     cert,
+			rootCert: caCert,
 			roots:    artificialRoots(testdata.TestPreCertPEM),
 			want:     subLogList(map[string]bool{"https://ct.googleapis.com/icarus/": true}), // icarus has no root info.
 		},
 		{
 			name:     "UnRootedChain",
 			in:       sampleLogList,
-			cert:     cert(),
-			rootCert: cert(),
+			cert:     cert,
+			rootCert: cert,
 			roots:    artificialRoots(testdata.CACertPEM),
 			want:     subLogList(map[string]bool{}),
 		},

--- a/loglist2/logfilter_test.go
+++ b/loglist2/logfilter_test.go
@@ -64,15 +64,14 @@ func TestSelectUsable(t *testing.T) {
 	}
 }
 
-func certChain() []*x509.Certificate {
+func cert() *x509.Certificate {
 	cert, _ := x509util.CertificateFromPEM([]byte(testdata.TestPreCertPEM))
-	caCert, _ := x509util.CertificateFromPEM([]byte(testdata.CACertPEM))
-	return []*x509.Certificate{cert, caCert}
+	return cert
 }
 
-func singleCert() []*x509.Certificate {
-	cert, _ := x509util.CertificateFromPEM([]byte(testdata.TestPreCertPEM))
-	return []*x509.Certificate{cert}
+func caCert() *x509.Certificate {
+	cert, _ := x509util.CertificateFromPEM([]byte(testdata.CACertPEM))
+	return cert
 }
 
 func artificialRoots(source string) LogRoots {
@@ -88,45 +87,50 @@ func artificialRoots(source string) LogRoots {
 
 func TestRootCompatible(t *testing.T) {
 	tests := []struct {
-		name  string
-		in    LogList
-		chain []*x509.Certificate
-		roots LogRoots
-		want  LogList
+		name     string
+		in       LogList
+		cert     *x509.Certificate
+		rootCert *x509.Certificate
+		roots    LogRoots
+		want     LogList
 	}{
 		{
-			name:  "RootedChain",
-			in:    sampleLogList,
-			chain: certChain(),
-			roots: artificialRoots(testdata.CACertPEM),
-			want:  subLogList(map[string]bool{"https://log.bob.io": true, "https://ct.googleapis.com/icarus/": true}), // icarus has no root info.
+			name:     "RootedChain",
+			in:       sampleLogList,
+			cert:     cert(),
+			rootCert: caCert(),
+			roots:    artificialRoots(testdata.CACertPEM),
+			want:     subLogList(map[string]bool{"https://log.bob.io": true, "https://ct.googleapis.com/icarus/": true}), // icarus has no root info.
 		},
 		{
-			name:  "RootedChainNoRootAccepted",
-			in:    sampleLogList,
-			chain: certChain(),
-			roots: artificialRoots(testdata.TestPreCertPEM),
-			want:  subLogList(map[string]bool{"https://ct.googleapis.com/icarus/": true}), // icarus has no root info.
+			name:     "RootedChainNoRootAccepted",
+			in:       sampleLogList,
+			cert:     cert(),
+			rootCert: caCert(),
+			roots:    artificialRoots(testdata.TestPreCertPEM),
+			want:     subLogList(map[string]bool{"https://ct.googleapis.com/icarus/": true}), // icarus has no root info.
 		},
 		{
-			name:  "UnRootedChain",
-			in:    sampleLogList,
-			chain: singleCert(),
-			roots: artificialRoots(testdata.CACertPEM),
-			want:  subLogList(map[string]bool{}),
+			name:     "UnRootedChain",
+			in:       sampleLogList,
+			cert:     cert(),
+			rootCert: cert(),
+			roots:    artificialRoots(testdata.CACertPEM),
+			want:     subLogList(map[string]bool{}),
 		},
 		{
-			name:  "EmptyChain",
-			in:    sampleLogList,
-			chain: []*x509.Certificate{},
-			roots: artificialRoots(testdata.CACertPEM),
-			want:  subLogList(map[string]bool{"https://ct.googleapis.com/icarus/": true}),
+			name:     "EmptyChain",
+			in:       sampleLogList,
+			cert:     nil,
+			rootCert: nil,
+			roots:    artificialRoots(testdata.CACertPEM),
+			want:     subLogList(map[string]bool{"https://ct.googleapis.com/icarus/": true}),
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := test.in.RootCompatible(test.chain, test.roots)
+			got := test.in.RootCompatible(test.cert, test.rootCert, test.roots)
 			if diff := pretty.Compare(test.want, got); diff != "" {
 				t.Errorf("Getting compatible logs diff: (-want +got)\n%s", diff)
 			}


### PR DESCRIPTION
Removing full chain input. Using original cert and its root only.