### PR TITLE
Fix nit where type byte is used to name a variable.

### DIFF
--- a/x509util/x509util.go
+++ b/x509util/x509util.go
@@ -112,14 +112,14 @@ func publicKeyAlgorithmToString(algo x509.PublicKeyAlgorithm) string {
 // after each set of count bytes, and with each new line prefixed with the
 // given prefix.
 func appendHexData(buf *bytes.Buffer, data []byte, count int, prefix string) {
-	for ii, byte := range data {
+	for ii, b := range data {
 		if ii%count == 0 {
 			if ii > 0 {
 				buf.WriteString("\n")
 			}
 			buf.WriteString(prefix)
 		}
-		buf.WriteString(fmt.Sprintf("%02x:", byte))
+		buf.WriteString(fmt.Sprintf("%02x:", b))
 	}
 }
 


### PR DESCRIPTION
Probably better not to do this, though it does currently work.