### PR TITLE
Fix an easy deprecation in ct_integration.

### DIFF
--- a/trillian/integration/ct_integration.go
+++ b/trillian/integration/ct_integration.go
@@ -71,7 +71,6 @@ var DefaultTransport = &http.Transport{
 	DialContext: (&net.Dialer{
 		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,
-		DualStack: true,
 	}).DialContext,
 	MaxIdleConns:          1000,
 	MaxIdleConnsPerHost:   1000,


### PR DESCRIPTION
The DualStack: true behaviour is now the default.