### PR TITLE
Remove usages of all deprecated SignedLogRoot fields from ct-go

### DIFF
--- a/trillian/ctfe/handlers.go
+++ b/trillian/ctfe/handlers.go
@@ -647,12 +647,12 @@ func getProofByHash(ctx context.Context, li *logInfo, w http.ResponseWriter, r *
 		return li.toHTTPStatus(err), fmt.Errorf("backend GetInclusionProofByHash request failed: %s", err)
 	}
 
-	// We could fail to get the proof because the tree size that the server has
-	// is not large enough.
 	var currentRoot types.LogRootV1
 	if err := currentRoot.UnmarshalBinary(rsp.GetSignedLogRoot().GetLogRoot()); err != nil {
 		return http.StatusInternalServerError, fmt.Errorf("failed to unmarshal root: %v", rsp.GetSignedLogRoot().GetLogRoot())
 	}
+	// We could fail to get the proof because the tree size that the server has
+	// is not large enough.
 	if currentRoot.TreeSize < uint64(treeSize) {
 		return http.StatusNotFound, fmt.Errorf("log returned tree size: %d but we expected: %d", currentRoot.TreeSize, treeSize)
 	}

--- a/trillian/ctfe/handlers.go
+++ b/trillian/ctfe/handlers.go
@@ -724,7 +724,7 @@ func getEntries(ctx context.Context, li *logInfo, w http.ResponseWriter, r *http
 		if currentRoot.TreeSize <= uint64(start) {
 			// If the returned tree is too small to contain any leaves return the 4xx
 			// explicitly here.
-			return http.StatusBadRequest, fmt.Errorf("request for leaves from %d but current tree size only %d", start, currentRoot.TreeSize)
+			return http.StatusBadRequest, fmt.Errorf("need tree size: %d to get leaves but only got: %d", start+1, currentRoot.TreeSize)
 		}
 		// Do some sanity checks on the result.
 		if len(rsp.Leaves) > int(count) {
@@ -755,7 +755,7 @@ func getEntries(ctx context.Context, li *logInfo, w http.ResponseWriter, r *http
 			// If the returned tree is too small to contain any leaves return the 4xx
 			// explicitly here. It was previously returned via the error status
 			// mapping above.
-			return http.StatusBadRequest, fmt.Errorf("need tree size: %d to get leaves but only got: %d", currentRoot.TreeSize, start)
+			return http.StatusBadRequest, fmt.Errorf("need tree size: %d to get leaves but only got: %d", start+1, currentRoot.TreeSize)
 		}
 
 		// Trillian doesn't guarantee the returned leaves are in order (they don't need to be

--- a/trillian/ctfe/handlers_test.go
+++ b/trillian/ctfe/handlers_test.go
@@ -726,26 +726,26 @@ func TestGetSTH(t *testing.T) {
 		},
 		{
 			descr:  "bad-hash",
-			rpcRsp: makeGetRootResponseForTest(12345, 25, []byte("thisisnot32byteslong")),
+			rpcRsp: makeGetRootResponseForTest(t, 12345, 25, []byte("thisisnot32byteslong")),
 			want:   http.StatusInternalServerError,
 			errStr: "bad hash size",
 		},
 		{
 			descr:   "signer-fail",
-			rpcRsp:  makeGetRootResponseForTest(12345, 25, []byte("abcdabcdabcdabcdabcdabcdabcdabcd")),
+			rpcRsp:  makeGetRootResponseForTest(t, 12345, 25, []byte("abcdabcdabcdabcdabcdabcdabcdabcd")),
 			want:    http.StatusInternalServerError,
 			signErr: errors.New("signerfails"),
 			errStr:  "signerfails",
 		},
 		{
 			descr:  "ok",
-			rpcRsp: makeGetRootResponseForTest(12345000000, 25, []byte("abcdabcdabcdabcdabcdabcdabcdabcd")),
+			rpcRsp: makeGetRootResponseForTest(t, 12345000000, 25, []byte("abcdabcdabcdabcdabcdabcdabcdabcd")),
 			toSign: "1e88546f5157bfaf77ca2454690b602631fedae925bbe7cf708ea275975bfe74",
 			want:   http.StatusOK,
 		},
 		{
 			descr:         "ok with quota",
-			rpcRsp:        makeGetRootResponseForTest(12345000000, 25, []byte("abcdabcdabcdabcdabcdabcdabcdabcd")),
+			rpcRsp:        makeGetRootResponseForTest(t, 12345000000, 25, []byte("abcdabcdabcdabcdabcdabcdabcdabcd")),
 			toSign:        "1e88546f5157bfaf77ca2454690b602631fedae925bbe7cf708ea275975bfe74",
 			want:          http.StatusOK,
 			wantQuotaUser: remoteQuotaUser,
@@ -914,7 +914,7 @@ func runTestGetEntries(t *testing.T) {
 		{
 			descr: "start outside tree size",
 			req:   "start=2&end=3",
-			slr: mustMarshalRoot(&types.LogRootV1{
+			slr: mustMarshalRoot(t, &types.LogRootV1{
 				TreeSize: 2, // Not large enough - only indices 0 and 1 valid.
 			}),
 			glbir:  &trillian.GetLeavesByIndexRequest{LogId: 0x42, LeafIndex: []int64{2, 3}},
@@ -926,7 +926,7 @@ func runTestGetEntries(t *testing.T) {
 		{
 			descr: "backend extra leaves",
 			req:   "start=1&end=2",
-			slr: mustMarshalRoot(&types.LogRootV1{
+			slr: mustMarshalRoot(t, &types.LogRootV1{
 				TreeSize: 2,
 			}),
 			want:   http.StatusInternalServerError,
@@ -936,7 +936,7 @@ func runTestGetEntries(t *testing.T) {
 		{
 			descr:  "backend non-contiguous range",
 			req:    "start=1&end=2",
-			slr:    mustMarshalRoot(&types.LogRootV1{TreeSize: 100}),
+			slr:    mustMarshalRoot(t, &types.LogRootV1{TreeSize: 100}),
 			want:   http.StatusInternalServerError,
 			leaves: []*trillian.LogLeaf{{LeafIndex: 1}, {LeafIndex: 3}},
 			errStr: "unexpected leaf index",
@@ -944,7 +944,7 @@ func runTestGetEntries(t *testing.T) {
 		{
 			descr: "backend leaf corrupt",
 			req:   "start=1&end=2",
-			slr:   mustMarshalRoot(&types.LogRootV1{TreeSize: 100}),
+			slr:   mustMarshalRoot(t, &types.LogRootV1{TreeSize: 100}),
 			want:  http.StatusOK,
 			leaves: []*trillian.LogLeaf{
 				{LeafIndex: 1, MerkleLeafHash: []byte("hash"), LeafValue: []byte("NOT A MERKLE TREE LEAF")},
@@ -954,7 +954,7 @@ func runTestGetEntries(t *testing.T) {
 		{
 			descr: "leaves ok",
 			req:   "start=1&end=2",
-			slr:   mustMarshalRoot(&types.LogRootV1{TreeSize: 100}),
+			slr:   mustMarshalRoot(t, &types.LogRootV1{TreeSize: 100}),
 			want:  http.StatusOK,
 			leaves: []*trillian.LogLeaf{
 				{LeafIndex: 1, MerkleLeafHash: []byte("hash"), LeafValue: merkleBytes1, ExtraData: []byte("extra1")},
@@ -964,7 +964,7 @@ func runTestGetEntries(t *testing.T) {
 		{
 			descr:         "leaves ok with quota",
 			req:           "start=1&end=2",
-			slr:           mustMarshalRoot(&types.LogRootV1{TreeSize: 100}),
+			slr:           mustMarshalRoot(t, &types.LogRootV1{TreeSize: 100}),
 			want:          http.StatusOK,
 			wantQuotaUser: remoteQuotaUser,
 			leaves: []*trillian.LogLeaf{
@@ -978,7 +978,7 @@ func runTestGetEntries(t *testing.T) {
 			glbir: &trillian.GetLeavesByIndexRequest{LogId: 0x42, LeafIndex: []int64{5, 6}},
 			glbrr: &trillian.GetLeavesByRangeRequest{LogId: 0x42, StartIndex: 5, Count: 2},
 			want:  http.StatusBadRequest,
-			slr: mustMarshalRoot(&types.LogRootV1{
+			slr: mustMarshalRoot(t, &types.LogRootV1{
 				TreeSize: 5,
 			}),
 			leaves: []*trillian.LogLeaf{},
@@ -989,7 +989,7 @@ func runTestGetEntries(t *testing.T) {
 			glbir: &trillian.GetLeavesByIndexRequest{LogId: 0x42, LeafIndex: []int64{5, 6}},
 			glbrr: &trillian.GetLeavesByRangeRequest{LogId: 0x42, StartIndex: 5, Count: 2},
 			want:  http.StatusOK,
-			slr: mustMarshalRoot(&types.LogRootV1{
+			slr: mustMarshalRoot(t, &types.LogRootV1{
 				TreeSize: 6,
 			}),
 			leaves: []*trillian.LogLeaf{
@@ -1002,7 +1002,7 @@ func runTestGetEntries(t *testing.T) {
 			glbir: &trillian.GetLeavesByIndexRequest{LogId: 0x42, LeafIndex: []int64{5, 6}},
 			glbrr: &trillian.GetLeavesByRangeRequest{LogId: 0x42, StartIndex: 5, Count: 2},
 			want:  http.StatusOK,
-			slr: mustMarshalRoot(&types.LogRootV1{
+			slr: mustMarshalRoot(t, &types.LogRootV1{
 				TreeSize: 7,
 			}),
 			leaves: []*trillian.LogLeaf{
@@ -1024,7 +1024,7 @@ func runTestGetEntries(t *testing.T) {
 		}
 		slr := test.slr
 		if slr == nil {
-			slr = mustMarshalRoot(&types.LogRootV1{})
+			slr = mustMarshalRoot(t, &types.LogRootV1{})
 		}
 		if test.leaves != nil || test.rpcErr != nil {
 			var chargeTo *trillian.ChargeTo
@@ -1317,7 +1317,7 @@ func TestGetProofByHash(t *testing.T) {
 			req:  "tree_size=11&hash=YWhhc2g=",
 			want: http.StatusNotFound,
 			rpcRsp: &trillian.GetInclusionProofByHashResponse{
-				SignedLogRoot: mustMarshalRoot(&types.LogRootV1{
+				SignedLogRoot: mustMarshalRoot(t, &types.LogRootV1{
 					TreeSize: 10, // Not large enough to handle the request.
 				}),
 				Proof: []*trillian.Proof{
@@ -1341,7 +1341,7 @@ func TestGetProofByHash(t *testing.T) {
 			req:  "tree_size=1&hash=YWhhc2g=",
 			want: http.StatusOK,
 			rpcRsp: &trillian.GetInclusionProofByHashResponse{
-				SignedLogRoot: mustMarshalRoot(&types.LogRootV1{
+				SignedLogRoot: mustMarshalRoot(t, &types.LogRootV1{
 					TreeSize: 10,
 				}),
 				Proof: []*trillian.Proof{
@@ -1361,7 +1361,7 @@ func TestGetProofByHash(t *testing.T) {
 			// Want quota
 			wantQuotaUser: remoteQuotaUser,
 			rpcRsp: &trillian.GetInclusionProofByHashResponse{
-				SignedLogRoot: mustMarshalRoot(&types.LogRootV1{
+				SignedLogRoot: mustMarshalRoot(t, &types.LogRootV1{
 					TreeSize: 10,
 				}),
 				Proof: []*trillian.Proof{
@@ -1379,7 +1379,7 @@ func TestGetProofByHash(t *testing.T) {
 			req:  "tree_size=7&hash=YWhhc2g=",
 			want: http.StatusOK,
 			rpcRsp: &trillian.GetInclusionProofByHashResponse{
-				SignedLogRoot: mustMarshalRoot(&types.LogRootV1{
+				SignedLogRoot: mustMarshalRoot(t, &types.LogRootV1{
 					TreeSize: 10,
 				}),
 				Proof: []*trillian.Proof{
@@ -1400,7 +1400,7 @@ func TestGetProofByHash(t *testing.T) {
 			req:  "tree_size=9&hash=YWhhc2g=",
 			want: http.StatusInternalServerError,
 			rpcRsp: &trillian.GetInclusionProofByHashResponse{
-				SignedLogRoot: mustMarshalRoot(&types.LogRootV1{
+				SignedLogRoot: mustMarshalRoot(t, &types.LogRootV1{
 					TreeSize: 10,
 				}),
 				Proof: []*trillian.Proof{
@@ -1420,7 +1420,7 @@ func TestGetProofByHash(t *testing.T) {
 			req:  "tree_size=7&hash=YWhhc2g=",
 			want: http.StatusOK,
 			rpcRsp: &trillian.GetInclusionProofByHashResponse{
-				SignedLogRoot: mustMarshalRoot(&types.LogRootV1{
+				SignedLogRoot: mustMarshalRoot(t, &types.LogRootV1{
 					TreeSize: 10,
 				}),
 				Proof: []*trillian.Proof{
@@ -1437,7 +1437,7 @@ func TestGetProofByHash(t *testing.T) {
 			req:  "hash=WtfX3Axbm7UwtY7GhHoAHPCtXJVrY5vZsH%2ByaXOD2GI=&tree_size=1",
 			want: http.StatusOK,
 			rpcRsp: &trillian.GetInclusionProofByHashResponse{
-				SignedLogRoot: mustMarshalRoot(&types.LogRootV1{
+				SignedLogRoot: mustMarshalRoot(t, &types.LogRootV1{
 					TreeSize: 10,
 				}),
 				Proof: []*trillian.Proof{
@@ -1453,7 +1453,7 @@ func TestGetProofByHash(t *testing.T) {
 			req:  "tree_size=10&hash=YWhhc2g=",
 			want: http.StatusNotFound,
 			rpcRsp: &trillian.GetInclusionProofByHashResponse{
-				SignedLogRoot: mustMarshalRoot(&types.LogRootV1{
+				SignedLogRoot: mustMarshalRoot(t, &types.LogRootV1{
 					TreeSize: 5,
 				}),
 				Proof: []*trillian.Proof{
@@ -1468,7 +1468,7 @@ func TestGetProofByHash(t *testing.T) {
 			req:  "tree_size=10&hash=YWhhc2g=",
 			want: http.StatusOK,
 			rpcRsp: &trillian.GetInclusionProofByHashResponse{
-				SignedLogRoot: mustMarshalRoot(&types.LogRootV1{
+				SignedLogRoot: mustMarshalRoot(t, &types.LogRootV1{
 					// Returned tree large enough to include the leaf.
 					TreeSize: 10,
 				}),
@@ -1485,7 +1485,7 @@ func TestGetProofByHash(t *testing.T) {
 			req:  "tree_size=10&hash=YWhhc2g=",
 			want: http.StatusOK,
 			rpcRsp: &trillian.GetInclusionProofByHashResponse{
-				SignedLogRoot: mustMarshalRoot(&types.LogRootV1{
+				SignedLogRoot: mustMarshalRoot(t, &types.LogRootV1{
 					// Returned tree larger than needed to include the leaf.
 					TreeSize: 20,
 				}),
@@ -1661,7 +1661,7 @@ func TestGetSTHConsistency(t *testing.T) {
 			second: 20,
 			want:   http.StatusInternalServerError,
 			rpcRsp: &trillian.GetConsistencyProofResponse{
-				SignedLogRoot: mustMarshalRoot(&types.LogRootV1{
+				SignedLogRoot: mustMarshalRoot(t, &types.LogRootV1{
 					TreeSize: 50,
 				}),
 				Proof: &trillian.Proof{
@@ -1693,7 +1693,7 @@ func TestGetSTHConsistency(t *testing.T) {
 			second: 20,
 			want:   http.StatusBadRequest,
 			rpcRsp: &trillian.GetConsistencyProofResponse{
-				SignedLogRoot: mustMarshalRoot(&types.LogRootV1{
+				SignedLogRoot: mustMarshalRoot(t, &types.LogRootV1{
 					TreeSize: 19, // Tree not large enough to serve the request.
 				}),
 				Proof: &trillian.Proof{
@@ -1713,7 +1713,7 @@ func TestGetSTHConsistency(t *testing.T) {
 			second: 20,
 			want:   http.StatusInternalServerError,
 			rpcRsp: &trillian.GetConsistencyProofResponse{
-				SignedLogRoot: mustMarshalRoot(&types.LogRootV1{
+				SignedLogRoot: mustMarshalRoot(t, &types.LogRootV1{
 					TreeSize: 50,
 				}),
 				Proof: &trillian.Proof{
@@ -1733,7 +1733,7 @@ func TestGetSTHConsistency(t *testing.T) {
 			second: 20,
 			want:   http.StatusOK,
 			rpcRsp: &trillian.GetConsistencyProofResponse{
-				SignedLogRoot: mustMarshalRoot(&types.LogRootV1{
+				SignedLogRoot: mustMarshalRoot(t, &types.LogRootV1{
 					TreeSize: 50,
 				}),
 				Proof: &trillian.Proof{
@@ -1751,7 +1751,7 @@ func TestGetSTHConsistency(t *testing.T) {
 			second: 2,
 			want:   http.StatusOK,
 			rpcRsp: &trillian.GetConsistencyProofResponse{
-				SignedLogRoot: mustMarshalRoot(&types.LogRootV1{
+				SignedLogRoot: mustMarshalRoot(t, &types.LogRootV1{
 					TreeSize: 50,
 				}),
 				Proof: &trillian.Proof{
@@ -1771,7 +1771,7 @@ func TestGetSTHConsistency(t *testing.T) {
 			second: 332,
 			want:   http.StatusOK,
 			rpcRsp: &trillian.GetConsistencyProofResponse{
-				SignedLogRoot: mustMarshalRoot(&types.LogRootV1{
+				SignedLogRoot: mustMarshalRoot(t, &types.LogRootV1{
 					TreeSize: 333,
 				}),
 				Proof: &trillian.Proof{
@@ -1791,7 +1791,7 @@ func TestGetSTHConsistency(t *testing.T) {
 			second: 332,
 			want:   http.StatusBadRequest,
 			rpcRsp: &trillian.GetConsistencyProofResponse{
-				SignedLogRoot: mustMarshalRoot(&types.LogRootV1{
+				SignedLogRoot: mustMarshalRoot(t, &types.LogRootV1{
 					// Backend returns a tree size too small to satisfy the proof.
 					TreeSize: 331,
 				}),
@@ -1806,7 +1806,7 @@ func TestGetSTHConsistency(t *testing.T) {
 			second: 332,
 			want:   http.StatusOK,
 			rpcRsp: &trillian.GetConsistencyProofResponse{
-				SignedLogRoot: mustMarshalRoot(&types.LogRootV1{
+				SignedLogRoot: mustMarshalRoot(t, &types.LogRootV1{
 					// Backend returns a tree size just large enough to satisfy the proof.
 					TreeSize: 332,
 				}),
@@ -1825,7 +1825,7 @@ func TestGetSTHConsistency(t *testing.T) {
 			second: 332,
 			want:   http.StatusOK,
 			rpcRsp: &trillian.GetConsistencyProofResponse{
-				SignedLogRoot: mustMarshalRoot(&types.LogRootV1{
+				SignedLogRoot: mustMarshalRoot(t, &types.LogRootV1{
 					// Backend returns a tree size larger than needed to satisfy the proof.
 					TreeSize: 333,
 				}),
@@ -1996,7 +1996,7 @@ func TestGetEntryAndProof(t *testing.T) {
 			want:    http.StatusOK,
 			wantRsp: &proofRsp,
 			rpcRsp: &trillian.GetEntryAndProofResponse{
-				SignedLogRoot: mustMarshalRoot(&types.LogRootV1{
+				SignedLogRoot: mustMarshalRoot(t, &types.LogRootV1{
 					// Server returns a tree not large enough for the proof.
 					TreeSize: 20,
 				}),
@@ -2025,7 +2025,7 @@ func TestGetEntryAndProof(t *testing.T) {
 			// wantQuota
 			wantQuotaUser: remoteQuotaUser,
 			rpcRsp: &trillian.GetEntryAndProofResponse{
-				SignedLogRoot: mustMarshalRoot(&types.LogRootV1{
+				SignedLogRoot: mustMarshalRoot(t, &types.LogRootV1{
 					// Server returns a tree not large enough for the proof.
 					TreeSize: 20,
 				}),
@@ -2051,7 +2051,7 @@ func TestGetEntryAndProof(t *testing.T) {
 			sz:   3,
 			want: http.StatusBadRequest,
 			rpcRsp: &trillian.GetEntryAndProofResponse{
-				SignedLogRoot: mustMarshalRoot(&types.LogRootV1{
+				SignedLogRoot: mustMarshalRoot(t, &types.LogRootV1{
 					// Server returns a tree not large enough for the proof.
 					TreeSize: 2,
 				}),
@@ -2065,7 +2065,7 @@ func TestGetEntryAndProof(t *testing.T) {
 			want:    http.StatusOK,
 			wantRsp: &proofRsp,
 			rpcRsp: &trillian.GetEntryAndProofResponse{
-				SignedLogRoot: mustMarshalRoot(&types.LogRootV1{
+				SignedLogRoot: mustMarshalRoot(t, &types.LogRootV1{
 					// Server returns a tree just large enough for the proof.
 					TreeSize: 3,
 				}),
@@ -2092,7 +2092,7 @@ func TestGetEntryAndProof(t *testing.T) {
 			want:    http.StatusOK,
 			wantRsp: &proofRsp,
 			rpcRsp: &trillian.GetEntryAndProofResponse{
-				SignedLogRoot: mustMarshalRoot(&types.LogRootV1{
+				SignedLogRoot: mustMarshalRoot(t, &types.LogRootV1{
 					// Server returns a tree larger than needed for the proof.
 					TreeSize: 300,
 				}),
@@ -2122,7 +2122,7 @@ func TestGetEntryAndProof(t *testing.T) {
 				ExtraData: []byte("extra"),
 			},
 			rpcRsp: &trillian.GetEntryAndProofResponse{
-				SignedLogRoot: mustMarshalRoot(&types.LogRootV1{
+				SignedLogRoot: mustMarshalRoot(t, &types.LogRootV1{
 					// Server returns a tree larger than needed for the proof.
 					TreeSize: 300,
 				}),
@@ -2144,7 +2144,7 @@ func TestGetEntryAndProof(t *testing.T) {
 			sz:   1,
 			want: http.StatusInternalServerError,
 			rpcRsp: &trillian.GetEntryAndProofResponse{
-				SignedLogRoot: mustMarshalRoot(&types.LogRootV1{
+				SignedLogRoot: mustMarshalRoot(t, &types.LogRootV1{
 					// Server returns a tree larger than needed for the proof.
 					TreeSize: 300,
 				}),
@@ -2162,7 +2162,7 @@ func TestGetEntryAndProof(t *testing.T) {
 			sz:   1,
 			want: http.StatusInternalServerError,
 			rpcRsp: &trillian.GetEntryAndProofResponse{
-				SignedLogRoot: mustMarshalRoot(&types.LogRootV1{
+				SignedLogRoot: mustMarshalRoot(t, &types.LogRootV1{
 					// Server returns a tree larger than needed for the proof.
 					TreeSize: 300,
 				}),
@@ -2233,7 +2233,9 @@ func createJSONChain(t *testing.T, p PEMCertPool) io.Reader {
 	// It's tempting to avoid creating and flushing the intermediate writer but it doesn't work
 	writer := bufio.NewWriter(&buffer)
 	err := json.NewEncoder(writer).Encode(&req)
-	writer.Flush()
+	if err := writer.Flush(); err != nil {
+		t.Error(err)
+	}
 
 	if err != nil {
 		t.Fatalf("Failed to create test json: %v", err)
@@ -2310,9 +2312,10 @@ func makeAddChainRequestInternal(t *testing.T, handler AppHandler, path string, 
 	return w
 }
 
-func makeGetRootResponseForTest(stamp, treeSize int64, hash []byte) *trillian.GetLatestSignedLogRootResponse {
+func makeGetRootResponseForTest(t *testing.T, stamp, treeSize int64, hash []byte) *trillian.GetLatestSignedLogRootResponse {
+	t.Helper()
 	return &trillian.GetLatestSignedLogRootResponse{
-		SignedLogRoot: mustMarshalRoot(&types.LogRootV1{
+		SignedLogRoot: mustMarshalRoot(t, &types.LogRootV1{
 			TimestampNanos: uint64(stamp),
 			TreeSize:       uint64(treeSize),
 			RootHash:       hash,
@@ -2331,10 +2334,11 @@ func loadCertsIntoPoolOrDie(t *testing.T, certs []string) *PEMCertPool {
 	return pool
 }
 
-func mustMarshalRoot(lr *types.LogRootV1) *trillian.SignedLogRoot {
+func mustMarshalRoot(t *testing.T, lr *types.LogRootV1) *trillian.SignedLogRoot {
+	t.Helper()
 	rootBytes, err := lr.MarshalBinary()
 	if err != nil {
-		glog.Fatalf("Failed to marshal root in test: %v", err)
+		t.Fatalf("Failed to marshal root in test: %v", err)
 	}
 	return &trillian.SignedLogRoot{
 		LogRoot: rootBytes,

--- a/trillian/ctfe/handlers_test.go
+++ b/trillian/ctfe/handlers_test.go
@@ -900,6 +900,18 @@ func runTestGetEntries(t *testing.T) {
 			errStr: "bang",
 		},
 		{
+			descr: "invalid log root",
+			req:   "start=2&end=3",
+			slr: &trillian.SignedLogRoot{
+				LogRoot: []byte("not tls encoded data"),
+			},
+			glbir:  &trillian.GetLeavesByIndexRequest{LogId: 0x42, LeafIndex: []int64{2, 3}},
+			glbrr:  &trillian.GetLeavesByRangeRequest{LogId: 0x42, StartIndex: 2, Count: 2},
+			want:   http.StatusInternalServerError,
+			leaves: []*trillian.LogLeaf{{LeafIndex: 2}, {LeafIndex: 3}},
+			errStr: "failed to unmarshal",
+		},
+		{
 			descr: "start outside tree size",
 			req:   "start=2&end=3",
 			slr: mustMarshalRoot(&types.LogRootV1{
@@ -1317,6 +1329,15 @@ func TestGetProofByHash(t *testing.T) {
 			},
 		},
 		{
+			req:  "tree_size=11&hash=YWhhc2g=",
+			want: http.StatusInternalServerError,
+			rpcRsp: &trillian.GetInclusionProofByHashResponse{
+				SignedLogRoot: &trillian.SignedLogRoot{
+					LogRoot: []byte("not tls encoded data"),
+				},
+			},
+		},
+		{
 			req:  "tree_size=1&hash=YWhhc2g=",
 			want: http.StatusOK,
 			rpcRsp: &trillian.GetInclusionProofByHashResponse{
@@ -1653,6 +1674,18 @@ func TestGetSTHConsistency(t *testing.T) {
 				},
 			},
 			errStr: "invalid proof",
+		},
+		{
+			req:    "first=10&second=20",
+			first:  10,
+			second: 20,
+			want:   http.StatusInternalServerError,
+			rpcRsp: &trillian.GetConsistencyProofResponse{
+				SignedLogRoot: &trillian.SignedLogRoot{
+					LogRoot: []byte("not tls encoded data"),
+				},
+			},
+			errStr: "failed to unmarshal",
 		},
 		{
 			req:    "first=10&second=20",

--- a/trillian/ctfe/sth.go
+++ b/trillian/ctfe/sth.go
@@ -153,9 +153,6 @@ func getSignedLogRoot(ctx context.Context, client trillian.TrillianLogClient, lo
 	if err := currentRoot.UnmarshalBinary(slr.GetLogRoot()); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal root: %v", slr)
 	}
-	if treeSize := currentRoot.TreeSize; treeSize < 0 {
-		return nil, fmt.Errorf("bad tree size from backend: %d", treeSize)
-	}
 	if hashSize := len(currentRoot.RootHash); hashSize != sha256.Size {
 		return nil, fmt.Errorf("bad hash size from backend expecting: %d got %d", sha256.Size, hashSize)
 	}

--- a/trillian/ctfe/sth_test.go
+++ b/trillian/ctfe/sth_test.go
@@ -1,0 +1,302 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ctfe
+
+import (
+	"context"
+	"crypto"
+	"errors"
+	"io"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	ct "github.com/google/certificate-transparency-go"
+	"github.com/google/certificate-transparency-go/tls"
+	"github.com/google/certificate-transparency-go/trillian/mockclient"
+	"github.com/google/trillian"
+	"github.com/google/trillian/types"
+)
+
+type testCase struct {
+	desc     string
+	ctxSetup func(ctx context.Context) context.Context
+	ms       MirrorSTHStorage // Only set for mirror getter tests.
+	slr      *trillian.GetLatestSignedLogRootResponse
+	slrErr   error
+	sig      []byte // Only set (and sigErr) for log getter tests.
+	sigErr   error
+	wantSTH  *ct.SignedTreeHead
+	errStr   string
+}
+
+// commonTests are valid for both cases, mostly basic parameter checks
+// and type / error handling.
+var commonTests = []testCase{
+	{
+		desc: "bad quota value",
+		ctxSetup: func(ctx context.Context) context.Context {
+			return context.WithValue(ctx, remoteQuotaCtxKey, []byte("not a string value"))
+		},
+		errStr: "incorrect quota",
+	},
+	{
+		desc:   "latest root RPC fails",
+		slrErr: errors.New("slr failed"),
+		errStr: "slr failed",
+	},
+	{
+		desc:   "nil slr",
+		slr:    &trillian.GetLatestSignedLogRootResponse{},
+		errStr: "no log root",
+	},
+	{
+		desc:   "bad slr",
+		slr:    &trillian.GetLatestSignedLogRootResponse{SignedLogRoot: &trillian.SignedLogRoot{LogRoot: []byte("not tls encoded")}},
+		errStr: "unmarshal root: log_root:\"not tls",
+	},
+	{
+		desc: "bad hash",
+		slr: &trillian.GetLatestSignedLogRootResponse{
+			SignedLogRoot: mustMarshalRoot(
+				&types.LogRootV1{RootHash: []byte("not a 32 byte hash")}),
+		},
+		errStr: "bad hash size",
+	},
+}
+
+// logTests apply only to the LogSTHGetter where things are signed.
+var logTests = []testCase{
+	{
+		desc: "signer error",
+		slr: &trillian.GetLatestSignedLogRootResponse{
+			SignedLogRoot: mustMarshalRoot(
+				&types.LogRootV1{RootHash: []byte("12345678123456781234567812345678")}),
+		},
+		sigErr: errors.New("not signing that"),
+		errStr: "sign tree head: not signing",
+	},
+	{
+		desc: "empty sig",
+		slr: &trillian.GetLatestSignedLogRootResponse{
+			SignedLogRoot: mustMarshalRoot(
+				&types.LogRootV1{RootHash: []byte("12345678123456781234567812345678")}),
+		},
+		sig:    []byte{},
+		errStr: "sign tree head: <nil>",
+	},
+	{
+		desc: "ok",
+		slr: &trillian.GetLatestSignedLogRootResponse{
+			SignedLogRoot: mustMarshalRoot(
+				&types.LogRootV1{
+					// Ensure response contains all fields needed for the CT STH.
+					TreeSize:       12345,
+					TimestampNanos: 987654321,
+					RootHash:       []byte("12345678123456781234567812345678")}),
+		},
+		sig: []byte("signedit"),
+		wantSTH: &ct.SignedTreeHead{
+			Timestamp:      987,
+			SHA256RootHash: hashFromString("12345678123456781234567812345678"),
+			TreeHeadSignature: ct.DigitallySigned{
+				Algorithm: tls.SignatureAndHashAlgorithm{
+					Hash:      tls.SHA256,
+					Signature: tls.SignatureAlgorithmFromPubKey(tls.Anonymous),
+				},
+				Signature: []byte("signedit"),
+			},
+			TreeSize: 12345,
+		},
+	},
+}
+
+// mirrorTests apply only to the MirrorSTHGetter where sth is read from a store.
+var mirrorTests = []testCase{
+	{
+		desc: "bad mirror storage",
+		ms: &fakeMirrorSTHStorage{
+			err: errors.New("mirror store failed"),
+		},
+		slr: &trillian.GetLatestSignedLogRootResponse{
+			SignedLogRoot: mustMarshalRoot(
+				&types.LogRootV1{
+					// Ensure response contains all fields needed for the CT STH.
+					TreeSize:       12345,
+					TimestampNanos: 987654321,
+					RootHash:       []byte("12345678123456781234567812345678")}),
+		},
+		errStr: "mirror store failed",
+	},
+	{
+		desc: "ok",
+		ms: &fakeMirrorSTHStorage{
+			sth: &ct.SignedTreeHead{
+				Timestamp:      987,
+				SHA256RootHash: hashFromString("12345678123456781234567812345678"),
+				TreeHeadSignature: ct.DigitallySigned{
+					Algorithm: tls.SignatureAndHashAlgorithm{
+						Hash:      tls.SHA256,
+						Signature: tls.SignatureAlgorithmFromPubKey(tls.Anonymous),
+					},
+					Signature: []byte("signedit"),
+				},
+				TreeSize: 12345,
+			},
+		},
+		slr: &trillian.GetLatestSignedLogRootResponse{
+			SignedLogRoot: mustMarshalRoot(
+				&types.LogRootV1{
+					// Ensure response contains all fields needed for the CT STH.
+					TreeSize:       12345,
+					TimestampNanos: 987654321,
+					RootHash:       []byte("12345678123456781234567812345678")}),
+		},
+		wantSTH: &ct.SignedTreeHead{
+			Timestamp:      987,
+			SHA256RootHash: hashFromString("12345678123456781234567812345678"),
+			TreeHeadSignature: ct.DigitallySigned{
+				Algorithm: tls.SignatureAndHashAlgorithm{
+					Hash:      tls.SHA256,
+					Signature: tls.SignatureAlgorithmFromPubKey(tls.Anonymous),
+				},
+				Signature: []byte("signedit"),
+			},
+			TreeSize: 12345,
+		},
+	},
+}
+
+func TestLogSTHGetter(t *testing.T) {
+	// Note: Does not test signature cache interaction as this is inside
+	// signV1TreeHead and covered by other tests.
+	tests := make([]testCase, 0, 30)
+	tests = append(tests, commonTests...)
+	tests = append(tests, logTests...)
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			rpcCl := mockclient.NewMockTrillianLogClient(ctrl)
+			if tc.slr != nil || tc.slrErr != nil {
+				rpcCl.EXPECT().GetLatestSignedLogRoot(gomock.Any(), &trillian.GetLatestSignedLogRootRequest{LogId: 99}).Return(tc.slr, tc.slrErr)
+			}
+
+			sthg := LogSTHGetter{li: &logInfo{rpcClient: rpcCl, logID: 99, signer: &fakeSigner{sig: tc.sig, err: tc.sigErr}}}
+			ctx := context.Background()
+			if tc.ctxSetup != nil {
+				ctx = tc.ctxSetup(ctx)
+			}
+
+			sth, err := sthg.GetSTH(ctx)
+			if len(tc.errStr) > 0 {
+				if err == nil || !strings.Contains(err.Error(), tc.errStr) {
+					t.Errorf("GetSTH()=%v, %v want: nil, err containing %s", sth, err, tc.errStr)
+				}
+			} else {
+				if err != nil || !reflect.DeepEqual(sth, tc.wantSTH) {
+					t.Errorf("GetSTH()=%v, %v, want: %v, nil", sth, err, tc.wantSTH)
+				}
+			}
+			ctrl.Finish()
+		})
+	}
+}
+
+func TestMirrorSTHGetter(t *testing.T) {
+	// Note: This does not test the operation of MirrorSTHStorage. Implementations
+	// of this need their own tests.
+	tests := make([]testCase, 0, 30)
+	tests = append(tests, commonTests...)
+	tests = append(tests, mirrorTests...)
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			rpcCl := mockclient.NewMockTrillianLogClient(ctrl)
+			if tc.slr != nil || tc.slrErr != nil {
+				rpcCl.EXPECT().GetLatestSignedLogRoot(gomock.Any(), &trillian.GetLatestSignedLogRootRequest{LogId: 99}).Return(tc.slr, tc.slrErr)
+			}
+
+			sthg := MirrorSTHGetter{li: &logInfo{rpcClient: rpcCl, logID: 99}, st: tc.ms}
+			ctx := context.Background()
+			if tc.ctxSetup != nil {
+				ctx = tc.ctxSetup(ctx)
+			}
+
+			sth, err := sthg.GetSTH(ctx)
+			if len(tc.errStr) > 0 {
+				if err == nil || !strings.Contains(err.Error(), tc.errStr) {
+					t.Errorf("GetSTH()=%v, %v want: nil, err containing %s", sth, err, tc.errStr)
+				}
+			} else {
+				if err != nil || !reflect.DeepEqual(sth, tc.wantSTH) {
+					t.Errorf("GetSTH()=%v, %v, want: %v, nil", sth, err, tc.wantSTH)
+				}
+			}
+			ctrl.Finish()
+		})
+	}
+}
+
+func TestFrozenSTHGetter(t *testing.T) {
+	sth := &ct.SignedTreeHead{TreeSize: 123, Version: 1}
+	f := FrozenSTHGetter{sth: sth}
+	// This should always return its canned value and never an error.
+	if sth2, err := f.GetSTH(context.Background()); sth2 != sth || err != nil {
+		t.Fatalf("FrozenSTHGetter.GetSTH()=%v, %v, want: %v, nil", sth2, err, sth)
+	}
+}
+
+func TestDefaultMirrorSTHStorage(t *testing.T) {
+	s, err := DefaultMirrorSTHFactory{}.NewStorage([32]byte{})
+	if err != nil {
+		t.Fatalf("NewStorage()=%v, %v, want: no err", s, err)
+	}
+	// We expect a "not implemented" error from this and nil sth.
+	sth, err := s.GetMirrorSTH(context.Background(), 9999)
+	if sth != nil || err == nil || !strings.Contains(err.Error(), "not impl") {
+		t.Fatalf("MirrorSTHStorage.GetMirrorSTH(): got: %v, %v, want: nil, err containing 'not impl'", sth, err)
+	}
+}
+
+type fakeSigner struct {
+	sig []byte
+	err error
+}
+
+func (f *fakeSigner) Public() crypto.PublicKey {
+	return []byte("this key is public") // This will map to tls.Anonymous.
+}
+
+func (f *fakeSigner) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
+	return f.sig, f.err
+}
+
+type fakeMirrorSTHStorage struct {
+	sth *ct.SignedTreeHead
+	err error
+}
+
+func (f *fakeMirrorSTHStorage) GetMirrorSTH(ctx context.Context, maxTreeSize int64) (*ct.SignedTreeHead, error) {
+	return f.sth, f.err
+}
+
+func hashFromString(str string) [32]byte {
+	var hash = [32]byte{}
+	copy(hash[:], []byte(str))
+	return hash
+}


### PR DESCRIPTION
These were all in `ctfe/handlers.go` and `ctfe/sth.go`. Update all affected tests for new structure + remove tests that don't apply. Add explicit tests for sth.go to ensure the mirror case is covered.