### PR TITLE
Refactor STH metric updates

### DIFF
--- a/trillian/ctfe/ct_server/main.go
+++ b/trillian/ctfe/ct_server/main.go
@@ -303,11 +303,11 @@ func setupAndRegister(ctx context.Context, client trillian.TrillianLogClient, de
 		glog.Infof("Log with prefix: %s is using a custom HandlerPrefix: %s", cfg.Prefix, ohPrefix)
 		lhp = "/" + strings.Trim(ohPrefix, "/")
 	}
-	handlers, err := ctfe.SetUpInstance(ctx, opts)
+	inst, err := ctfe.SetUpInstance(ctx, opts)
 	if err != nil {
 		return err
 	}
-	for path, handler := range *handlers {
+	for path, handler := range inst.Handlers {
 		mux.Handle(lhp+path, handler)
 	}
 	return nil

--- a/trillian/ctfe/handlers.go
+++ b/trillian/ctfe/handlers.go
@@ -503,20 +503,6 @@ func addPreChain(ctx context.Context, li *logInfo, w http.ResponseWriter, r *htt
 	return addChainInternal(ctx, li, w, r, true)
 }
 
-// PingTreeHead retrieves a tree head for the given log, and updates the STH
-// timestamp metrics correspondingly.
-// TODO(pavelkalinnikov): Should we cache the resulting STH?
-// nolint:staticcheck
-func PingTreeHead(ctx context.Context, client trillian.TrillianLogClient, logID int64, prefix string) error {
-	slr, err := getSignedLogRoot(ctx, client, logID, prefix)
-	if err != nil {
-		return err
-	}
-	lastSTHTimestamp.Set(float64(slr.TimestampNanos/1000/1000), strconv.FormatInt(logID, 10))
-	lastSTHTreeSize.Set(float64(slr.TreeSize), strconv.FormatInt(logID, 10))
-	return nil
-}
-
 func getSTH(ctx context.Context, li *logInfo, w http.ResponseWriter, r *http.Request) (int, error) {
 	qctx := ctx
 	if li.instanceOpts.RemoteQuotaUser != nil {

--- a/trillian/ctfe/instance.go
+++ b/trillian/ctfe/instance.go
@@ -66,7 +66,6 @@ type InstanceOptions struct {
 // Instance is a set up log/mirror instance. It must be created with the
 // SetUpInstance call.
 type Instance struct {
-	Opts      InstanceOptions
 	Handlers  PathHandlers
 	STHGetter STHGetter
 	li        *logInfo
@@ -75,7 +74,7 @@ type Instance struct {
 // RunUpdateSTH regularly updates the internal STH for each log so our metrics
 // stay up-to-date with any tree head changes that are not triggered by us.
 func (i *Instance) RunUpdateSTH(ctx context.Context, period time.Duration) {
-	c := i.Opts.Validated.Config
+	c := i.li.instanceOpts.Validated.Config
 	ticker := time.NewTicker(period)
 	glog.Infof("Start internal get-sth operations on %v (%d)", c.Prefix, c.LogId)
 	for t := range ticker.C {
@@ -99,7 +98,7 @@ func SetUpInstance(ctx context.Context, opts InstanceOptions) (*Instance, error)
 		return nil, err
 	}
 	handlers := logInfo.Handlers(opts.Validated.Config.Prefix)
-	return &Instance{Opts: opts, Handlers: handlers, STHGetter: logInfo.sthGetter, li: logInfo}, nil
+	return &Instance{Handlers: handlers, STHGetter: logInfo.sthGetter, li: logInfo}, nil
 }
 
 func setUpLogInfo(ctx context.Context, opts InstanceOptions) (*logInfo, error) {

--- a/trillian/ctfe/instance.go
+++ b/trillian/ctfe/instance.go
@@ -62,28 +62,25 @@ type InstanceOptions struct {
 	STHStorage MirrorSTHStorage
 }
 
-// SetUpInstance sets up a log (or log mirror) instance using the provided
-// configuration, and returns a set of handlers for this log. This is the
-// standard way of setting up a log instance.
-func SetUpInstance(ctx context.Context, opts InstanceOptions) (*PathHandlers, error) {
-	handlers, _, err := SetUpInstanceAndGetter(ctx, opts)
-	return handlers, err
+// Instance is a set up log/mirror instance. It must be created with the
+// SetUpInstance call.
+type Instance struct {
+	Opts      InstanceOptions
+	Handlers  PathHandlers
+	STHGetter STHGetter
 }
 
-// SetUpInstanceAndGetter sets up a log (or log mirror) instance using the
-// provided configuration, and returns a set of handlers for this log and the
-// STHGetter being used for it.
-//
-// Note: This is for experiments with DNS serving and is not currently used
-// by CTFE. This may either go away or become an official thing in future.
-func SetUpInstanceAndGetter(ctx context.Context, opts InstanceOptions) (*PathHandlers, STHGetter, error) {
+// SetUpInstance sets up a log (or log mirror) instance using the provided
+// configuration, and returns an object containing a set of handlers for this
+// log, and an STH getter.
+func SetUpInstance(ctx context.Context, opts InstanceOptions) (*Instance, error) {
 	logInfo, err := setUpLogInfo(ctx, opts)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	// TODO(pavelkalinnikov): Handlers can take the prefix from logInfo's opts.
 	handlers := logInfo.Handlers(opts.Validated.Config.Prefix)
-	return &handlers, logInfo.sthGetter, nil
+	return &Instance{Opts: opts, Handlers: handlers, STHGetter: logInfo.sthGetter}, nil
 }
 
 func setUpLogInfo(ctx context.Context, opts InstanceOptions) (*logInfo, error) {

--- a/trillian/ctfe/instance.go
+++ b/trillian/ctfe/instance.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/golang/glog"
 	"github.com/google/certificate-transparency-go/trillian/util"
 	"github.com/google/certificate-transparency-go/x509"
 	"github.com/google/trillian"
@@ -68,6 +69,25 @@ type Instance struct {
 	Opts      InstanceOptions
 	Handlers  PathHandlers
 	STHGetter STHGetter
+	li        *logInfo
+}
+
+// RunUpdateSTH regularly updates the internal STH for each log so our metrics
+// stay up-to-date with any tree head changes that are not triggered by us.
+func (i *Instance) RunUpdateSTH(ctx context.Context, period time.Duration) {
+	c := i.Opts.Validated.Config
+	ticker := time.NewTicker(period)
+	glog.Infof("Start internal get-sth operations on %v (%d)", c.Prefix, c.LogId)
+	for t := range ticker.C {
+		glog.V(1).Infof("Tick at %v: force internal get-sth for %v (%d)", t, c.Prefix, c.LogId)
+		_, err := i.li.getSTH(ctx)
+		if err != nil {
+			glog.Warningf("Failed to retrieve STH for %v (%d): %v", c.Prefix, c.LogId, err)
+			if ctx.Err() != nil {
+				break
+			}
+		}
+	}
 }
 
 // SetUpInstance sets up a log (or log mirror) instance using the provided
@@ -78,9 +98,8 @@ func SetUpInstance(ctx context.Context, opts InstanceOptions) (*Instance, error)
 	if err != nil {
 		return nil, err
 	}
-	// TODO(pavelkalinnikov): Handlers can take the prefix from logInfo's opts.
 	handlers := logInfo.Handlers(opts.Validated.Config.Prefix)
-	return &Instance{Opts: opts, Handlers: handlers, STHGetter: logInfo.sthGetter}, nil
+	return &Instance{Opts: opts, Handlers: handlers, STHGetter: logInfo.sthGetter, li: logInfo}, nil
 }
 
 func setUpLogInfo(ctx context.Context, opts InstanceOptions) (*logInfo, error) {

--- a/trillian/ctfe/instance.go
+++ b/trillian/ctfe/instance.go
@@ -71,16 +71,15 @@ type Instance struct {
 	li        *logInfo
 }
 
-// RunUpdateSTH regularly updates the internal STH for each log so our metrics
-// stay up-to-date with any tree head changes that are not triggered by us.
+// RunUpdateSTH regularly updates the Instance STH so our metrics stay
+// up-to-date with any tree head changes that are not triggered by us.
 func (i *Instance) RunUpdateSTH(ctx context.Context, period time.Duration) {
 	c := i.li.instanceOpts.Validated.Config
 	ticker := time.NewTicker(period)
 	glog.Infof("Start internal get-sth operations on %v (%d)", c.Prefix, c.LogId)
 	for t := range ticker.C {
 		glog.V(1).Infof("Tick at %v: force internal get-sth for %v (%d)", t, c.Prefix, c.LogId)
-		_, err := i.li.getSTH(ctx)
-		if err != nil {
+		if _, err := i.li.getSTH(ctx); err != nil {
 			glog.Warningf("Failed to retrieve STH for %v (%d): %v", c.Prefix, c.LogId, err)
 			if ctx.Err() != nil {
 				break

--- a/trillian/ctfe/instance_test.go
+++ b/trillian/ctfe/instance_test.go
@@ -230,11 +230,11 @@ func TestSetUpInstanceSetsValidationOpts(t *testing.T) {
 			}
 			opts := InstanceOptions{Validated: vCfg, Deadline: time.Second, MetricFactory: monitoring.InertMetricFactory{}}
 
-			h, err := SetUpInstance(ctx, opts)
+			inst, err := SetUpInstance(ctx, opts)
 			if err != nil {
 				t.Fatalf("%v: SetUpInstance() = %v, want no error", test.desc, err)
 			}
-			addChainHandler, ok := (*h)[test.cfg.Prefix+ct.AddChainPath]
+			addChainHandler, ok := inst.Handlers[test.cfg.Prefix+ct.AddChainPath]
 			if !ok {
 				t.Fatal("Couldn't find AddChain handler")
 			}

--- a/trillian/ctfe/sth.go
+++ b/trillian/ctfe/sth.go
@@ -35,6 +35,7 @@ var remoteQuotaCtxKey = contextKey("quotaUser")
 type MirrorSTHStorage interface {
 	// GetMirrorSTH returns an STH of TreeSize <= maxTreeSize. It does best
 	// effort to maximize the returned STH's TreeSize and/or Timestamp.
+	// If maxTreeSize < 0 then returns the latest known STH.
 	GetMirrorSTH(ctx context.Context, maxTreeSize int64) (*ct.SignedTreeHead, error)
 }
 

--- a/trillian/ctfe/sth.go
+++ b/trillian/ctfe/sth.go
@@ -35,7 +35,6 @@ var remoteQuotaCtxKey = contextKey("quotaUser")
 type MirrorSTHStorage interface {
 	// GetMirrorSTH returns an STH of TreeSize <= maxTreeSize. It does best
 	// effort to maximize the returned STH's TreeSize and/or Timestamp.
-	// If maxTreeSize < 0 then returns the latest known STH.
 	GetMirrorSTH(ctx context.Context, maxTreeSize int64) (*ct.SignedTreeHead, error)
 }
 

--- a/trillian/integration/logenv.go
+++ b/trillian/integration/logenv.go
@@ -89,11 +89,11 @@ func NewCTLogEnv(ctx context.Context, cfgs []*configpb.LogConfig, numSequencers 
 				MetricFactory: prometheus.MetricFactory{},
 				RequestLog:    new(ctfe.DefaultRequestLog),
 			}
-			handlers, err := ctfe.SetUpInstance(ctx, opts)
+			inst, err := ctfe.SetUpInstance(ctx, opts)
 			if err != nil {
 				glog.Fatalf("Failed to set up log instance for %+v: %v", cfg, err)
 			}
-			for path, handler := range *handlers {
+			for path, handler := range inst.Handlers {
 				http.Handle(path, handler)
 			}
 		}


### PR DESCRIPTION
This change introduces a new `Instance` type that incorporates information on a running log/mirror instance. It also factors out the code that keeps updating STH metrics into an `Instance` method, which can be reused by other CTFE implementations. Finally, this loop can now also update STHs for mirror logs.