### PR TITLE
Use []byte instead of string when handling raw data

### DIFF
--- a/submission/distributor_test.go
+++ b/submission/distributor_test.go
@@ -37,12 +37,12 @@ import (
 )
 
 // readCertFile returns the first certificate it finds in file provided.
-func readCertFile(filename string) string {
+func readCertFile(filename string) []byte {
 	data, err := x509util.ReadPossiblePEMFile(filename, "CERTIFICATE")
 	if err != nil {
-		return ""
+		return nil
 	}
-	return string(data[0])
+	return data[0]
 }
 
 type rootInfo struct {
@@ -213,7 +213,7 @@ func (m stubLogClient) GetAcceptedRoots(ctx context.Context) ([]ct.ASN1Cert, err
 				roots = append(roots, ct.ASN1Cert{Data: []byte(certInfo.raw)})
 			} else {
 
-				roots = append(roots, ct.ASN1Cert{Data: []byte(readCertFile(certInfo.filename))})
+				roots = append(roots, ct.ASN1Cert{Data: readCertFile(certInfo.filename)})
 			}
 		}
 	}

--- a/submission/distributor_test.go
+++ b/submission/distributor_test.go
@@ -46,7 +46,7 @@ func readCertFile(filename string) []byte {
 }
 
 type rootInfo struct {
-	raw      string
+	raw      []byte
 	filename string
 }
 
@@ -63,11 +63,11 @@ var (
 			rootInfo{filename: "testdata/another.cert"},
 		},
 		"ct.googleapis.com/icarus/": {
-			rootInfo{raw: "aW52YWxpZDAwMA=="}, // encoded 'invalid000'
+			rootInfo{raw: []byte("invalid000")},
 			rootInfo{filename: "testdata/another.cert"},
 		},
 		"uncollectable-roots/log/": {
-			rootInfo{raw: "invalid"},
+			rootInfo{raw: []byte("invalid")},
 		},
 	}
 )
@@ -210,7 +210,7 @@ func (m stubLogClient) GetAcceptedRoots(ctx context.Context) ([]ct.ASN1Cert, err
 	if certInfos, ok := RootsCerts[m.logURL]; ok {
 		for _, certInfo := range certInfos {
 			if len(certInfo.raw) > 0 {
-				roots = append(roots, ct.ASN1Cert{Data: []byte(certInfo.raw)})
+				roots = append(roots, ct.ASN1Cert{Data: certInfo.raw})
 			} else {
 
 				roots = append(roots, ct.ASN1Cert{Data: readCertFile(certInfo.filename)})


### PR DESCRIPTION
This makes it clearer that the data is raw (e.g. not encoded in base64) and moves casts to where the data is defined. This revealed a piece of test data that was base64-encoded but never decoded (it was simply cast to []byte at the point it was used).