### PR TITLE
Fix bug in Distributor.AddPreChain() when ValidateChain() fails

### DIFF
--- a/submission/distributor.go
+++ b/submission/distributor.go
@@ -230,7 +230,7 @@ func (d *Distributor) AddPreChain(ctx context.Context, rawChain [][]byte) ([]*As
 		if err != nil {
 			return nil, fmt.Errorf("distributor unable to parse cert-chain: %v", err)
 		}
-		compatibleLogs = d.ll.Compatible(rootedChain[0], nil, d.logRoots)
+		compatibleLogs = d.ll.Compatible(parsedChain[0], nil, d.logRoots)
 	}
 	d.mu.RUnlock()
 

--- a/submission/distributor_test.go
+++ b/submission/distributor_test.go
@@ -359,6 +359,7 @@ func TestDistributorAddPreChain(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		// TODO(merkulova): Add tests to cover more cases where log roots aren't available
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
If `d.isRootDataFull() == false`, the Distributor will access the first element of `rootedChain`, but `rootedChain` is nil when `ValidateChain()` fails.