### PR TITLE
Submission refactor

### DIFF
--- a/submission/distributor_test.go
+++ b/submission/distributor_test.go
@@ -25,8 +25,6 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-
-	ct "github.com/google/certificate-transparency-go"
 	"github.com/google/certificate-transparency-go/client"
 	"github.com/google/certificate-transparency-go/ctpolicy"
 	"github.com/google/certificate-transparency-go/loglist"
@@ -36,6 +34,8 @@ import (
 	"github.com/google/certificate-transparency-go/x509util"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+
+	ct "github.com/google/certificate-transparency-go"
 )
 
 func ExampleDistributor() {

--- a/submission/schedule.go
+++ b/submission/schedule.go
@@ -1,0 +1,41 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package submission
+
+import (
+	"context"
+	"time"
+)
+
+// Every will call f periodically.
+// The first call will be made immediately.
+// Calls are made synchronously, so f will not be executed concurrently.
+func Every(ctx context.Context, period time.Duration, f func(context.Context)) {
+	if ctx.Err() != nil {
+		return
+	}
+	// Run f immediately, then periodically call it again.
+	t := time.NewTicker(period)
+	defer t.Stop()
+	f(ctx)
+	for {
+		select {
+		case <-t.C:
+			f(ctx)
+		case <-ctx.Done():
+			return
+		}
+	}
+}

--- a/submission/schedule_test.go
+++ b/submission/schedule_test.go
@@ -1,0 +1,65 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package submission
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestEvery(t *testing.T) {
+	for _, test := range []struct {
+		name           string
+		period         time.Duration
+		timeout        time.Duration
+		wantExecutions uint32
+	}{
+		{
+			name:           "0 runs",
+			period:         100 * time.Millisecond,
+			timeout:        0,
+			wantExecutions: 0,
+		},
+		{
+			name:           "1 run",
+			period:         100 * time.Millisecond,
+			timeout:        50 * time.Millisecond,
+			wantExecutions: 1,
+		},
+		{
+			name:           "3 runs 100ms apart",
+			period:         100 * time.Millisecond,
+			timeout:        250 * time.Millisecond,
+			wantExecutions: 3,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			ctx, cancel := context.WithTimeout(context.Background(), test.timeout)
+			defer cancel()
+			var counter uint32
+
+			Every(ctx, test.period, func(ctx context.Context) {
+				atomic.AddUint32(&counter, 1)
+			})
+
+			if got, want := atomic.LoadUint32(&counter), test.wantExecutions; got != want {
+				t.Fatalf("Every(%v, f): executed f %d times, want %d times", test.period, got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
I think this substantially reduces the complexity of the code by extracting everything that concerns itself with asynchronicity. I've added a couple of examples to the tests that show how you could still run it in the background on a schedule, as well as added an `Every()` func to facilitate that (I'm considering moving that to its own package in a future PR and re-using it across the repo).