### PR TITLE
Migrillian: Restart Controller while master

### DIFF
--- a/trillian/migrillian/core/controller.go
+++ b/trillian/migrillian/core/controller.go
@@ -207,13 +207,15 @@ func (c *Controller) RunWhenMaster(ctx context.Context) error {
 	}
 }
 
-// runWithRestarts calls Run until it succeeds or the context is done.
+// runWithRestarts calls Run until the context is done, in continuous mode. For
+// non-continuous mode it is simply equivalent to Run.
 func (c *Controller) runWithRestarts(ctx context.Context) error {
+	if !c.opts.Continuous {
+		return c.Run(ctx)
+	}
 	for ctx.Err() == nil {
-		if err := c.Run(ctx); err != nil { // There was an error, so we try again.
+		if err := c.Run(ctx); err != nil {
 			glog.Errorf("%s: Controller.Run: %v", c.label, err)
-		} else if !c.opts.Continuous {
-			break // A non-continuous run completed successfully.
 		}
 		sleepRandom(ctx, 0, c.opts.StartDelay)
 	}

--- a/trillian/migrillian/core/controller.go
+++ b/trillian/migrillian/core/controller.go
@@ -207,17 +207,17 @@ func (c *Controller) RunWhenMaster(ctx context.Context) error {
 	}
 }
 
-// runWithRestarts calls Run until the context is done, in continuous mode. For
-// non-continuous mode it is simply equivalent to Run.
+// runWithRestarts calls Run until it succeeds or the context is done, in
+// continuous mode. For non-continuous mode it is simply equivalent to Run.
 func (c *Controller) runWithRestarts(ctx context.Context) error {
+	err := c.Run(ctx)
 	if !c.opts.Continuous {
-		return c.Run(ctx)
+		return err
 	}
-	for ctx.Err() == nil {
-		if err := c.Run(ctx); err != nil {
-			glog.Errorf("%s: Controller.Run: %v", c.label, err)
-		}
+	for err != nil && ctx.Err() == nil {
+		glog.Errorf("%s: Controller.Run: %v", c.label, err)
 		sleepRandom(ctx, 0, c.opts.StartDelay)
+		err = c.Run(ctx)
 	}
 	return ctx.Err()
 }

--- a/trillian/migrillian/core/controller.go
+++ b/trillian/migrillian/core/controller.go
@@ -160,8 +160,6 @@ func (c *Controller) RunWhenMaster(ctx context.Context) error {
 		return err // The context has been canceled.
 	}
 
-	metrics.controllerStarts.Inc(c.label)
-
 	el, err := c.ef.NewElection(ctx, c.label)
 	if err != nil {
 		return err
@@ -215,6 +213,8 @@ func (c *Controller) RunWhenMaster(ctx context.Context) error {
 // log. Returns if an error occurs, the context is canceled, or all the entries
 // have been transferred (in non-Continuous mode).
 func (c *Controller) Run(ctx context.Context) error {
+	metrics.controllerStarts.Inc(c.label)
+
 	root, err := c.plClient.getVerifiedRoot(ctx)
 	if err != nil {
 		return err

--- a/trillian/migrillian/core/controller.go
+++ b/trillian/migrillian/core/controller.go
@@ -256,6 +256,8 @@ func (c *Controller) Run(ctx context.Context) error {
 		}()
 	}
 
+	// TODO(pavelkalinnikov): Move this out of Run, because now the timer is
+	// reset on restarts, so it's possible that it never fires.
 	if c.opts.StopAfter != 0 { // Configured with max running time.
 		go func() {
 			// Sleep for random duration in [StopAfter, 2*StopAfter).


### PR DESCRIPTION
This change makes Migrillian more robust. In case the source log returns errors (e.g. it is unavailable), we will restart without giving up mastership.

Also, simplify log messages formatting.