### PR TITLE
Re-use `Every()`

### DIFF
--- a/gossip/minimal/gossip.go
+++ b/gossip/minimal/gossip.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/google/certificate-transparency-go/jsonclient"
+	"github.com/google/certificate-transparency-go/schedule"
 	"github.com/google/certificate-transparency-go/x509"
 
 	ct "github.com/google/certificate-transparency-go"
@@ -295,8 +296,7 @@ func (src *sourceLog) Retriever(ctx context.Context, g *Gossiper, s chan<- sthIn
 		glog.V(1).Infof("Retriever(%s): wait for %v before starting...done", src.Name, jitterWait)
 	}
 
-	ticker := time.NewTicker(src.MinInterval)
-	for {
+	schedule.Every(ctx, src.MinInterval, func(ctx context.Context) {
 		glog.V(1).Infof("Retriever(%s): Get STH", src.Name)
 		readsCounter.Inc(src.Name)
 		sth, err := src.GetNewerSTH(ctx, g)
@@ -309,16 +309,9 @@ func (src *sourceLog) Retriever(ctx context.Context, g *Gossiper, s chan<- sthIn
 			lastRecordedSTHTreeSize.Set(float64(sth.TreeSize), src.Name)
 			s <- sthInfo{name: src.Name, sth: sth}
 		}
-
 		glog.V(2).Infof("Retriever(%s): wait for a %s tick", src.Name, src.MinInterval)
-		select {
-		case <-ctx.Done():
-			glog.Infof("Retriever(%s): termination requested", src.Name)
-			return
-		case <-ticker.C:
-		}
-
-	}
+	})
+	glog.Infof("Retriever(%s): termination requested", src.Name)
 }
 
 // GetNewerSTH retrieves a current STH from the source log and (if it is new)

--- a/gossip/minimal/gossip.go
+++ b/gossip/minimal/gossip.go
@@ -29,18 +29,18 @@ import (
 	"sync"
 	"time"
 
-	// Register PEMKeyFile ProtoHandler
-	_ "github.com/google/trillian/crypto/keys/pem/proto"
-	"github.com/google/trillian/monitoring"
-
 	"github.com/golang/glog"
 	"github.com/google/certificate-transparency-go/jsonclient"
 	"github.com/google/certificate-transparency-go/schedule"
 	"github.com/google/certificate-transparency-go/x509"
+	"github.com/google/trillian/monitoring"
 
 	ct "github.com/google/certificate-transparency-go"
 	logclient "github.com/google/certificate-transparency-go/client"
 	hubclient "github.com/google/trillian-examples/gossip/client"
+
+	// Register PEMKeyFile ProtoHandler
+	_ "github.com/google/trillian/crypto/keys/pem/proto"
 )
 
 var (

--- a/schedule/schedule.go
+++ b/schedule/schedule.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package submission
+package schedule
 
 import (
 	"context"

--- a/schedule/schedule_test.go
+++ b/schedule/schedule_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package submission
+package schedule
 
 import (
 	"context"

--- a/submission/distributor.go
+++ b/submission/distributor.go
@@ -22,13 +22,14 @@ import (
 	"sync"
 	"time"
 
-	ct "github.com/google/certificate-transparency-go"
 	"github.com/google/certificate-transparency-go/client"
 	"github.com/google/certificate-transparency-go/ctpolicy"
 	"github.com/google/certificate-transparency-go/jsonclient"
 	"github.com/google/certificate-transparency-go/loglist"
 	"github.com/google/certificate-transparency-go/trillian/ctfe"
 	"github.com/google/certificate-transparency-go/x509"
+
+	ct "github.com/google/certificate-transparency-go"
 )
 
 const (

--- a/submission/distributor_test.go
+++ b/submission/distributor_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/google/certificate-transparency-go/client"
 	"github.com/google/certificate-transparency-go/ctpolicy"
 	"github.com/google/certificate-transparency-go/loglist"
+	"github.com/google/certificate-transparency-go/schedule"
 	"github.com/google/certificate-transparency-go/testdata"
 	"github.com/google/certificate-transparency-go/tls"
 	"github.com/google/certificate-transparency-go/x509"
@@ -50,7 +51,7 @@ func ExampleDistributor() {
 	// Refresh roots periodically so they stay up-to-date.
 	// Not necessary for this example, but appropriate for long-running systems.
 	refresh := make(chan struct{})
-	go Every(ctx, time.Hour, func(ctx context.Context) {
+	go schedule.Every(ctx, time.Hour, func(ctx context.Context) {
 		if errs := d.RefreshRoots(ctx); len(errs) > 0 {
 			glog.Error(errs)
 		}

--- a/submission/loglist_refresher_test.go
+++ b/submission/loglist_refresher_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/google/certificate-transparency-go/loglist"
+	"github.com/google/certificate-transparency-go/schedule"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -61,7 +62,7 @@ func ExampleLogListRefresher() {
 	// Not necessary for this example, but appropriate for long-running systems.
 	llChan := make(chan *loglist.LogList)
 	errChan := make(chan error)
-	go Every(ctx, time.Hour, func(ctx context.Context) {
+	go schedule.Every(ctx, time.Hour, func(ctx context.Context) {
 		if ll, err := llr.Refresh(); err != nil {
 			errChan <- err
 		} else {


### PR DESCRIPTION
There are various pieces of code that start a recurring task with a context. This change replaces those with calls to `schedule.Every()`, which simplifies the code and ensures that they all have consistent behaviour. This also encourages future changes to use `Every()`, which reduces the chances of bugs being introduced.