### PR TITLE
Migrillian: Refactor continuous mode

### DIFF
--- a/trillian/migrillian/core/controller.go
+++ b/trillian/migrillian/core/controller.go
@@ -228,7 +228,7 @@ func (c *Controller) runWithRestarts(ctx context.Context) error {
 // have been transferred (in non-Continuous mode).
 func (c *Controller) Run(ctx context.Context) error {
 	metrics.controllerStarts.Inc(c.label)
-	dur := randDuration(c.opts.StopAfter, c.opts.StopAfter)
+	stopAfter := randDuration(c.opts.StopAfter, c.opts.StopAfter)
 	start := time.Now()
 
 	// Note: Non-continuous runs are not affected by StopAfter.
@@ -240,7 +240,7 @@ func (c *Controller) Run(ctx context.Context) error {
 		return nil
 	}
 
-	for dur == 0 || time.Since(start) < dur {
+	for stopAfter == 0 || time.Since(start) < stopAfter {
 		// TODO(pavelkalinnikov): Integrate runWithRestarts here.
 		next, err := c.fetchTail(ctx, pos)
 		if err != nil {

--- a/trillian/migrillian/core/controller.go
+++ b/trillian/migrillian/core/controller.go
@@ -272,6 +272,7 @@ func (c *Controller) fetchTail(ctx context.Context, begin uint64) (uint64, error
 	if fo.Continuous { // Ignore range parameters in continuous mode.
 		fo.StartIndex, fo.EndIndex = int64(root.TreeSize), 0
 		// Use non-continuous Fetcher, as we implement continuity in Controller.
+		// TODO(pavelkalinnikov): Don't overload Fetcher's Continuous flag.
 		fo.Continuous = false
 	} else if fo.StartIndex < 0 {
 		fo.StartIndex = int64(root.TreeSize)

--- a/trillian/migrillian/core/controller.go
+++ b/trillian/migrillian/core/controller.go
@@ -336,12 +336,18 @@ func (c *Controller) runSubmitter(ctx context.Context) error {
 
 // sleepRandom sleeps for random duration in [base, base+spread).
 func sleepRandom(ctx context.Context, base, spread time.Duration) error {
-	d := base
-	if spread != 0 {
-		d += time.Duration(rand.Int63n(int64(spread)))
-	}
+	d := randDuration(base, spread)
 	if d == 0 {
 		return nil
 	}
 	return clock.SleepContext(ctx, d)
+}
+
+// randDuration returns a random duration in [base, base+spread).
+func randDuration(base, spread time.Duration) time.Duration {
+	d := base
+	if spread != 0 {
+		d += time.Duration(rand.Int63n(int64(spread)))
+	}
+	return d
 }


### PR DESCRIPTION
This change implements continuous mode in Migrillian directly, without relying on `Fetcher`. This gives us couple of advantages:
- We can now export fresh STH metrics, each time it is updated.
- Better resignation handling in between runs.