### PR TITLE
gossip: use incident reporting framework

### DIFF
--- a/gossip/minimal/goshawk.go
+++ b/gossip/minimal/goshawk.go
@@ -36,6 +36,7 @@ import (
 	"github.com/google/certificate-transparency-go/schedule"
 	"github.com/google/certificate-transparency-go/tls"
 	"github.com/google/certificate-transparency-go/x509"
+	"github.com/google/monologue/incident"
 	"github.com/google/trillian/merkle"
 	"github.com/google/trillian/merkle/rfc6962"
 
@@ -66,6 +67,8 @@ type FetchOptions struct {
 	// Manage hub retrieval state persistence.
 	State         ScanStateManager
 	FlushInterval time.Duration
+	// Mechanism for reporting compliance incidents.
+	Reporter incident.Reporter
 }
 
 // ScanStateManager controls hub scanning state, with the intention of allowing
@@ -195,6 +198,7 @@ func (f *FileStateManager) Flush(ctx context.Context) error {
 }
 
 type originLog struct {
+	reporter incident.Reporter
 	logConfig
 	sigAlgo tls.SignatureAlgorithm
 
@@ -367,6 +371,9 @@ func NewBoundaryGoshawk(_ context.Context, cfg *configpb.GoshawkConfig, hcLog, h
 	if fetchOpts.FlushInterval == 0 {
 		fetchOpts.FlushInterval = 10 * time.Minute
 	}
+	if fetchOpts.Reporter == nil {
+		fetchOpts.Reporter = &incident.LoggingReporter{}
+	}
 
 	hawk := Goshawk{
 		dests:     make(map[string]*hubScanner),
@@ -415,6 +422,7 @@ func NewBoundaryGoshawk(_ context.Context, cfg *configpb.GoshawkConfig, hcLog, h
 		}
 
 		hawk.origins[base.URL] = &originLog{
+			reporter:  hawk.fetchOpts.Reporter,
 			logConfig: *base,
 			sigAlgo:   sigAlgo,
 			sths:      make(chan *x509ext.LogSTHInfo, cfg.BufferSize),
@@ -535,6 +543,9 @@ func (o *originLog) validateSTH(ctx context.Context, sthInfo *x509ext.LogSTHInfo
 		TreeHeadSignature: sthInfo.TreeHeadSignature,
 	}
 	if err := o.Log.VerifySTHSignature(sth); err != nil {
+		o.reporter.Logf(ctx, o.URL, "STH signature verification failure", "signature",
+			fmt.Sprintf("%s/ct/v1/get-sth", o.URL),
+			"sthInfo=%+v", sthInfo)
 		return fmt.Errorf("failed to validate STH signature: %v", err)
 	}
 
@@ -552,11 +563,17 @@ func (o *originLog) validateSTH(ctx context.Context, sthInfo *x509ext.LogSTHInfo
 	}
 	proof, err := o.Log.GetSTHConsistency(ctx, first, second)
 	if err != nil {
+		o.reporter.Logf(ctx, o.URL, "STH consistency retrieval failure", "get",
+			fmt.Sprintf("%s/ct/v1/get-sth-consistency?first=%d&second=%d", o.URL, first, second),
+			"err=%s", expandRspError(err))
 		return err
 	}
 	glog.V(2).Infof("Checker(%s): got STH consistency proof %d=>%d of size %d", o.Name, first, second, len(proof))
 
 	if err := verifier.VerifyConsistencyProof(int64(first), int64(second), firstHash, secondHash, proof); err != nil {
+		o.reporter.Logf(ctx, o.URL, "STH consistency proof failure", "proof",
+			fmt.Sprintf("%s/ct/v1/get-sth-consistency?first=%d&second=%d", o.URL, first, second),
+			"hash1=%x hash2=%x proof=%x err=%s", firstHash, secondHash, proof, err)
 		return fmt.Errorf("failed to VerifyConsistencyProof(%x @size=%d, %x @size=%d): %v", firstHash, first, secondHash, second, err)
 	}
 	glog.Infof("Checker(%s): verified that hash %x @%d + proof = hash %x @%d\n", o.Name, firstHash, first, secondHash, second)

--- a/gossip/minimal/goshawk/main.go
+++ b/gossip/minimal/goshawk/main.go
@@ -60,27 +60,27 @@ func main() {
 		var err error
 		fetchOpts.State, err = minimal.NewFileStateManager(*stateFile)
 		if err != nil {
-			glog.Exitf("failed to create file-based state manager: %v", err)
+			glog.Exitf("Failed to create file-based state manager: %v", err)
 		}
 	} else if len(*mySQLStateURI) > 0 {
 		glog.Infof("State will be persisted to %s", *mySQLStateURI)
 		db, err := sql.Open("mysql", *mySQLStateURI)
 		if err != nil {
-			glog.Exitf("failed to open MySQL state database: %v", err)
+			glog.Exitf("Failed to open MySQL state database: %v", err)
 		}
 		if _, err := db.ExecContext(ctx, "SET sql_mode = 'STRICT_ALL_TABLES'"); err != nil {
 			glog.Warningf("Failed to set strict mode on MySQL db: %s", err)
 		}
 		fetchOpts.State, err = mysql.NewStateManager(ctx, db)
 		if err != nil {
-			glog.Exitf("failed to create MySQL-based state manager: %v", err)
+			glog.Exitf("Failed to create MySQL-based state manager: %v", err)
 		}
 	}
 	if len(*mySQLIncidentURI) > 0 {
 		glog.Infof("Incidents will be stored in %s", *mySQLIncidentURI)
 		db, err := sql.Open("mysql", *mySQLIncidentURI)
 		if err != nil {
-			glog.Exitf("failed to open MySQL incident database: %v", err)
+			glog.Exitf("Failed to open MySQL incident database: %v", err)
 		}
 		if _, err := db.ExecContext(ctx, "SET sql_mode = 'STRICT_ALL_TABLES'"); err != nil {
 			glog.Warningf("Failed to set strict mode on MySQL incident db: %s", err)
@@ -88,13 +88,13 @@ func main() {
 
 		fetchOpts.Reporter, err = incidentmysql.NewMySQLReporter(ctx, db, "goshawk")
 		if err != nil {
-			glog.Exitf("failed to create MySQL-based incident reporter: %v", err)
+			glog.Exitf("Failed to create MySQL-based incident reporter: %v", err)
 		}
 	}
 
 	hawk, err := minimal.NewGoshawkFromFile(ctx, *config, nil, fetchOpts)
 	if err != nil {
-		glog.Exitf("failed to load --config: %v", err)
+		glog.Exitf("Failed to load --config: %v", err)
 	}
 
 	glog.CopyStandardLogTo("WARNING")

--- a/gossip/minimal/goshawk_test.go
+++ b/gossip/minimal/goshawk_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/certificate-transparency-go/gossip/minimal/x509ext"
 	"github.com/google/certificate-transparency-go/jsonclient"
 	"github.com/google/certificate-transparency-go/tls"
+	"github.com/google/monologue/incident"
 
 	ct "github.com/google/certificate-transparency-go"
 )
@@ -136,11 +137,14 @@ func TestValidateSTH(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
-	o := originLog{logConfig: logConfig{
-		Name: "argon2018",
-		URL:  "http://ct.googleapis.com/logs/argon2018",
-		Log:  client,
-	}}
+	o := originLog{
+		reporter: &incident.LoggingReporter{},
+		logConfig: logConfig{
+			Name: "argon2018",
+			URL:  "http://ct.googleapis.com/logs/argon2018",
+			Log:  client,
+		},
+	}
 	sthInfo1 := x509ext.LogSTHInfo{
 		LogURL:            []byte(o.URL),
 		Version:           tls.Enum(argonSTH1.Version),
@@ -198,7 +202,10 @@ func TestValidateSTH(t *testing.T) {
 
 func TestUpdateAndGetLastSTH(t *testing.T) {
 	var nilp *ct.SignedTreeHead
-	o := originLog{logConfig: logConfig{Name: "argon2018", URL: "http://ct.googleapis.com/logs/argon2018"}}
+	o := originLog{
+		reporter:  &incident.LoggingReporter{},
+		logConfig: logConfig{Name: "argon2018", URL: "http://ct.googleapis.com/logs/argon2018"},
+	}
 
 	if got, want := o.getLastSTH(), nilp; got != want {
 		t.Errorf("o.getLastSTH()=%v; want %v", got, want)

--- a/trillian/integration/ct_functions.sh
+++ b/trillian/integration/ct_functions.sh
@@ -8,6 +8,7 @@ CT_LIFECYCLE_CFG=
 CT_COMBINED_CFG=
 PROMETHEUS_CFGDIR=
 readonly CT_GO_PATH=$(go list -f '{{.Dir}}' github.com/google/certificate-transparency-go)
+readonly MONO_PATH="$(go list -f '{{.Dir}}' github.com/google/monologue/incident)/.."
 
 # ct_prep_test prepares a set of running processes for a CT test.
 # Parameters:
@@ -30,9 +31,14 @@ ct_prep_test() {
   local log_signer_count=${2:-1}
   local http_server_count=${3:-1}
 
-  # Wipe the cttest database
-  echo "Wiping and re-creating cttest database"
-  "${CT_GO_PATH}/scripts/resetctdb.sh" --force
+  if [[ "${HAMMER_GOSSIP}" != "off" ]]; then
+    # Wipe the cttest database
+    echo "Wiping and re-creating cttest database"
+    "${CT_GO_PATH}/scripts/resetctdb.sh" --force
+    # Wipe the incident database
+    echo "Wiping and re-creating incident database"
+    "${MONO_PATH}/scripts/resetmondb.sh" --force
+  fi
 
   echo "Launching core Trillian log components"
   log_prep_test "${rpc_server_count}" "${log_signer_count}"
@@ -202,7 +208,7 @@ ct_goshawk_config() {
   GOSHAWK_CFG=$(mktemp ${TMPDIR}/goshawk-XXXXXX)
   sed "s/@SERVER@/${server}/" ${GOPATH}/src/github.com/google/certificate-transparency-go/trillian/integration/goshawk.cfg > "${GOSHAWK_CFG}"
 
-  echo "gosmin configuration at ${GOSHAWK_CFG}:"
+  echo "goshawk configuration at ${GOSHAWK_CFG}:"
   cat "${GOSHAWK_CFG}"
   echo
 }


### PR DESCRIPTION
 - Add use of incident.Reporter interface.
 - Add an --incident_mysql_uri flag to goshawk to point at
   a MySQL-based incident database.
 - Set this up and use it in ct_hammer_test.sh (by default).