### PR TITLE
Update from Go 1.10 to 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: true  # required for CI push into Kubernetes.
 os: linux
 dist: xenial
 language: go
-go: "1.10"
+go: "1.11"
 go_import_path: github.com/google/certificate-transparency-go
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
   - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.13.2
   - go get -u github.com/golang/protobuf/proto
   - go get -u github.com/golang/protobuf/protoc-gen-go
-  - go install github.com/golang/mock/mockgen
+  - go get -u github.com/golang/mock/mockgen
   # install vendored etcd binary
   - go install ./vendor/github.com/coreos/etcd/cmd/etcd
   - go install ./vendor/github.com/coreos/etcd/cmd/etcdctl

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,8 @@ install:
   - go get -u github.com/golang/protobuf/protoc-gen-go
   - go get -u github.com/golang/mock/mockgen
   # install vendored etcd binary
-  - go install ./vendor/github.com/coreos/etcd/cmd/etcd
-  - go install ./vendor/github.com/coreos/etcd/cmd/etcdctl
+  - go get -u ./vendor/github.com/coreos/etcd/cmd/etcd
+  - go get -u ./vendor/github.com/coreos/etcd/cmd/etcdctl
   - pushd ${GOPATH}/src/github.com/google/trillian
   - go get -d -t ./...
   - popd

--- a/gossip/examples/deployment/docker/gosmin/Dockerfile
+++ b/gossip/examples/deployment/docker/gosmin/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /go/src/github.com/google/certificate-transparency-go
 
 ARG GOFLAGS=""
 
-RUN go get -v ${GOFLAGS} ./gossip/minimal/gosmin
+RUN go get -v ./gossip/minimal/gosmin
 
 FROM gcr.io/distroless/base
 

--- a/gossip/examples/deployment/docker/gosmin/Dockerfile
+++ b/gossip/examples/deployment/docker/gosmin/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10 as build
+FROM golang:1.11 as build
 
 ADD . /go/src/github.com/google/certificate-transparency-go
 WORKDIR /go/src/github.com/google/certificate-transparency-go

--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -87,13 +87,8 @@ main() {
   fi
 
   if [[ "${run_build}" -eq 1 ]]; then
-    local goflags=''
-    if [[ "${GOFLAGS:+x}" ]]; then
-      goflags="${GOFLAGS}"
-    fi
-
     echo 'running go build'
-    go build ${goflags} ./...
+    go build ./...
 
     echo 'running go test'
 
@@ -125,7 +120,7 @@ main() {
           -short \
           -timeout=${GO_TEST_TIMEOUT:-5m} \
           ${coverflags} \
-          ${goflags} "$d"
+          "$d"
     done | xargs -I '{}' -P ${GO_TEST_PARALLELISM:-10} bash -c '{}'
 
     [[ ${coverage} -eq 1 ]] && \

--- a/trillian/examples/deployment/docker/ctfe/Dockerfile
+++ b/trillian/examples/deployment/docker/ctfe/Dockerfile
@@ -4,7 +4,7 @@ ADD . /go/src/github.com/google/certificate-transparency-go
 WORKDIR /go/src/github.com/google/certificate-transparency-go
 
 ARG GOFLAGS=""
-RUN go get ${GOFLAGS} ./trillian/ctfe/ct_server
+RUN go get ./trillian/ctfe/ct_server
 
 FROM gcr.io/distroless/base
 

--- a/trillian/examples/deployment/docker/ctfe/Dockerfile
+++ b/trillian/examples/deployment/docker/ctfe/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10 as build
+FROM golang:1.11 as build
 
 ADD . /go/src/github.com/google/certificate-transparency-go
 WORKDIR /go/src/github.com/google/certificate-transparency-go

--- a/trillian/integration/ct_functions.sh
+++ b/trillian/integration/ct_functions.sh
@@ -38,7 +38,7 @@ ct_prep_test() {
   log_prep_test "${rpc_server_count}" "${log_signer_count}"
 
   echo "Building CT personality code"
-  go build ${GOFLAGS} github.com/google/certificate-transparency-go/trillian/ctfe/ct_server
+  go build github.com/google/certificate-transparency-go/trillian/ctfe/ct_server
 
   echo "Provisioning logs for CT"
   ct_provision "${RPC_SERVER_1}"
@@ -110,7 +110,7 @@ ct_provision() {
   sed "s!@TESTDATA@!${GOPATH}/src/github.com/google/certificate-transparency-go/trillian/testdata!" ${GOPATH}/src/github.com/google/certificate-transparency-go/trillian/integration/ct_lifecycle_test.cfg > "${CT_LIFECYCLE_CFG}"
 
   echo 'Building createtree'
-  go build ${GOFLAGS} github.com/google/trillian/cmd/createtree/
+  go build github.com/google/trillian/cmd/createtree/
 
   echo 'Provisioning Integration Logs'
   ct_provision_cfg ${admin_server} ${CT_CFG}
@@ -174,7 +174,7 @@ ct_gosmin_config() {
 # Populates:
 #   - GOSMIN_PID : pid for gosmin instance.
 ct_start_gosmin() {
-  go build ${GOFLAGS} github.com/google/certificate-transparency-go/gossip/minimal/gosmin
+  go build github.com/google/certificate-transparency-go/gossip/minimal/gosmin
   local metrics_port=$(pick_unused_port)
   echo "Starting gosmin with metrics on localhost:${metrics_port}"
   ./gosmin --config="${GOSMIN_CFG}" --metrics_endpoint "localhost:${metrics_port}" --logtostderr &
@@ -213,7 +213,7 @@ ct_goshawk_config() {
 # Populates:
 #   - GOSHAWK_PID : pid for gosmin instance.
 ct_start_goshawk() {
-  go build ${GOFLAGS} github.com/google/certificate-transparency-go/gossip/minimal/goshawk
+  go build github.com/google/certificate-transparency-go/gossip/minimal/goshawk
   ./goshawk --config="${GOSHAWK_CFG}" --logtostderr --flush_state=10s &
   GOSHAWK_PID=$!
 }


### PR DESCRIPTION
Required changes:
- Stop passing $GOFLAGS to `go` commands (they read it themselves)
- Make Travis download tools that it uses (and their dependencies), rather than assuming that they're already downloaded.