### PR TITLE
 x509: add support for Ed25519 key parsing

### DIFF
--- a/x509/pkcs8.go
+++ b/x509/pkcs8.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/google/certificate-transparency-go/asn1"
 	"github.com/google/certificate-transparency-go/x509/pkix"
+	"golang.org/x/crypto/ed25519"
 )
 
 // pkcs8 reflects an ASN.1, PKCS#8 PrivateKey. See
@@ -48,6 +49,13 @@ func ParsePKCS8PrivateKey(der []byte) (key interface{}, err error) {
 		key, err = parseECPrivateKey(namedCurveOID, privKey.PrivateKey)
 		if err != nil {
 			return nil, errors.New("x509: failed to parse EC private key embedded in PKCS#8: " + err.Error())
+		}
+		return key, nil
+
+	case privKey.Algo.Algorithm.Equal(OIDPublicKeyEd25519):
+		key, err = ParseEd25519PrivateKey(privKey.PrivateKey)
+		if err != nil {
+			return nil, errors.New("x509: failed to parse Ed25519 private key embedded in PKCS#8: " + err.Error())
 		}
 		return key, nil
 
@@ -94,9 +102,32 @@ func MarshalPKCS8PrivateKey(key interface{}) ([]byte, error) {
 			return nil, errors.New("x509: failed to marshal EC private key while building PKCS#8: " + err.Error())
 		}
 
+	case ed25519.PrivateKey:
+		privKey.Algo = pkix.AlgorithmIdentifier{Algorithm: OIDPublicKeyEd25519}
+		privKey.PrivateKey = MarshalEd25519PrivateKey(k)
+
 	default:
 		return nil, fmt.Errorf("x509: unknown key type while marshalling PKCS#8: %T", key)
 	}
 
 	return asn1.Marshal(privKey)
+}
+
+// MarshalEd25519PrivateKey converts an Ed25519 private key to ASN.1 DER encoded form
+// (as an OCTET STRING holding the key seed).
+func MarshalEd25519PrivateKey(key ed25519.PrivateKey) []byte {
+	b, _ := asn1.Marshal(key.Seed())
+	return b
+}
+
+// ParseEd25519PrivateKey returns an Ed25519 private key from its ASN.1 DER encoded form.
+func ParseEd25519PrivateKey(der []byte) (ed25519.PrivateKey, error) {
+	var keySeed []byte
+	if _, err := asn1.Unmarshal(der, &keySeed); err != nil {
+		return nil, err
+	}
+	if len(keySeed) != ed25519.SeedSize {
+		return nil, fmt.Errorf("ed25519: bad seed length %d", len(keySeed))
+	}
+	return ed25519.NewKeyFromSeed(keySeed), nil
 }

--- a/x509/pkcs8_test.go
+++ b/x509/pkcs8_test.go
@@ -12,6 +12,8 @@ import (
 	"encoding/hex"
 	"reflect"
 	"testing"
+
+	"golang.org/x/crypto/ed25519"
 )
 
 // Generated using:
@@ -38,6 +40,18 @@ var pkcs8P384PrivateKeyHex = `3081b6020100301006072a8648ce3d020106052b8104002204
 // regenerate this you may, randomly, find that it's a byte shorter than
 // expected and the Go test will fail to recreate it exactly.
 var pkcs8P521PrivateKeyHex = `3081ee020100301006072a8648ce3d020106052b810400230481d63081d3020101044200cfe0b87113a205cf291bb9a8cd1a74ac6c7b2ebb8199aaa9a5010d8b8012276fa3c22ac913369fa61beec2a3b8b4516bc049bde4fb3b745ac11b56ab23ac52e361a1818903818600040138f75acdd03fbafa4f047a8e4b272ba9d555c667962b76f6f232911a5786a0964e5edea6bd21a6f8725720958de049c6e3e6661c1c91b227cebee916c0319ed6ca003db0a3206d372229baf9dd25d868bf81140a518114803ce40c1855074d68c4e9dab9e65efba7064c703b400f1767f217dac82715ac1f6d88c74baf47a7971de4ea`
+
+// Taken from RFC 8410 section 10.3:
+//   -----BEGIN PRIVATE KEY-----
+//   MC4CAQAwBQYDK2VwBCIEINTuctv5E1hK1bbY8fdp+K06/nwoy/HU++CXqI9EdVhC
+//   -----END PRIVATE KEY-----
+var pkcs8Ed25519PrivateKeyHex = ("302e" + // SEQUENCE len=46
+	"0201" + "00" + // INTEGER len=1 value=0
+	("3005" + // SEQUENCE len=5
+		"0603" + "2b6570") + // OID len=3
+	("0422" + // OCTET STRING len=34
+		("0420" + // OCTET STRING len=32
+			"d4ee72dbf913584ad5b6d8f1f769f8ad3afe7c28cbf1d4fbe097a88f44755842")))
 
 func TestPKCS8(t *testing.T) {
 	tests := []struct {
@@ -74,6 +88,11 @@ func TestPKCS8(t *testing.T) {
 			keyHex:  pkcs8P521PrivateKeyHex,
 			keyType: reflect.TypeOf(&ecdsa.PrivateKey{}),
 			curve:   elliptic.P521(),
+		},
+		{
+			name:    "Ed25519 private key",
+			keyHex:  pkcs8Ed25519PrivateKeyHex,
+			keyType: reflect.TypeOf(ed25519.PrivateKey{}),
 		},
 	}
 

--- a/x509/x509_test.go
+++ b/x509/x509_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/google/certificate-transparency-go/asn1"
 	"github.com/google/certificate-transparency-go/x509/pkix"
+	"golang.org/x/crypto/ed25519"
 )
 
 func TestParsePKCS1PrivateKey(t *testing.T) {
@@ -78,6 +79,34 @@ func TestParsePKIXPublicKey(t *testing.T) {
 		t.Errorf("Reserialization of public key didn't match. got %x, want %x", pubBytes2, block.Bytes)
 	}
 }
+
+func TestParsePKIXPublicKeyEd25519(t *testing.T) {
+	block, _ := pem.Decode([]byte(pemPublicKeyEd25519))
+	pub, err := ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		t.Errorf("Failed to parse Ed25519 public key: %s", err)
+		return
+	}
+	edPub, ok := pub.(ed25519.PublicKey)
+	if !ok {
+		t.Errorf("Value returned from ParsePKIXPublicKey was not an Ed25519 public key")
+		return
+	}
+
+	pubBytes2, err := MarshalPKIXPublicKey(edPub)
+	if err != nil {
+		t.Errorf("Failed to marshal Ed25519 public key for the second time: %s", err)
+		return
+	}
+	if !bytes.Equal(pubBytes2, block.Bytes) {
+		t.Errorf("Reserialization of public key didn't match. got %x, want %x", pubBytes2, block.Bytes)
+	}
+}
+
+// From RFC 8410 section 10.1.
+var pemPublicKeyEd25519 = `-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEAGb9ECWmEzf6FQbrBZ9w7lshQhqowtrbLDFw4rXAxZuE=
+-----END PUBLIC KEY-----`
 
 var pemPublicKey = `-----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3VoPN9PKUjKFLMwOge6+

--- a/x509/x509_test.go
+++ b/x509/x509_test.go
@@ -84,22 +84,19 @@ func TestParsePKIXPublicKeyEd25519(t *testing.T) {
 	block, _ := pem.Decode([]byte(pemPublicKeyEd25519))
 	pub, err := ParsePKIXPublicKey(block.Bytes)
 	if err != nil {
-		t.Errorf("Failed to parse Ed25519 public key: %s", err)
-		return
+		t.Fatalf("ParsePKIXPublicKey(Ed25519)=nil,%v; want _,nil", err)
 	}
 	edPub, ok := pub.(ed25519.PublicKey)
 	if !ok {
-		t.Errorf("Value returned from ParsePKIXPublicKey was not an Ed25519 public key")
-		return
+		t.Fatalf("ParsePKIXPublicKey.(ed25519.PublicKey)=nil,%v; want _,true", ok)
 	}
 
 	pubBytes2, err := MarshalPKIXPublicKey(edPub)
 	if err != nil {
-		t.Errorf("Failed to marshal Ed25519 public key for the second time: %s", err)
-		return
+		t.Fatalf("MarshalPKIXPublicKey(Ed25519)=nil,%v; want _,nil", err)
 	}
 	if !bytes.Equal(pubBytes2, block.Bytes) {
-		t.Errorf("Reserialization of public key didn't match. got %x, want %x", pubBytes2, block.Bytes)
+		t.Errorf("MarshalPKIXPublicKey(Ed25519)=%x; want %x", pubBytes2, block.Bytes)
 	}
 }
 


### PR DESCRIPTION
As described in RFC 8410.

Upstream crypto/x509 doesn't support this as yet, possibly because
ed25519 support is only available from golang.org/x/crypto and so
can't be a dependency for the Go core.
