### PR TITLE
Make certificate validity checks clearer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # CERTIFICATE-TRANSPARENCY-GO Changelog
 
+## HEAD
+
+Not yet released.
+
+### CTFE
+
+The `reject_expired` and `reject_unexpired` configuration fields for the CTFE
+have been changed so that their behaviour reflects their name:
+
+  - `reject_expired` only rejects expired certificates (i.e. it now allows
+    not-yet-valid certificates).
+  - `reject_unexpired` only allows expired certificates (i.e. it now rejects
+    not-yet-valid certificates).
+
+
 ## v1.0.21 - CTFE Logging / Path Options. Mirroring. RPKI. Non Fatal X.509 error improvements
 
 Published 2018-08-20 10:11:04 +0000 UTC
@@ -229,4 +244,3 @@ Published 2018-06-01 13:59:00 +0000 UTC
 This is the point that corresponds to the 1.0 release in the trillian repo.
 
 Commit [abb79e468b6f3bbd48d1ab0c9e68febf80d52c4d](https://api.github.com/repos/google/certificate-transparency-go/commits/abb79e468b6f3bbd48d1ab0c9e68febf80d52c4d) Download [zip](https://api.github.com/repos/google/certificate-transparency-go/zipball/v1.0)
-

--- a/trillian/ctfe/cert_checker_test.go
+++ b/trillian/ctfe/cert_checker_test.go
@@ -358,7 +358,7 @@ func TestRejectExpiredUnexpired(t *testing.T) {
 			desc: "no-reject-before",
 			now:  beforeValidPeriod,
 		},
-		// Reject-Expired: only allow currently-valid
+		// Reject-Expired: only allow currently-valid and not yet valid
 		{
 			desc:          "reject-expired-current",
 			rejectExpired: true,
@@ -368,15 +368,14 @@ func TestRejectExpiredUnexpired(t *testing.T) {
 			desc:          "reject-expired-after",
 			rejectExpired: true,
 			now:           afterValidPeriod,
-			wantErr:       "expired or is not yet valid",
+			wantErr:       "rejecting expired certificate",
 		},
 		{
 			desc:          "reject-expired-before",
 			rejectExpired: true,
 			now:           beforeValidPeriod,
-			wantErr:       "expired or is not yet valid",
 		},
-		// Reject-Unexpired: only allow expired and not yet valid
+		// Reject-Unexpired: only allow expired
 		{
 			desc:            "reject-non-expired-after",
 			rejectUnexpired: true,
@@ -386,12 +385,13 @@ func TestRejectExpiredUnexpired(t *testing.T) {
 			desc:            "reject-non-expired-before",
 			rejectUnexpired: true,
 			now:             beforeValidPeriod,
+			wantErr:         "rejecting unexpired certificate",
 		},
 		{
 			desc:            "reject-non-expired-current",
 			rejectUnexpired: true,
 			now:             currentValidPeriod,
-			wantErr:         "only expired certificates",
+			wantErr:         "rejecting unexpired certificate",
 		},
 		// Reject-Expired AND Reject-Unexpired: nothing allowed
 		{
@@ -399,21 +399,21 @@ func TestRejectExpiredUnexpired(t *testing.T) {
 			rejectExpired:   true,
 			rejectUnexpired: true,
 			now:             afterValidPeriod,
-			wantErr:         "expired or is not yet valid",
+			wantErr:         "rejecting expired certificate",
 		},
 		{
 			desc:            "reject-all-before",
 			rejectExpired:   true,
 			rejectUnexpired: true,
 			now:             beforeValidPeriod,
-			wantErr:         "expired or is not yet valid",
+			wantErr:         "rejecting unexpired certificate",
 		},
 		{
 			desc:            "reject-all-current",
 			rejectExpired:   true,
 			rejectUnexpired: true,
 			now:             currentValidPeriod,
-			wantErr:         "only expired certificates",
+			wantErr:         "rejecting unexpired certificate",
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/trillian/ctfe/configpb/config.pb.go
+++ b/trillian/ctfe/configpb/config.pb.go
@@ -189,10 +189,10 @@ type LogConfig struct {
 	PublicKey *keyspb.PublicKey `protobuf:"bytes,5,opt,name=public_key,json=publicKey,proto3" json:"public_key,omitempty"`
 	// If reject_expired is true then the certificate validity period will be
 	// checked against the current time during the validation of submissions.
-	// This will cause expired and not-yet-valid certificates to be rejected.
+	// This will cause expired certificates to be rejected.
 	RejectExpired bool `protobuf:"varint,6,opt,name=reject_expired,json=rejectExpired,proto3" json:"reject_expired,omitempty"`
-	// If reject_unexpired is true then CTFE rejects certificates that are within
-	// their validity period with respect to the current time.
+	// If reject_unexpired is true then CTFE rejects certificates that are either
+	// currently valid or not yet valid.
 	RejectUnexpired bool `protobuf:"varint,17,opt,name=reject_unexpired,json=rejectUnexpired,proto3" json:"reject_unexpired,omitempty"`
 	// If set, ext_key_usages will restrict the set of such usages that the
 	// server will accept. By default all are accepted. The values specified

--- a/trillian/ctfe/configpb/config.proto
+++ b/trillian/ctfe/configpb/config.proto
@@ -74,10 +74,10 @@ message LogConfig {
   keyspb.PublicKey public_key = 5;
   // If reject_expired is true then the certificate validity period will be
   // checked against the current time during the validation of submissions.
-  // This will cause expired and not-yet-valid certificates to be rejected.
+  // This will cause expired certificates to be rejected.
   bool reject_expired = 6;
-  // If reject_unexpired is true then CTFE rejects certificates that are within
-  // their validity period with respect to the current time.
+  // If reject_unexpired is true then CTFE rejects certificates that are either
+  // currently valid or not yet valid.
   bool reject_unexpired = 17;
   // If set, ext_key_usages will restrict the set of such usages that the
   // server will accept. By default all are accepted. The values specified

--- a/trillian/ctfe/handlers.go
+++ b/trillian/ctfe/handlers.go
@@ -205,9 +205,9 @@ type CertValidationOpts struct {
 	// currentTime is the time used for checking a certificate's validity period
 	// against. If it's zero then time.Now() is used. Only for testing.
 	currentTime time.Time
-	// rejectExpired indicates whether certificate validity period should be used during chain verification
+	// rejectExpired indicates that expired certificates will be rejected.
 	rejectExpired bool
-	// rejectUnexpired instructs to reject certificates that are still valid.
+	// rejectUnexpired indicates that certificates that are currently valid or not yet valid will be rejected.
 	rejectUnexpired bool
 	// notAfterStart is the earliest notAfter date which will be accepted.
 	// nil means no lower bound on the accepted range.


### PR DESCRIPTION
Note that this changes the semantics of the log config proto.

Would fix #509 