### PR TITLE
ct_hammer: don't re-use the same error

### DIFF
--- a/trillian/integration/chains.go
+++ b/trillian/integration/chains.go
@@ -270,6 +270,7 @@ func SyntheticGeneratorFactory(testDir, leafNotAfter string) (GeneratorFactory, 
 	return func(c *configpb.LogConfig) (ChainGenerator, error) {
 		notAfter := notAfterOverride
 		if notAfter.IsZero() {
+			var err error
 			notAfter, err = NotAfterForLog(c)
 			if err != nil {
 				return nil, fmt.Errorf("failed to determine notAfter for %s: %v", c.Prefix, err)


### PR DESCRIPTION
Triggers a race as multiple threads write to the factory's
err variable.