### PR TITLE
Introduce Log List confirmation for Proxy.

### DIFF
--- a/submission/proxy.go
+++ b/submission/proxy.go
@@ -61,7 +61,7 @@ type Proxy struct {
 	rootsRefreshInterval time.Duration
 
 	// latest unconfirmed Log-list update. To be confirmed for production
-	llUpdate *loglist.LogList
+	llUpdate   *loglist.LogList
 	llUpdateMu sync.RWMutex // guards recent uncomfirmed Log-list update
 
 	llWatcher          LogListRefresher
@@ -79,7 +79,6 @@ func NewProxy(llr LogListRefresher, db DistributorBuilder) *Proxy {
 	p.distributorBuilder = db
 	p.Errors = make(chan error, 1)
 	p.rootsRefreshInterval = 24 * time.Hour
-
 
 	return &p
 }


### PR DESCRIPTION
Before: on every regular-timed Log-list refresh, it's immediately propagated as active.

After:

- first initialization Log-list is propagated as active

- every subsequent Log-list refresh updates cache only

- To propagate cache into active state, confirmation required