### PR TITLE
Remove wildcards from codecov config

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -9,5 +9,5 @@
 ignore:
   - "**/mock_*.go"
   - "**/testonly"
-  - "trillian/integration/**"
-  - "vendor/**/*"
+  - "trillian/integration"
+  - "vendor"


### PR DESCRIPTION
For top level folders as they can be matched directly.