### PR TITLE
Allow lax parsing of certificates in ParseCertificate functions.

### DIFF
--- a/x509/x509.go
+++ b/x509/x509.go
@@ -2093,9 +2093,8 @@ func ParseCertificate(asn1Data []byte) (*Certificate, error) {
 	}
 	ret, err := parseCertificate(&cert)
 	if err != nil {
-		var errs NonFatalErrors
-		var ok bool
-		if errs, ok = err.(NonFatalErrors); !ok {
+		errs, ok := err.(NonFatalErrors)
+		if !ok {
 			return nil, err
 		}
 		nfe.Errors = append(nfe.Errors, errs.Errors...)
@@ -2133,9 +2132,8 @@ func ParseCertificates(asn1Data []byte) ([]*Certificate, error) {
 	for i, ci := range v {
 		cert, err := parseCertificate(ci)
 		if err != nil {
-			var errs NonFatalErrors
-			var ok bool
-			if errs, ok = err.(NonFatalErrors); !ok {
+			errs, ok := err.(NonFatalErrors)
+			if !ok {
 				return nil, err
 			}
 			nfe.Errors = append(nfe.Errors, errs.Errors...)

--- a/x509/x509.go
+++ b/x509/x509.go
@@ -2045,9 +2045,9 @@ func parseCertificate(in *certificate) (*Certificate, error) {
 func ParseTBSCertificate(asn1Data []byte) (*Certificate, error) {
 	var tbsCert tbsCertificate
 	var nfe NonFatalErrors
-	var laxErr error
 	rest, err := asn1.Unmarshal(asn1Data, &tbsCert)
 	if err != nil {
+		var laxErr error
 		rest, laxErr = asn1.UnmarshalWithParams(asn1Data, &tbsCert, "lax")
 		if laxErr != nil {
 			return nil, laxErr
@@ -2061,9 +2061,8 @@ func ParseTBSCertificate(asn1Data []byte) (*Certificate, error) {
 		Raw:            tbsCert.Raw,
 		TBSCertificate: tbsCert})
 	if err != nil {
-		var errs NonFatalErrors
-		var ok bool
-		if errs, ok = err.(NonFatalErrors); !ok {
+		errs, ok := err.(NonFatalErrors)
+		if !ok {
 			return nil, err
 		}
 		nfe.Errors = append(nfe.Errors, errs.Errors...)
@@ -2080,9 +2079,9 @@ func ParseTBSCertificate(asn1Data []byte) (*Certificate, error) {
 func ParseCertificate(asn1Data []byte) (*Certificate, error) {
 	var cert certificate
 	var nfe NonFatalErrors
-	var laxErr error
 	rest, err := asn1.Unmarshal(asn1Data, &cert)
 	if err != nil {
+		var laxErr error
 		rest, laxErr = asn1.UnmarshalWithParams(asn1Data, &cert, "lax")
 		if laxErr != nil {
 			return nil, laxErr
@@ -2114,13 +2113,13 @@ func ParseCertificate(asn1Data []byte) (*Certificate, error) {
 func ParseCertificates(asn1Data []byte) ([]*Certificate, error) {
 	var v []*certificate
 	var nfe NonFatalErrors
-	var laxErr error
 
 	for len(asn1Data) > 0 {
 		cert := new(certificate)
 		var err error
 		asn1Data, err = asn1.Unmarshal(asn1Data, cert)
 		if err != nil {
+			var laxErr error
 			asn1Data, laxErr = asn1.UnmarshalWithParams(asn1Data, &cert, "lax")
 			if laxErr != nil {
 				return nil, laxErr

--- a/x509/x509.go
+++ b/x509/x509.go
@@ -2044,16 +2044,34 @@ func parseCertificate(in *certificate) (*Certificate, error) {
 // The parsed data is returned in a Certificate struct for ease of access.
 func ParseTBSCertificate(asn1Data []byte) (*Certificate, error) {
 	var tbsCert tbsCertificate
+	var nfe NonFatalErrors
+	var laxErr error
 	rest, err := asn1.Unmarshal(asn1Data, &tbsCert)
 	if err != nil {
-		return nil, err
+		rest, laxErr = asn1.UnmarshalWithParams(asn1Data, &tbsCert, "lax")
+		if laxErr != nil {
+			return nil, laxErr
+		}
+		nfe.AddError(err)
 	}
 	if len(rest) > 0 {
 		return nil, asn1.SyntaxError{Msg: "trailing data"}
 	}
-	return parseCertificate(&certificate{
+	ret, err := parseCertificate(&certificate{
 		Raw:            tbsCert.Raw,
 		TBSCertificate: tbsCert})
+	if err != nil {
+		var errs NonFatalErrors
+		var ok bool
+		if errs, ok = err.(NonFatalErrors); !ok {
+			return nil, err
+		}
+		nfe.Errors = append(nfe.Errors, errs.Errors...)
+	}
+	if nfe.HasError() {
+		return ret, nfe
+	}
+	return ret, nil
 }
 
 // ParseCertificate parses a single certificate from the given ASN.1 DER data.
@@ -2061,15 +2079,32 @@ func ParseTBSCertificate(asn1Data []byte) (*Certificate, error) {
 // error will be of type NonFatalErrors).
 func ParseCertificate(asn1Data []byte) (*Certificate, error) {
 	var cert certificate
+	var nfe NonFatalErrors
+	var laxErr error
 	rest, err := asn1.Unmarshal(asn1Data, &cert)
 	if err != nil {
-		return nil, err
+		rest, laxErr = asn1.UnmarshalWithParams(asn1Data, &cert, "lax")
+		if laxErr != nil {
+			return nil, laxErr
+		}
+		nfe.AddError(err)
 	}
 	if len(rest) > 0 {
 		return nil, asn1.SyntaxError{Msg: "trailing data"}
 	}
-
-	return parseCertificate(&cert)
+	ret, err := parseCertificate(&cert)
+	if err != nil {
+		var errs NonFatalErrors
+		var ok bool
+		if errs, ok = err.(NonFatalErrors); !ok {
+			return nil, err
+		}
+		nfe.Errors = append(nfe.Errors, errs.Errors...)
+	}
+	if nfe.HasError() {
+		return ret, nfe
+	}
+	return ret, nil
 }
 
 // ParseCertificates parses one or more certificates from the given ASN.1 DER
@@ -2078,27 +2113,33 @@ func ParseCertificate(asn1Data []byte) (*Certificate, error) {
 // case the error will be of type NonFatalErrors).
 func ParseCertificates(asn1Data []byte) ([]*Certificate, error) {
 	var v []*certificate
+	var nfe NonFatalErrors
+	var laxErr error
 
 	for len(asn1Data) > 0 {
 		cert := new(certificate)
 		var err error
 		asn1Data, err = asn1.Unmarshal(asn1Data, cert)
 		if err != nil {
-			return nil, err
+			asn1Data, laxErr = asn1.UnmarshalWithParams(asn1Data, &cert, "lax")
+			if laxErr != nil {
+				return nil, laxErr
+			}
+			nfe.AddError(err)
 		}
 		v = append(v, cert)
 	}
 
-	var nfe NonFatalErrors
 	ret := make([]*Certificate, len(v))
 	for i, ci := range v {
 		cert, err := parseCertificate(ci)
 		if err != nil {
-			if errs, ok := err.(NonFatalErrors); !ok {
+			var errs NonFatalErrors
+			var ok bool
+			if errs, ok = err.(NonFatalErrors); !ok {
 				return nil, err
-			} else {
-				nfe.Errors = append(nfe.Errors, errs.Errors...)
 			}
+			nfe.Errors = append(nfe.Errors, errs.Errors...)
 		}
 		ret[i] = cert
 	}

--- a/x509/x509_test.go
+++ b/x509/x509_test.go
@@ -2623,7 +2623,7 @@ func TestParseCertificateFail(t *testing.T) {
 		{desc: "EmptyEKU", in: "testdata/invalid/xf-ext-extended-key-usage-empty.pem", wantErr: "empty ExtendedKeyUsage"},
 		{desc: "EKUEmptyOID", in: "testdata/invalid/xf-ext-extended-key-usage-empty-oid.pem", wantErr: "zero length OBJECT IDENTIFIER"},
 		{desc: "SECp192r1TooShort", in: "testdata/invalid/xf-pubkey-ecdsa-secp192r1.pem", wantErr: "insecure curve (secp192r1)"},
-		{desc: "SerialNoIntegerNotMinimal", in: "testdata/invalid/xf-der-invalid-nonminimal-int.pem", wantErr: "integer not minimally-encoded", wantFatal: true},
+		{desc: "SerialNoIntegerNotMinimal", in: "testdata/invalid/xf-der-invalid-nonminimal-int.pem", wantErr: "integer not minimally-encoded"},
 		{desc: "RSAIntegerNotMinimal", in: "testdata/invalid/xf-der-pubkey-rsa-nonminimal-int.pem", wantErr: "integer not minimally-encoded"},
 		{desc: "SubjectNonPrintable", in: "testdata/invalid/xf-subject-nonprintable.pem", wantErr: "PrintableString contains invalid character"},
 		{desc: "NegativeRSAModulus", in: "testdata/invalid/xf-pubkey-rsa-modulus-negative.pem", wantErr: "RSA modulus is not a positive number"},

--- a/x509/x509_test.go
+++ b/x509/x509_test.go
@@ -2623,7 +2623,7 @@ func TestParseCertificateFail(t *testing.T) {
 		{desc: "EmptyEKU", in: "testdata/invalid/xf-ext-extended-key-usage-empty.pem", wantErr: "empty ExtendedKeyUsage"},
 		{desc: "EKUEmptyOID", in: "testdata/invalid/xf-ext-extended-key-usage-empty-oid.pem", wantErr: "zero length OBJECT IDENTIFIER"},
 		{desc: "SECp192r1TooShort", in: "testdata/invalid/xf-pubkey-ecdsa-secp192r1.pem", wantErr: "insecure curve (secp192r1)"},
-		{desc: "SerialNoIntegerNotMinimal", in: "testdata/invalid/xf-der-invalid-nonminimal-int.pem", wantErr: "integer not minimally-encoded"},
+		{desc: "SerialNumIntegerNotMinimal", in: "testdata/invalid/xf-der-invalid-nonminimal-int.pem", wantErr: "integer not minimally-encoded"},
 		{desc: "RSAIntegerNotMinimal", in: "testdata/invalid/xf-der-pubkey-rsa-nonminimal-int.pem", wantErr: "integer not minimally-encoded"},
 		{desc: "SubjectNonPrintable", in: "testdata/invalid/xf-subject-nonprintable.pem", wantErr: "PrintableString contains invalid character"},
 		{desc: "NegativeRSAModulus", in: "testdata/invalid/xf-pubkey-rsa-modulus-negative.pem", wantErr: "RSA modulus is not a positive number"},


### PR DESCRIPTION
There are certificates in the wild (such as STMicro TPM certificatse) that
contain a non-minimally encoded serial number. Retry unmarshalling with
lax enabled in order to allow us to parse them.