### PR TITLE
Use go list instead of $GOPATH

### DIFF
--- a/trillian/integration/ct_functions.sh
+++ b/trillian/integration/ct_functions.sh
@@ -79,7 +79,7 @@ ct_prep_test() {
         PROMETHEUS_CFGDIR="$(mktemp -d ${TMPDIR}/ct-prometheus-XXXXXX)"
         local prom_cfg="${PROMETHEUS_CFGDIR}/config.yaml"
         local etcdiscovered="${PROMETHEUS_CFGDIR}/trillian.json"
-        sed "s!@ETCDISCOVERED@!${etcdiscovered}!" $(go list -f '{{ .Dir }}' github.com/google/certificate-transparency-go)/trillian/integration/prometheus.yml > "${prom_cfg}"
+        sed "s!@ETCDISCOVERED@!${etcdiscovered}!" ${CT_GO_PATH}/trillian/integration/prometheus.yml > "${prom_cfg}"
         echo "Prometheus configuration in ${prom_cfg}:"
         cat ${prom_cfg}
 
@@ -91,8 +91,8 @@ ct_prep_test() {
         ETCDISCOVER_PID=$!
         echo "Launching Prometheus (default location localhost:9090)"
         ${PROMETHEUS_DIR}/prometheus --config.file=${prom_cfg} \
-                           --web.console.templates=$(go list -f '{{ .Dir }}' github.com/google/certificate-transparency-go)/trillian/integration/consoles \
-                           --web.console.libraries=$(go list -f '{{ .Dir }}' github.com/google/certificate-transparency-go)/third_party/prometheus/console_libs &
+                           --web.console.templates=${CT_GO_PATH}/trillian/integration/consoles \
+                           --web.console.libraries=${CT_GO_PATH}/third_party/prometheus/console_libs &
         PROMETHEUS_PID=$!
     fi
   fi
@@ -110,10 +110,10 @@ ct_provision() {
 
   # Build config files with absolute paths
   CT_CFG=$(mktemp ${TMPDIR}/ct-XXXXXX)
-  sed "s!@TESTDATA@!$(go list -f '{{ .Dir }}' github.com/google/certificate-transparency-go)/trillian/testdata!" $(go list -f '{{ .Dir }}' github.com/google/certificate-transparency-go)/trillian/integration/ct_integration_test.cfg > "${CT_CFG}"
+  sed "s!@TESTDATA@!${CT_GO_PATH}/trillian/testdata!" ${CT_GO_PATH}/trillian/integration/ct_integration_test.cfg > "${CT_CFG}"
 
   CT_LIFECYCLE_CFG=$(mktemp ${TMPDIR}/ct-XXXXXX)
-  sed "s!@TESTDATA@!$(go list -f '{{ .Dir }}' github.com/google/certificate-transparency-go)/trillian/testdata!" $(go list -f '{{ .Dir }}' github.com/google/certificate-transparency-go)/trillian/integration/ct_lifecycle_test.cfg > "${CT_LIFECYCLE_CFG}"
+  sed "s!@TESTDATA@!${CT_GO_PATH}/trillian/testdata!" ${CT_GO_PATH}/trillian/integration/ct_lifecycle_test.cfg > "${CT_LIFECYCLE_CFG}"
 
   echo 'Building createtree'
   go build github.com/google/trillian/cmd/createtree/
@@ -147,7 +147,7 @@ ct_provision_cfg() {
     tree_id=$(./createtree \
       --admin_server="${admin_server}" \
       --private_key_format=PrivateKey \
-      --pem_key_path=$(go list -f '{{ .Dir }}' github.com/google/certificate-transparency-go)/trillian/testdata/log-rpc-server.privkey.pem \
+      --pem_key_path=${CT_GO_PATH}/trillian/testdata/log-rpc-server.privkey.pem \
       --pem_key_password=towel \
       --signature_algorithm=ECDSA)
     echo "Created tree ${tree_id}"
@@ -167,7 +167,7 @@ ct_gosmin_config() {
 
   # Build config file with absolute paths
   GOSMIN_CFG=$(mktemp ${TMPDIR}/gosmin-XXXXXX)
-  sed "s/@SERVER@/${server}/" $(go list -f '{{ .Dir }}' github.com/google/certificate-transparency-go)/trillian/integration/gosmin.cfg > "${GOSMIN_CFG}"
+  sed "s/@SERVER@/${server}/" ${CT_GO_PATH}/trillian/integration/gosmin.cfg > "${GOSMIN_CFG}"
 
   echo "gosmin configuration at ${GOSMIN_CFG}:"
   cat "${GOSMIN_CFG}"
@@ -206,7 +206,7 @@ ct_goshawk_config() {
 
   # Build config file with absolute paths
   GOSHAWK_CFG=$(mktemp ${TMPDIR}/goshawk-XXXXXX)
-  sed "s/@SERVER@/${server}/" $(go list -f '{{ .Dir }}' github.com/google/certificate-transparency-go)/trillian/integration/goshawk.cfg > "${GOSHAWK_CFG}"
+  sed "s/@SERVER@/${server}/" ${CT_GO_PATH}/trillian/integration/goshawk.cfg > "${GOSHAWK_CFG}"
 
   echo "goshawk configuration at ${GOSHAWK_CFG}:"
   cat "${GOSHAWK_CFG}"

--- a/trillian/integration/ct_functions.sh
+++ b/trillian/integration/ct_functions.sh
@@ -79,7 +79,7 @@ ct_prep_test() {
         PROMETHEUS_CFGDIR="$(mktemp -d ${TMPDIR}/ct-prometheus-XXXXXX)"
         local prom_cfg="${PROMETHEUS_CFGDIR}/config.yaml"
         local etcdiscovered="${PROMETHEUS_CFGDIR}/trillian.json"
-        sed "s!@ETCDISCOVERED@!${etcdiscovered}!" ${GOPATH}/src/github.com/google/certificate-transparency-go/trillian/integration/prometheus.yml > "${prom_cfg}"
+        sed "s!@ETCDISCOVERED@!${etcdiscovered}!" $(go list -f '{{ .Dir }}' github.com/google/certificate-transparency-go)/trillian/integration/prometheus.yml > "${prom_cfg}"
         echo "Prometheus configuration in ${prom_cfg}:"
         cat ${prom_cfg}
 
@@ -91,8 +91,8 @@ ct_prep_test() {
         ETCDISCOVER_PID=$!
         echo "Launching Prometheus (default location localhost:9090)"
         ${PROMETHEUS_DIR}/prometheus --config.file=${prom_cfg} \
-                           --web.console.templates=${GOPATH}/src/github.com/google/certificate-transparency-go/trillian/integration/consoles \
-                           --web.console.libraries=${GOPATH}/src/github.com/google/certificate-transparency-go/third_party/prometheus/console_libs &
+                           --web.console.templates=$(go list -f '{{ .Dir }}' github.com/google/certificate-transparency-go)/trillian/integration/consoles \
+                           --web.console.libraries=$(go list -f '{{ .Dir }}' github.com/google/certificate-transparency-go)/third_party/prometheus/console_libs &
         PROMETHEUS_PID=$!
     fi
   fi
@@ -110,10 +110,10 @@ ct_provision() {
 
   # Build config files with absolute paths
   CT_CFG=$(mktemp ${TMPDIR}/ct-XXXXXX)
-  sed "s!@TESTDATA@!${GOPATH}/src/github.com/google/certificate-transparency-go/trillian/testdata!" ${GOPATH}/src/github.com/google/certificate-transparency-go/trillian/integration/ct_integration_test.cfg > "${CT_CFG}"
+  sed "s!@TESTDATA@!$(go list -f '{{ .Dir }}' github.com/google/certificate-transparency-go)/trillian/testdata!" $(go list -f '{{ .Dir }}' github.com/google/certificate-transparency-go)/trillian/integration/ct_integration_test.cfg > "${CT_CFG}"
 
   CT_LIFECYCLE_CFG=$(mktemp ${TMPDIR}/ct-XXXXXX)
-  sed "s!@TESTDATA@!${GOPATH}/src/github.com/google/certificate-transparency-go/trillian/testdata!" ${GOPATH}/src/github.com/google/certificate-transparency-go/trillian/integration/ct_lifecycle_test.cfg > "${CT_LIFECYCLE_CFG}"
+  sed "s!@TESTDATA@!$(go list -f '{{ .Dir }}' github.com/google/certificate-transparency-go)/trillian/testdata!" $(go list -f '{{ .Dir }}' github.com/google/certificate-transparency-go)/trillian/integration/ct_lifecycle_test.cfg > "${CT_LIFECYCLE_CFG}"
 
   echo 'Building createtree'
   go build github.com/google/trillian/cmd/createtree/
@@ -147,7 +147,7 @@ ct_provision_cfg() {
     tree_id=$(./createtree \
       --admin_server="${admin_server}" \
       --private_key_format=PrivateKey \
-      --pem_key_path=${GOPATH}/src/github.com/google/certificate-transparency-go/trillian/testdata/log-rpc-server.privkey.pem \
+      --pem_key_path=$(go list -f '{{ .Dir }}' github.com/google/certificate-transparency-go)/trillian/testdata/log-rpc-server.privkey.pem \
       --pem_key_password=towel \
       --signature_algorithm=ECDSA)
     echo "Created tree ${tree_id}"
@@ -167,7 +167,7 @@ ct_gosmin_config() {
 
   # Build config file with absolute paths
   GOSMIN_CFG=$(mktemp ${TMPDIR}/gosmin-XXXXXX)
-  sed "s/@SERVER@/${server}/" ${GOPATH}/src/github.com/google/certificate-transparency-go/trillian/integration/gosmin.cfg > "${GOSMIN_CFG}"
+  sed "s/@SERVER@/${server}/" $(go list -f '{{ .Dir }}' github.com/google/certificate-transparency-go)/trillian/integration/gosmin.cfg > "${GOSMIN_CFG}"
 
   echo "gosmin configuration at ${GOSMIN_CFG}:"
   cat "${GOSMIN_CFG}"
@@ -206,7 +206,7 @@ ct_goshawk_config() {
 
   # Build config file with absolute paths
   GOSHAWK_CFG=$(mktemp ${TMPDIR}/goshawk-XXXXXX)
-  sed "s/@SERVER@/${server}/" ${GOPATH}/src/github.com/google/certificate-transparency-go/trillian/integration/goshawk.cfg > "${GOSHAWK_CFG}"
+  sed "s/@SERVER@/${server}/" $(go list -f '{{ .Dir }}' github.com/google/certificate-transparency-go)/trillian/integration/goshawk.cfg > "${GOSHAWK_CFG}"
 
   echo "goshawk configuration at ${GOSHAWK_CFG}:"
   cat "${GOSHAWK_CFG}"

--- a/trillian/integration/ct_hammer_test.sh
+++ b/trillian/integration/ct_hammer_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-. "${GOPATH}"/src/github.com/google/trillian/integration/functions.sh
+. "$(go list -f '{{ .Dir }}' github.com/google/trillian)"/integration/functions.sh
 INTEGRATION_DIR="$( cd "$( dirname "$0" )" && pwd )"
 . "${INTEGRATION_DIR}"/ct_functions.sh
 
@@ -41,7 +41,8 @@ fi
 metrics_port=$(pick_unused_port)
 echo "Running test(s) with metrics at localhost:${metrics_port}"
 set +e
-./ct_hammer --log_config "${CT_CFG}" --ct_http_servers=${CT_SERVERS} --mmd=30s --testdata_dir=${GOPATH}/src/github.com/google/certificate-transparency-go/trillian/testdata --metrics_endpoint="localhost:${metrics_port}" --logtostderr ${HAMMER_OPTS}
+./ct_hammer --log_config "${CT_CFG}" --ct_http_servers=${CT_SERVERS} --mmd=30s --testdata_dir=$(go list -f '{{ .Dir }}' github.com/google/certificate-transparency-go)/trillian/testdata --metrics_endpoint="localhost:${metrics_port}" --logtostderr ${HAMMER_OPTS}
+
 RESULT=$?
 set -e
 

--- a/trillian/integration/ct_integration_test.sh
+++ b/trillian/integration/ct_integration_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-. "${GOPATH}"/src/github.com/google/trillian/integration/functions.sh
+. "$(go list -f '{{ .Dir }}' github.com/google/trillian)"/integration/functions.sh
 INTEGRATION_DIR="$( cd "$( dirname "$0" )" && pwd )"
 . "${INTEGRATION_DIR}"/ct_functions.sh
 
@@ -23,7 +23,7 @@ TO_KILL+=(${ETCDISCOVER_PID})
 TO_DELETE="${TO_DELETE} ${CT_CFG} ${CT_LIFECYCLE_CFG} ${CT_COMBINED_CONFIG}"
 TO_KILL+=(${CT_SERVER_PIDS[@]})
 
-COMMON_ARGS="--ct_http_servers=${CT_SERVERS} --ct_metrics_servers=${CT_METRICS_SERVERS} --testdata_dir=${GOPATH}/src/github.com/google/certificate-transparency-go/trillian/testdata"
+COMMON_ARGS="--ct_http_servers=${CT_SERVERS} --ct_metrics_servers=${CT_METRICS_SERVERS} --testdata_dir="$(go list -f '{{ .Dir }}' github.com/google/certificate-transparency-go)"/trillian/testdata"
 
 echo "Running test(s)"
 pushd "${INTEGRATION_DIR}"

--- a/trillian/integration/integration_test.sh
+++ b/trillian/integration/integration_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-. "${GOPATH}"/src/github.com/google/trillian/integration/functions.sh
+. "$(go list -f '{{ .Dir }}' github.com/google/trillian)/integration/functions.sh"
 
-run_test "CT integration test" "${GOPATH}/src/github.com/google/certificate-transparency-go/trillian/integration/ct_integration_test.sh" 1 1 1
-run_test "CT multi-server integration test" "${GOPATH}/src/github.com/google/certificate-transparency-go/trillian/integration/ct_integration_test.sh" 3 3 3
+run_test "CT integration test" "$(go list -f '{{ .Dir }}' github.com/google/certificate-transparency-go)/trillian/integration/ct_integration_test.sh" 1 1 1
+run_test "CT multi-server integration test" "$(go list -f '{{ .Dir }}' github.com/google/certificate-transparency-go)/trillian/integration/ct_integration_test.sh" 3 3 3


### PR DESCRIPTION
Allow other go module enabled repos to use these scripts.

This will use the go command to resolve the package path, which works
correctly when GO111MODULE is off, auto, or on.