### PR TITLE
Upgrade to latest version of go 1.11.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: true  # required for CI push into Kubernetes.
 os: linux
 dist: xenial
 language: go
-go: "1.11"
+go: "1.11.x"
 go_import_path: github.com/google/certificate-transparency-go
 
 


### PR DESCRIPTION
Go 1.11.4 fixed some symlink traversing bugs. 
This bug prevents causes `go mod verify` to fail.  

https://github.com/golang/go/issues/17451