### PR TITLE
Add PKCS integration test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ env:
   - GOFLAGS=-race                PRESUBMIT_OPTS="--no-linters"
   - GOFLAGS=      WITH_ETCD=true PRESUBMIT_OPTS="--no-linters --coverage"
   - GOFLAGS=-race WITH_ETCD=true PRESUBMIT_OPTS="--no-linters"
+  - GOFLAGS='-race --tags=pkcs11' WITH_PKCS11=true PRESUBMIT_OPTS="--no-linters"
+
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
   - GOFLAGS=-race                PRESUBMIT_OPTS="--no-linters"
   - GOFLAGS=      WITH_ETCD=true PRESUBMIT_OPTS="--no-linters --coverage"
   - GOFLAGS=-race WITH_ETCD=true PRESUBMIT_OPTS="--no-linters"
+    # The CT integration tests do not currently use a pkcs11 key. This only tests the build.
   - GOFLAGS='-race --tags=pkcs11' WITH_PKCS11=true PRESUBMIT_OPTS="--no-linters"
 
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/google/certificate-transparency-go
 go 1.12
 
 require (
+	bitbucket.org/creachadair/shell v0.0.6 // indirect
 	contrib.go.opencensus.io/exporter/stackdriver v0.12.1 // indirect
 	github.com/bgentry/speakeasy v0.1.0 // indirect
 	github.com/coreos/bbolt v1.3.2 // indirect
@@ -30,7 +31,7 @@ require (
 	github.com/jonboulle/clockwork v0.1.0 // indirect
 	github.com/juju/ratelimit v1.0.1
 	github.com/kylelemons/godebug v1.1.0
-	github.com/letsencrypt/pkcs11key v2.0.0+incompatible // indirect
+	github.com/letsencrypt/pkcs11key v2.0.1-0.20170608213348-396559074696+incompatible // indirect
 	github.com/lib/pq v1.1.1 // indirect
 	github.com/mattn/go-runewidth v0.0.4 // indirect
 	github.com/mattn/go-sqlite3 v1.10.0

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/jonboulle/clockwork v0.1.0 // indirect
 	github.com/juju/ratelimit v1.0.1
 	github.com/kylelemons/godebug v1.1.0
+	// TODO(gbelvin): Remove when Trillian declares its dependencies with go.mod
 	github.com/letsencrypt/pkcs11key v2.0.1-0.20170608213348-396559074696+incompatible // indirect
 	github.com/lib/pq v1.1.1 // indirect
 	github.com/mattn/go-runewidth v0.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+bitbucket.org/creachadair/shell v0.0.6 h1:reJflDbKqnlnqb4Oo2pQ1/BqmY/eCWcNGHrIUO8qIzc=
+bitbucket.org/creachadair/shell v0.0.6/go.mod h1:8Qqi/cYk7vPnsOePHroKXDJYmb5x7ENhtiFtfZq8K+M=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0 h1:ROfEUZz+Gh5pa62DJWXSaonyu3StP6EA6lPEXPI6mCo=
@@ -195,6 +197,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/letsencrypt/pkcs11key v2.0.0+incompatible h1:zYbII8Qh9OY9zYhS8nvIZVojd8tP756M1W1C3r7Uoq0=
 github.com/letsencrypt/pkcs11key v2.0.0+incompatible/go.mod h1:iGYXKqDXt0cpBthCHdr9ZdsQwyGlYFh/+8xa4WzIQ34=
+github.com/letsencrypt/pkcs11key v2.0.1-0.20170608213348-396559074696+incompatible h1:GfzE+uq7odDW7nOmp1QWuilLEK7kJf8i84XcIfk3mKA=
+github.com/letsencrypt/pkcs11key v2.0.1-0.20170608213348-396559074696+incompatible/go.mod h1:iGYXKqDXt0cpBthCHdr9ZdsQwyGlYFh/+8xa4WzIQ34=
 github.com/lib/pq v1.1.1 h1:sJZmqHoEaY7f+NPP8pgLB/WxulyR3fewgCM2qaSlBb4=
 github.com/lib/pq v1.1.1/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/logrusorgru/aurora v0.0.0-20181002194514-a7b3b318ed4e/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=


### PR DESCRIPTION
The Trillian Repo runs the CT integration tests with with PKCS11 support turned on. 
Those tests probably belong here as well.

In doing so, we discover and pin a new dependency on pkcs11key. 

Resolving this should also fix the Trillian builds. 