### PR TITLE
Update prometheus-to-sd from v0.3.2 to v0.5.2

### DIFF
--- a/trillian/examples/deployment/kubernetes/ctfe-deployment.yaml
+++ b/trillian/examples/deployment/kubernetes/ctfe-deployment.yaml
@@ -51,7 +51,7 @@ spec:
           - name: ctfe-config-volume
             mountPath: /ctfe-config
         - name: prometheus-to-sd
-          image: gcr.io/google-containers/prometheus-to-sd:v0.3.2
+          image: gcr.io/google-containers/prometheus-to-sd:v0.5.2
           ports:
             - name: profiler
               containerPort: 6060


### PR DESCRIPTION
Fixes some error messages about unsupported metrics.