### PR TITLE
Remove --log_rpc_server flag from CTFE Kubernetes deployment

### DIFF
--- a/trillian/examples/deployment/kubernetes/ctfe-deployment.yaml
+++ b/trillian/examples/deployment/kubernetes/ctfe-deployment.yaml
@@ -18,7 +18,6 @@ spec:
           args: [
             "--http_endpoint=0.0.0.0:6962",
             "--metrics_endpoint=0.0.0.0:6963",
-            "--log_rpc_server=dns:///trillian-log-service:8090",
             "--log_config=/ctfe-config/ct_server.cfg",
             "--alsologtostderr"
           ]


### PR DESCRIPTION
Rely on the log config specifying the backends instead. This enables support for multiple backends, e.g. separate Trillian instances with different storage implementations.