### PR TITLE
Make cloudbuild.yaml only dry-run deployment to Kubernetes

### DIFF
--- a/cloudbuild_master.yaml
+++ b/cloudbuild_master.yaml
@@ -10,6 +10,23 @@ steps:
   - --tag=gcr.io/${PROJECT_ID}/ctfe:${COMMIT_SHA}
   - .
   waitFor: ["-"]
+- id: push_ctfe
+  name: gcr.io/cloud-builders/docker
+  args:
+  - push
+  - gcr.io/${PROJECT_ID}/ctfe:${COMMIT_SHA}
+  waitFor:
+  - build_ctfe
+- id: tag_latest_ctfe
+  name: gcr.io/cloud-builders/gcloud
+  args:
+  - container
+  - images
+  - add-tag
+  - gcr.io/${PROJECT_ID}/ctfe:${COMMIT_SHA}
+  - gcr.io/${PROJECT_ID}/ctfe:latest
+  waitFor:
+  - push_ctfe
 - id: build_envsubst
   name: gcr.io/cloud-builders/docker
   args:
@@ -29,11 +46,10 @@ steps:
   - IMAGE_TAG=${COMMIT_SHA}
   waitFor:
   - build_envsubst
-- id: update_kubernetes_configs_dryrun
+- id: update_kubernetes_configs
   name: gcr.io/cloud-builders/kubectl
   args:
   - apply
-  - --server-dry-run
   - -f=trillian/examples/deployment/kubernetes/ctfe-deployment.yaml
   - -f=trillian/examples/deployment/kubernetes/ctfe-service.yaml
   - -f=trillian/examples/deployment/kubernetes/ctfe-ingress.yaml
@@ -42,5 +58,6 @@ steps:
   - CLOUDSDK_CONTAINER_CLUSTER=${_CLUSTER_NAME}
   waitFor:
   - envsubst_kubernetes_configs
+  - push_ctfe
 images:
 - gcr.io/${PROJECT_ID}/ctfe:${COMMIT_SHA}


### PR DESCRIPTION
The actual deployment will be handled by cloudbuild_master.yaml. This means that cloudbuild.yaml can safely be used for pull requests, whereas cloudbuild_master.yaml should only be used for commits merged to master.