### PR TITLE
Enable goproxy in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ go_import_path: github.com/google/certificate-transparency-go
 env:
   global:
   - GO111MODULE=on
+  - GOPROXY=https://proxy.golang.org
   matrix:
   - GOFLAGS=
   - GOFLAGS=-race                PRESUBMIT_OPTS="--no-linters"


### PR DESCRIPTION
Trial using the Google module proxy in travis builds:

* in preparation for Golang module transparency
* makes dep fetching faster and more reliable.