### PR TITLE
Prefix port name with "http-" in ctfe-deployment.yaml

### DIFF
--- a/trillian/examples/deployment/kubernetes/ctfe-deployment.yaml
+++ b/trillian/examples/deployment/kubernetes/ctfe-deployment.yaml
@@ -45,7 +45,7 @@ spec:
           - containerPort: 6962
             name: http
           - containerPort: 6963
-            name: metrics
+            name: http-metrics
           volumeMounts:
           - name: ctfe-config-volume
             mountPath: /ctfe-config


### PR DESCRIPTION
Allows Istio to understand the protocol being used and provide better monitoring.

https://istio.io/docs/setup/kubernetes/additional-setup/requirements/