### PR TITLE
Allow tuning of dupe adds in Hammer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,13 @@ The `sctcheck` tool has these new flags:
 -   `--check_inclusion` - Checks that the SCT was honoured (i.e. the
     corresponding certificate was included in the issuing CT log)
 
+#### ct_hammer
+
+The `ct_hammer` tool has these new flags:
+
+-   `--duplicate_chance` - Allows setting the probability of the hammer sending
+    a duplicate submission.
+
 ## v1.0.21 - CTFE Logging / Path Options. Mirroring. RPKI. Non Fatal X.509 error improvements
 
 Published 2018-08-20 10:11:04 +0000 UTC

--- a/trillian/integration/ct_hammer/main.go
+++ b/trillian/integration/ct_hammer/main.go
@@ -88,6 +88,7 @@ var (
 	getRootsBias          = flag.Int("get_roots", 1, "Bias for get-roots operations")
 	getEntryAndProofBias  = flag.Int("get_entry_and_proof", 0, "Bias for get-entry-and-proof operations")
 	invalidChance         = flag.Int("invalid_chance", 10, "Chance of generating an invalid operation, as the N in 1-in-N (0 for never)")
+	dupeChance            = flag.Int("duplicate_chance", 10, "Chance of generating a duplicate submission, as the N in 1-in-N (0 for never)")
 )
 
 func newLimiter(rate int) integration.Limiter {
@@ -304,6 +305,7 @@ func main() {
 			IgnoreErrors:        *ignoreErrors,
 			MaxRetryDuration:    *maxRetry,
 			RequestDeadline:     *reqDeadline,
+			DuplicateChance:     *dupeChance,
 		}
 		go func(cfg integration.HammerConfig) {
 			defer wg.Done()

--- a/trillian/integration/hammer.go
+++ b/trillian/integration/hammer.go
@@ -141,6 +141,10 @@ type HammerConfig struct {
 	MaxRetryDuration time.Duration
 	// RequestDeadline indicates the deadline to set on each request to the log.
 	RequestDeadline time.Duration
+	// DuplicateChance sets the probability of attempting to add a duplicate when
+	// calling add[-pre]-chain (as the N in 1-in-N). Set to 0 to disable sending
+	// duplicates.
+	DuplicateChance int
 }
 
 // HammerBias indicates the bias for selecting different log operations.
@@ -381,9 +385,8 @@ func (s *hammerState) getChain() (Choice, []ct.ASN1Cert, error) {
 	s.chainMu.Lock()
 	defer s.chainMu.Unlock()
 
-	// TODO(drysdale): restore LastCert as an option
-	choices := []Choice{NewCert, FirstCert}
-	choice := choices[rand.Intn(len(choices))]
+	choice := s.chooseCertToAdd()
+	// Override choice if necessary
 	if s.lastChain == nil {
 		choice = NewCert
 	}
@@ -489,13 +492,21 @@ func (s *hammerState) addChainInvalid(ctx context.Context) error {
 	return nil
 }
 
+// chooseAddType determines whether to add a new or pre-existing cert.
+func (s *hammerState) chooseCertToAdd() Choice {
+	if s.cfg.DuplicateChance > 0 && rand.Intn(s.cfg.DuplicateChance) == 0 {
+		// TODO(drysdale): restore LastCert as an option
+		return FirstCert
+	}
+	return NewCert
+}
+
 func (s *hammerState) getPreChain() (Choice, []ct.ASN1Cert, []byte, error) {
 	s.chainMu.Lock()
 	defer s.chainMu.Unlock()
 
-	// TODO(drysdale): restore LastCert as an option
-	choices := []Choice{NewCert, FirstCert}
-	choice := choices[rand.Intn(len(choices))]
+	choice := s.chooseCertToAdd()
+	// Override choice if necessary
 	if s.lastPreChain == nil {
 		choice = NewCert
 	}

--- a/trillian/integration/hammer.go
+++ b/trillian/integration/hammer.go
@@ -492,7 +492,7 @@ func (s *hammerState) addChainInvalid(ctx context.Context) error {
 	return nil
 }
 
-// chooseAddType determines whether to add a new or pre-existing cert.
+// chooseCertToAdd determines whether to add a new or pre-existing cert.
 func (s *hammerState) chooseCertToAdd() Choice {
 	if s.cfg.DuplicateChance > 0 && rand.Intn(s.cfg.DuplicateChance) == 0 {
 		// TODO(drysdale): restore LastCert as an option

--- a/trillian/integration/hammer_test.go
+++ b/trillian/integration/hammer_test.go
@@ -306,3 +306,55 @@ func loadTestKeys(t *testing.T) *testKeys {
 		signer:    signer,
 	}
 }
+
+func TestChooseCertToAdd(t *testing.T) {
+	for _, test := range []struct {
+		desc    string
+		dupeInN int
+		wantNew bool
+		wantOld bool
+	}{
+		{
+			desc:    "all new",
+			dupeInN: 0,
+			wantNew: true,
+		},
+		{
+			desc:    "all old",
+			dupeInN: 1,
+			wantOld: true,
+		},
+		{
+			desc:    "mix",
+			dupeInN: 2,
+			wantNew: true,
+			wantOld: true,
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			state := hammerState{cfg: &HammerConfig{DuplicateChance: test.dupeInN}}
+			var gotNew, gotOld bool
+			for i := 0; i < 100; i++ {
+				switch state.chooseCertToAdd() {
+				case NewCert:
+					gotNew = true
+				case FirstCert, LastCert:
+					gotOld = true
+				}
+			}
+			if gotNew && !test.wantNew {
+				t.Errorf("got NewCert but expected none")
+			}
+			if !gotNew && test.wantNew {
+				t.Errorf("got no NewCerts but expected some")
+			}
+			if gotOld && !test.wantOld {
+				t.Errorf("got First/Last cert but expected none")
+			}
+			if !gotOld && test.wantOld {
+				t.Errorf("got no First/Last cert but expected some")
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
Currently, the hammer chooses whether to add a new or a duplicate submission with roughly 50% hardcoded probability, this change allows the user to set their own probability.

### Checklist

- [X] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
