### PR TITLE
Fix possible (unlikely) nil pointer access in instance_test

### DIFF
--- a/trillian/ctfe/instance_test.go
+++ b/trillian/ctfe/instance_test.go
@@ -183,6 +183,10 @@ func equivalentTimes(a *time.Time, b *timestamp.Timestamp) bool {
 	if a == nil && b == nil {
 		return true
 	}
+	if a == nil {
+		// b can't be nil as it would have returned above.
+		return false
+	}
 	tsA, err := ptypes.TimestampProto(*a)
 	if err != nil {
 		return false


### PR DESCRIPTION
`ptypes.TimestampString()` is nil safe but before that we convert it to a timestamp proto via a pointer that could be nil.

Would need to have bad test data to trigger it so not a major issue.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
