### PR TITLE
Minor changes for Loglist-filtering funcs

### DIFF
--- a/loglist2/logfilter.go
+++ b/loglist2/logfilter.go
@@ -26,22 +26,24 @@ type LogRoots map[string]*ctfe.PEMCertPool
 
 // Compatible creates a new LogList containing only Logs matching the temporal,
 // root-acceptance and Log-status conditions.
-func (ll *LogList) Compatible(cert *x509.Certificate, certRoot *x509.Certificate, roots LogRoots, lstat LogStatus) LogList {
+func (ll *LogList) Compatible(cert *x509.Certificate, certRoot *x509.Certificate, roots LogRoots) LogList {
 	active := ll.TemporallyCompatible(cert)
-	active = active.RootCompatible(certRoot, roots)
-	return active.SelectByStatus(lstat)
+	return active.RootCompatible(certRoot, roots)
 }
 
 // SelectByStatus creates a new LogList containing only logs with status
 // provided from the original.
-func (ll *LogList) SelectByStatus(lstat LogStatus) LogList {
+func (ll *LogList) SelectByStatus(lstats []LogStatus) LogList {
 	var active LogList
 	for _, op := range ll.Operators {
 		activeOp := *op
 		activeOp.Logs = []*Log{}
 		for _, l := range op.Logs {
-			if l.State.LogStatus() == lstat {
-				activeOp.Logs = append(activeOp.Logs, l)
+			for _, lstat := range lstats {
+				if l.State.LogStatus() == lstat {
+					activeOp.Logs = append(activeOp.Logs, l)
+					break
+				}
 			}
 		}
 		if len(activeOp.Logs) > 0 {

--- a/loglist2/logfilter_test.go
+++ b/loglist2/logfilter_test.go
@@ -58,7 +58,9 @@ func TestSelectUsable(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := test.in.SelectByStatus(UsableLogStatus)
+			usableStat := make([]LogStatus, 1)
+			usableStat[0] = UsableLogStatus
+			got := test.in.SelectByStatus(usableStat)
 			if diff := pretty.Compare(test.want, got); diff != "" {
 				t.Errorf("Extracting active logs out of %v diff: (-want +got)\n%s", test.in, diff)
 			}
@@ -66,7 +68,7 @@ func TestSelectUsable(t *testing.T) {
 	}
 }
 
-func TestSelectQualified(t *testing.T) {
+func TestSelectPendingAndQualified(t *testing.T) {
 	tests := []struct {
 		name string
 		in   LogList
@@ -81,7 +83,10 @@ func TestSelectQualified(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := test.in.SelectByStatus(QualifiedLogStatus)
+			stats := make([]LogStatus, 2)
+			stats[0] = PendingLogStatus
+			stats[1] = QualifiedLogStatus
+			got := test.in.SelectByStatus(stats)
 			if diff := pretty.Compare(test.want, got); diff != "" {
 				t.Errorf("Extracting qualified logs out of %v diff: (-want +got)\n%s", test.in, diff)
 			}
@@ -281,7 +286,7 @@ func TestCompatible(t *testing.T) {
 			if test.cert != nil {
 				test.cert.NotBefore = test.notBefore
 			}
-			got := test.in.Compatible(test.cert, test.rootCert, test.roots, UsableLogStatus)
+			got := test.in.Compatible(test.cert, test.rootCert, test.roots)
 			if diff := pretty.Compare(test.want, got); diff != "" {
 				t.Errorf("Getting compatible logs diff: (-want +got)\n%s", diff)
 			}

--- a/submission/distributor.go
+++ b/submission/distributor.go
@@ -219,7 +219,7 @@ func (d *Distributor) addSomeChain(ctx context.Context, rawChain [][]byte, asPre
 
 	if err == nil {
 		parsedChain = rootedChain
-		compatibleLogs = d.ll.Compatible(rootedChain[0], rootedChain[len(rootedChain)-1], d.logRoots, loglist2.UsableLogStatus)
+		compatibleLogs = d.ll.Compatible(rootedChain[0], rootedChain[len(rootedChain)-1], d.logRoots)
 	} else if d.isRootDataFull() {
 		// Could not verify the chain while root info for logs is complete.
 		d.mu.RUnlock()
@@ -230,7 +230,7 @@ func (d *Distributor) addSomeChain(ctx context.Context, rawChain [][]byte, asPre
 		if err != nil {
 			return nil, fmt.Errorf("distributor unable to parse cert-chain: %v", err)
 		}
-		compatibleLogs = d.ll.Compatible(parsedChain[0], nil, d.logRoots, loglist2.UsableLogStatus)
+		compatibleLogs = d.ll.Compatible(parsedChain[0], nil, d.logRoots)
 	}
 	d.mu.RUnlock()
 
@@ -298,7 +298,9 @@ func BuildLogClient(log *loglist2.Log) (client.AddLogClient, error) {
 // the local copy of the roots up-to-date.
 func NewDistributor(ll *loglist2.LogList, plc ctpolicy.CTPolicy, lcBuilder LogClientBuilder, mf monitoring.MetricFactory) (*Distributor, error) {
 	var d Distributor
-	active := ll.SelectByStatus(loglist2.UsableLogStatus)
+	usableStat := make([]loglist2.LogStatus, 1)
+	usableStat[0] = loglist2.UsableLogStatus
+	active := ll.SelectByStatus(usableStat)
 	d.ll = &active
 	d.policy = plc
 	d.logClients = make(map[string]client.AddLogClient)

--- a/submission/proxy_test.go
+++ b/submission/proxy_test.go
@@ -101,7 +101,7 @@ func TestProxyInitState(t *testing.T) {
 
 	llr := NewLogListRefresher(f)
 	p := NewProxy(NewLogListManager(llr), GetDistributorBuilder(ChromeCTPolicy, buildStubNoRootsLogClient, imf), imf)
-	p.Run(context.Background(), time.Millisecond, time.Hour)
+	p.Run(context.Background(), 100*time.Millisecond, time.Hour)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()


### PR DESCRIPTION
Log-list can be filtered by set of Log-statuses ,not by only one. Compatible function does not accept Log-status as param anymore. Reduce number of  refresh-loops for proxy-test
