### PR TITLE
Re-order Log-statuses for better statuses hierarchy representation

### DIFF
--- a/loglist2/loglist2.go
+++ b/loglist2/loglist2.go
@@ -102,12 +102,12 @@ type LogStatus int
 // LogStatus values
 const (
 	UndefinedLogStatus LogStatus = iota
+	RejectedLogStatus
+	RetiredLogStatus
+	ReadOnlyLogStatus
 	PendingLogStatus
 	QualifiedLogStatus
 	UsableLogStatus
-	ReadOnlyLogStatus
-	RetiredLogStatus
-	RejectedLogStatus
 )
 
 //go:generate stringer -type=LogStatus

--- a/loglist2/logstatus_string.go
+++ b/loglist2/logstatus_string.go
@@ -4,9 +4,22 @@ package loglist2
 
 import "strconv"
 
-const _LogStatus_name = "UndefinedLogStatusPendingLogStatusQualifiedLogStatusUsableLogStatusReadOnlyLogStatusRetiredLogStatusRejectedLogStatus"
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[UndefinedLogStatus-0]
+	_ = x[RejectedLogStatus-1]
+	_ = x[RetiredLogStatus-2]
+	_ = x[ReadOnlyLogStatus-3]
+	_ = x[PendingLogStatus-4]
+	_ = x[QualifiedLogStatus-5]
+	_ = x[UsableLogStatus-6]
+}
 
-var _LogStatus_index = [...]uint8{0, 18, 34, 52, 67, 84, 100, 117}
+const _LogStatus_name = "UndefinedLogStatusRejectedLogStatusRetiredLogStatusReadOnlyLogStatusPendingLogStatusQualifiedLogStatusUsableLogStatus"
+
+var _LogStatus_index = [...]uint8{0, 18, 35, 51, 68, 84, 102, 117}
 
 func (i LogStatus) String() string {
 	if i < 0 || i >= LogStatus(len(_LogStatus_index)-1) {


### PR DESCRIPTION
New order of statuses represents 'functional power' of Log slightly better. That should allow comparison of 2 statuses of a single Log in a case of 2 Log-list versions.