### PR TITLE
Stub x509 system cert pool methods for js/wasm

### DIFF
--- a/x509/root_js.go
+++ b/x509/root_js.go
@@ -8,3 +8,11 @@ package x509
 
 // Possible certificate files; stop after finding one.
 var certFiles = []string{}
+
+func loadSystemRoots() (*CertPool, error) {
+	return NewCertPool(), nil
+}
+
+func (c *Certificate) systemVerify(opts *VerifyOptions) (chains [][]*Certificate, err error) {
+	return nil, nil
+}

--- a/x509/root_unix.go
+++ b/x509/root_unix.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build dragonfly freebsd js,wasm linux nacl netbsd openbsd solaris
+// +build dragonfly freebsd linux nacl netbsd openbsd solaris
 
 package x509
 


### PR DESCRIPTION
This fixes the build against the GOOS=js GOARCH=wasm target.
