### PR TITLE
Fix improper gomock comparisons

### DIFF
--- a/trillian/ctfe/sth_test.go
+++ b/trillian/ctfe/sth_test.go
@@ -201,7 +201,7 @@ func TestLogSTHGetter(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			rpcCl := mockclient.NewMockTrillianLogClient(ctrl)
 			if tc.slr != nil || tc.slrErr != nil {
-				rpcCl.EXPECT().GetLatestSignedLogRoot(gomock.Any(), &trillian.GetLatestSignedLogRootRequest{LogId: 99}).Return(tc.slr, tc.slrErr)
+				rpcCl.EXPECT().GetLatestSignedLogRoot(gomock.Any(), cmpMatcher{&trillian.GetLatestSignedLogRootRequest{LogId: 99}}).Return(tc.slr, tc.slrErr)
 			}
 
 			sthg := LogSTHGetter{li: &logInfo{rpcClient: rpcCl, logID: 99, signer: &fakeSigner{sig: tc.sig, err: tc.sigErr}}}
@@ -237,7 +237,7 @@ func TestMirrorSTHGetter(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			rpcCl := mockclient.NewMockTrillianLogClient(ctrl)
 			if tc.slr != nil || tc.slrErr != nil {
-				rpcCl.EXPECT().GetLatestSignedLogRoot(gomock.Any(), &trillian.GetLatestSignedLogRootRequest{LogId: 99}).Return(tc.slr, tc.slrErr)
+				rpcCl.EXPECT().GetLatestSignedLogRoot(gomock.Any(), cmpMatcher{&trillian.GetLatestSignedLogRootRequest{LogId: 99}}).Return(tc.slr, tc.slrErr)
 			}
 
 			sthg := MirrorSTHGetter{li: &logInfo{rpcClient: rpcCl, logID: 99}, st: tc.ms}


### PR DESCRIPTION
The gomock framework uses reflect.DeepEqual by default unless the
test passes an object that implements gomock.Matcher.
Use of reflect.DeepEqual on protocol buffer messages is problematic
because generated messages contain unexported fields, mutexes,
and other internal data structures that reflect.DeepEqual does not
know how to handle. Fix the tests by defining a custom gomock.Matcher
to properly compare the inputs.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
