### PR TITLE
Add an HTTP handler to get a leaf index by hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 Not yet released; provisionally v1.1.1 (may change).
 
+### CTFE
+
+An experimental http handler has been added `x-get-index-by-hash`. This allows
+a leaf index to be looked up from its hash. It avoids the overhead of obtaining
+a proof if only the index is required. This is not an RFC 6962 required
+feature but has been useful in cases like implementing the experimental CT
+over DNS protocol.
+
 ## v1.1.0
 
 Published 2019-11-14 15:00:00 +0000 UTC

--- a/trillian/ctfe/handlers.go
+++ b/trillian/ctfe/handlers.go
@@ -905,7 +905,7 @@ func getIndexByHash(ctx context.Context, li *logInfo, w http.ResponseWriter, r *
 
 	logReq := &trillian.GetLeavesByHashRequest{
 		LogId:    li.logID,
-		ChargeTo:  li.chargeUser(r),
+		ChargeTo: li.chargeUser(r),
 		LeafHash: [][]byte{leafHash},
 	}
 	resp, err := li.rpcClient.GetLeavesByHash(ctx, logReq)

--- a/trillian/ctfe/handlers_test.go
+++ b/trillian/ctfe/handlers_test.go
@@ -2255,10 +2255,10 @@ func TestGetIndexByHash(t *testing.T) {
 			want: http.StatusBadRequest,
 		},
 		{
-			desc: "backend error",
-			req:  "bGVhZgo=",
+			desc:   "backend error",
+			req:    "bGVhZgo=",
 			rpcErr: status.Error(codes.PermissionDenied, "should be 403"),
-			want: http.StatusForbidden,
+			want:   http.StatusForbidden,
 		},
 		{
 			desc: "nothing found",
@@ -2286,7 +2286,7 @@ func TestGetIndexByHash(t *testing.T) {
 				Leaves: []*trillian.LogLeaf{{LeafIndex: 236}},
 			},
 			wantQuotaUser: "user",
-			want: http.StatusOK,
+			want:          http.StatusOK,
 			wantRsp: &ct.GetIndexByHashResponse{
 				LeafIndex: 236,
 			},
@@ -2309,8 +2309,8 @@ func TestGetIndexByHash(t *testing.T) {
 			if test.rpcRsp != nil || test.rpcErr != nil {
 				// Don't fail on decode here because we want the test to reach the parsing
 				// code in the handler.
-				decoded, _ := base64.StdEncoding.DecodeString(test.req);
-				req := &trillian.GetLeavesByHashRequest{LogId: 0x42, LeafHash:[][]byte{decoded}}
+				decoded, _ := base64.StdEncoding.DecodeString(test.req)
+				req := &trillian.GetLeavesByHashRequest{LogId: 0x42, LeafHash: [][]byte{decoded}}
 				if len(test.wantQuotaUser) > 0 {
 					req.ChargeTo = &trillian.ChargeTo{User: []string{test.wantQuotaUser}}
 				}
@@ -2337,7 +2337,7 @@ func TestGetIndexByHash(t *testing.T) {
 				t.Errorf("Failed to unmarshal json response %s: %v", w.Body.Bytes(), err)
 				return
 			}
-			// The result we expect after a roundtrip in the successful get entry and proof test
+			// The result we expect after a roundtrip in the successful test.
 			if diff := pretty.Compare(&resp, test.wantRsp); diff != "" {
 				t.Errorf("getIndexByHash(%q) diff:\n%v", test.req, diff)
 			}

--- a/types.go
+++ b/types.go
@@ -441,7 +441,7 @@ const (
 	GetRootsPath          = "/ct/v1/get-roots"
 	GetEntryAndProofPath  = "/ct/v1/get-entry-and-proof"
 	GetIndexByHashPath    = "/ct/v1/x-get-index-by-hash" // Experimental addition.
-	AddJSONPath           = "/ct/v1/add-json" // Experimental addition.
+	AddJSONPath           = "/ct/v1/add-json"            // Experimental addition.
 )
 
 // AddChainRequest represents the JSON request body sent to the add-chain and
@@ -547,5 +547,5 @@ type GetEntryAndProofResponse struct {
 // GetIndexByHashResponse represents a JSON response to our experimental API
 // to look up a leaf sequence number. This is not currently part of RFC 6962.
 type GetIndexByHashResponse struct {
-	LeafIndex int64    `json:"leaf_index"` // The 0-based index of the end entity corresponding to the "hash" parameter.
+	LeafIndex int64 `json:"leaf_index"` // The 0-based index of the end entity corresponding to the "hash" parameter.
 }

--- a/types.go
+++ b/types.go
@@ -440,8 +440,8 @@ const (
 	GetSTHConsistencyPath = "/ct/v1/get-sth-consistency"
 	GetRootsPath          = "/ct/v1/get-roots"
 	GetEntryAndProofPath  = "/ct/v1/get-entry-and-proof"
-
-	AddJSONPath = "/ct/v1/add-json" // Experimental addition
+	GetIndexByHashPath    = "/ct/v1/x-get-index-by-hash" // Experimental addition.
+	AddJSONPath           = "/ct/v1/add-json" // Experimental addition.
 )
 
 // AddChainRequest represents the JSON request body sent to the add-chain and
@@ -542,4 +542,10 @@ type GetEntryAndProofResponse struct {
 	LeafInput []byte   `json:"leaf_input"` // the entry itself
 	ExtraData []byte   `json:"extra_data"` // any chain provided when the entry was added to the log
 	AuditPath [][]byte `json:"audit_path"` // the corresponding proof
+}
+
+// GetIndexByHashResponse represents a JSON response to our experimental API
+// to look up a leaf sequence number. This is not currently part of RFC 6962.
+type GetIndexByHashResponse struct {
+	LeafIndex int64    `json:"leaf_index"` // The 0-based index of the end entity corresponding to the "hash" parameter.
 }


### PR DESCRIPTION
This allows a leaf index to be looked up from its hash. It avoids the overhead of obtaining a proof if only the index is required. This is not an RFC 6962 required feature but has been useful in cases like implementing the experimental CT over DNS protocol.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [X] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
