### PR TITLE
jsonclient: log client URI when logging errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 Not yet released; provisionally v1.1.1 (may change).
 
+### JSONClient
+
+- `PostAndParseWithRetry` error logging now includes log URI in messages.
+
 ## v1.1.0
 
 Published 2019-11-14 15:00:00 +0000 UTC

--- a/jsonclient/client.go
+++ b/jsonclient/client.go
@@ -286,14 +286,14 @@ func (c *JSONClient) PostAndParseWithRetry(ctx context.Context, path string, req
 				return nil, nil, err
 			}
 			wait := c.backoff.set(nil)
-			c.logger.Printf("Request failed, backing-off on %s for %s: %s", c.uri, wait, err)
+			c.logger.Printf("Request to %s failed, backing-off %s: %s", c.uri, wait, err)
 		} else {
 			switch {
 			case httpRsp.StatusCode == http.StatusOK:
 				return httpRsp, body, nil
 			case httpRsp.StatusCode == http.StatusRequestTimeout:
 				// Request timeout, retry immediately
-				c.logger.Printf("Request timed out, retrying immediately")
+				c.logger.Printf("Request to %s timed out, retrying immediately", c.uri)
 			case httpRsp.StatusCode == http.StatusServiceUnavailable:
 				var backoff *time.Duration
 				// Retry-After may be either a number of seconds as a int or a RFC 1123
@@ -308,7 +308,7 @@ func (c *JSONClient) PostAndParseWithRetry(ctx context.Context, path string, req
 					}
 				}
 				wait := c.backoff.set(backoff)
-				c.logger.Printf("Request failed, backing-off for %s: got HTTP status %s", wait, httpRsp.Status)
+				c.logger.Printf("Request to %s failed, backing-off for %s: got HTTP status %s", c.uri, wait, httpRsp.Status)
 			default:
 				return nil, nil, RspError{
 					StatusCode: httpRsp.StatusCode,


### PR DESCRIPTION
When dependent software manages submission to several logs by creating multiple `LogClient` instances the error messages logged by the underlying `JSONClient` need to identify the `URI` at fault or they don't have enough context to stand-alone. E.g. If a `LogClient` fails an initial submission to a log but will retry after a period a line like the following is logged:

```
Request failed, backing-off for 8.032332341s: got HTTP status 503 Service Temporarily Unavailable
```

Without more context it's difficult to determine _which_ log returned a 503 prompting a backed-off retry.

Prior to this PR `JSONClient.PostAndParseWithRetry` logged the underlying URI in one error logging site but not two others, including the bad status code case shared above. This PR adds the URI to the other two sites and adjusts the wording of the existing site to be consistent.

### Checklist

- [X] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [X] I have updated [documentation](docs/) accordingly.
