### PR TITLE
Change the default of --by_range to true.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 Not yet released; provisionally v1.2.0 (may change).
 
+### CTFE
+
+#### Flags
+
+The `ct_server` binary changed the default of these flags:
+
+-   `by_range` - Now defaults to `true`
+
 ### Libraries
 
 #### x509 fork

--- a/trillian/ctfe/handlers.go
+++ b/trillian/ctfe/handlers.go
@@ -46,7 +46,7 @@ import (
 )
 
 // TODO(drysdale): remove this flag once everything has migrated to ByRange
-var getByRange = flag.Bool("by_range", false, "Use trillian.GetEntriesByRange for get-entries processing")
+var getByRange = flag.Bool("by_range", true, "Use trillian.GetEntriesByRange for get-entries processing")
 
 const (
 	// HTTP content type header


### PR DESCRIPTION
`GetLeavesByRange` has been proven to be much more efficient than `GetLeavesByIndex`, and had a long-standing TODO for removing it. As a first step, we change the default of the flag to match the future behaviour, so existing users specifying will not cause errors due to an "unknown flag" being specified.