### PR TITLE
Set golangci-lint --exclude-use-default=false

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -31,3 +31,7 @@ linters:
     - varcheck
     # TODO(gbelvin): write license linter and commit to upstream.
     # ./scripts/check_license.sh is run by ./scripts/presubmit.sh
+
+issues:
+    # Don't turn off any checks by default. We can do this explicitly if needed.
+    exclude-use-default: false


### PR DESCRIPTION
This enables some checks that golangci-lint disables by default, such as checking for package comments. If it turns out that any of these checks are too noisy, we can re-enable them. However, right now, it's causing lint checks to fail when we try to import our code into Google (where these checks are not disabled).

See https://github.com/golangci/golangci-lint/blob/v1.21.0/README.md#command-line-options

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
