### PR TITLE
If realip is determined to be empty string, return clearer sentinel

### DIFF
--- a/trillian/ctfe/ct_server/main.go
+++ b/trillian/ctfe/ct_server/main.go
@@ -280,7 +280,7 @@ func setupAndRegister(ctx context.Context, client trillian.TrillianLogClient, de
 		glog.Info("Enabling quota for requesting IP")
 		opts.RemoteQuotaUser = func(r *http.Request) string {
 			var remoteUser = realip.FromRequest(r)
-			if remoteUser == "" {
+			if len(remoteUser) == 0 {
 				return unknownRemoteUser
 			}
 			return remoteUser


### PR DESCRIPTION
Empty string is a very unclear way of showing the address wasn't found. This should be a safe change, the only potential risk is that during rollout of this version compared to the previous version, any requests that previously were mapping to emptry string and were being limited will now get mapped to an empty bucket and get access to a one-time freebie.
