### PR TITLE
Update CT integration tests to avoid using a deprecated constructor

### DIFF
--- a/trillian/integration/ct_integration_test.go
+++ b/trillian/integration/ct_integration_test.go
@@ -145,7 +145,7 @@ func TestInProcessCTIntegration(t *testing.T) {
 		},
 	}
 
-	env, err := NewCTLogEnv(ctx, cfgs, 2, "TestInProcessCTIntegration")
+	env, err := NewCTLogEnv(ctx, cfgs, 2)
 	if err != nil {
 		t.Fatalf("Failed to launch test environment: %v", err)
 	}


### PR DESCRIPTION
It will be removed from the trillian repo. The extra parameter has never done anything useful.

Also improve error handling in test setup.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
