### PR TITLE
Use installer for golangci-lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,8 @@ install:
       unzip protoc-3.5.1-${TRAVIS_OS_NAME}-x86_64.zip
     )
   - export PATH=$(pwd)/../protoc/bin:$PATH
+  - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.21.0
   - GOPROXY=direct go install
-     github.com/golangci/golangci-lint/cmd/golangci-lint
      github.com/golang/protobuf/proto
      github.com/golang/protobuf/protoc-gen-go
      github.com/golang/mock/mockgen

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20191027212112-611e8accdfc9 // indirect
 	github.com/golang/mock v1.3.1
 	github.com/golang/protobuf v1.3.2
-	github.com/golangci/golangci-lint v1.21.0
+	github.com/golangci/golangci-lint v1.21.0 // indirect
 	github.com/google/go-cmp v0.3.1
 	github.com/google/monologue v0.0.0-20191105172128-0324c8b45f6f
 	github.com/google/trillian v1.3.3

--- a/tools.go
+++ b/tools.go
@@ -20,7 +20,6 @@ import (
 	_ "github.com/golang/mock/mockgen"
 	_ "github.com/golang/protobuf/proto"
 	_ "github.com/golang/protobuf/protoc-gen-go"
-	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
 	_ "github.com/google/monologue/incident"
 	_ "go.etcd.io/etcd"
 	_ "go.etcd.io/etcd/etcdctl"


### PR DESCRIPTION
Fixes #629

Golangci-lint specifically cautions against installing with go get -u: https://github.com/golangci/golangci-lint#go

### Checklist

- [x] I have updated [documentation](docs/) accordingly.