### PR TITLE
x509: fix OS X compile error

### DIFF
--- a/x509/root_cgo_darwin.go
+++ b/x509/root_cgo_darwin.go
@@ -284,14 +284,11 @@ import (
 )
 
 func loadSystemRoots() (*CertPool, error) {
-	roots := NewCertPool()
-
 	var data, untrustedData C.CFDataRef
 	err := C.CopyPEMRootsCTX509(&data, &untrustedData, C.bool(debugDarwinRoots))
 	if err == -1 {
 		return nil, errors.New("crypto/x509: failed to load darwin system roots with cgo")
 	}
-
 	defer C.CFRelease(C.CFTypeRef(data))
 	defer C.CFRelease(C.CFTypeRef(untrustedData))
 


### PR DESCRIPTION
Error message:
x509/root_cgo_darwin.go:299:8: no new variables on left side of :=

Looks to have come from a mis-merge in commit 5c2e9d394581
("x509: merge upstream Go 1.13 changes (#604)").
