### PR TITLE
Fix locking in submission/distributor.go

### DIFF
--- a/submission/distributor.go
+++ b/submission/distributor.go
@@ -169,13 +169,6 @@ func (d *Distributor) RefreshRoots(ctx context.Context) map[string]error {
 	return errors
 }
 
-// IsRootDataFull returns true if root certificates have been obtained for all Logs.
-func (d *Distributor) isRootDataFull() bool {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-	return d.rootDataFull
-}
-
 // incRspsCounter extracts HTTP status code and increments corresponding rspsCounter.
 func incRspsCounter(logURL string, endpoint string, rspErr error) {
 	status := http.StatusOK


### PR DESCRIPTION
- Fixed case of missing unlock by enclosing in a helper function with a defer unlock to remove future error patterns.
- Removed double RLock of mutex by using "rootDataFull" directly instead of the external API.

### Checklist

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
