### PR TITLE
Add Cache-Control header to some CTFE responses

### DIFF
--- a/trillian/ctfe/handlers.go
+++ b/trillian/ctfe/handlers.go
@@ -49,6 +49,10 @@ import (
 var getByRange = flag.Bool("by_range", true, "Use trillian.GetEntriesByRange for get-entries processing")
 
 const (
+	// HTTP Cache-Control header
+	cacheControlHeader = "Cache-Control"
+	// Value for Cache-Control header when response contains immutable data, i.e. entries or proofs. Allows the response to be cached for 1 day.
+	cacheControlImmutable = "public, max-age=86400"
 	// HTTP content type header
 	contentTypeHeader string = "Content-Type"
 	// MIME content type for JSON
@@ -612,6 +616,7 @@ func getSTHConsistency(ctx context.Context, li *logInfo, w http.ResponseWriter, 
 		jsonRsp.Consistency = emptyProof
 	}
 
+	w.Header().Set(cacheControlHeader, cacheControlImmutable)
 	w.Header().Set(contentTypeHeader, contentTypeJSON)
 	jsonData, err := json.Marshal(&jsonRsp)
 	if err != nil {
@@ -690,6 +695,7 @@ func getProofByHash(ctx context.Context, li *logInfo, w http.ResponseWriter, r *
 		proofRsp.AuditPath = emptyProof
 	}
 
+	w.Header().Set(cacheControlHeader, cacheControlImmutable)
 	w.Header().Set(contentTypeHeader, contentTypeJSON)
 	jsonData, err := json.Marshal(&proofRsp)
 	if err != nil {
@@ -791,6 +797,7 @@ func getEntries(ctx context.Context, li *logInfo, w http.ResponseWriter, r *http
 		return http.StatusInternalServerError, fmt.Errorf("failed to process leaves returned from backend: %s", err)
 	}
 
+	w.Header().Set(cacheControlHeader, cacheControlImmutable)
 	w.Header().Set(contentTypeHeader, contentTypeJSON)
 	jsonData, err := json.Marshal(&jsonRsp)
 	if err != nil {
@@ -872,6 +879,7 @@ func getEntryAndProof(ctx context.Context, li *logInfo, w http.ResponseWriter, r
 		AuditPath: rsp.Proof.Hashes,
 	}
 
+	w.Header().Set(cacheControlHeader, cacheControlImmutable)
 	w.Header().Set(contentTypeHeader, contentTypeJSON)
 	jsonData, err := json.Marshal(&jsonRsp)
 	if err != nil {

--- a/trillian/ctfe/handlers_test.go
+++ b/trillian/ctfe/handlers_test.go
@@ -1071,6 +1071,9 @@ func runTestGetEntries(t *testing.T) {
 		if test.want != http.StatusOK {
 			continue
 		}
+		if got, want := w.Header().Get("Cache-Control"), "public"; !strings.Contains(got, want) {
+			t.Errorf("GetEntries(%q): Cache-Control response header = %q, want %q", test.req, got, want)
+		}
 		// Leaf data should be passed through as-is even if invalid.
 		var jsonMap map[string][]ct.LeafEntry
 		if err := json.Unmarshal(w.Body.Bytes(), &jsonMap); err != nil {
@@ -1536,6 +1539,9 @@ func TestGetProofByHash(t *testing.T) {
 		if test.want != http.StatusOK {
 			continue
 		}
+		if got, want := w.Header().Get("Cache-Control"), "public"; !strings.Contains(got, want) {
+			t.Errorf("proofByHash(%q): Cache-Control response header = %q, want %q", test.req, got, want)
+		}
 		jsonData, err := ioutil.ReadAll(w.Body)
 		if err != nil {
 			t.Errorf("failed to read response body: %v", err)
@@ -1889,6 +1895,9 @@ func TestGetSTHConsistency(t *testing.T) {
 		if test.want != http.StatusOK {
 			continue
 		}
+		if got, want := w.Header().Get("Cache-Control"), "public"; !strings.Contains(got, want) {
+			t.Errorf("getSTHConsistency(%q): Cache-Control response header = %q, want %q", test.req, got, want)
+		}
 		jsonData, err := ioutil.ReadAll(w.Body)
 		if err != nil {
 			t.Errorf("failed to read response body: %v", err)
@@ -2217,6 +2226,10 @@ func TestGetEntryAndProof(t *testing.T) {
 		}
 		if test.want != http.StatusOK {
 			continue
+		}
+
+		if got, want := w.Header().Get("Cache-Control"), "public"; !strings.Contains(got, want) {
+			t.Errorf("getEntryAndProof(%q): Cache-Control response header = %q, want %q", test.req, got, want)
 		}
 
 		var resp ct.GetEntryAndProofResponse


### PR DESCRIPTION
Responses containing entries or proofs can be cached, because they should never change.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
