### PR TITLE
Attempt to coerce get-entries ranges into alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,11 +43,17 @@ Client B --|-X---------|---------|-------...
              `-- Requests truncated
 </pre>
 
+This behaviour can be disabled by setting the `--disable_align_getentries`
+flag to true.
+
 #### Flags
 
 The `ct_server` binary changed the default of these flags:
 
 -   `by_range` - Now defaults to `true`
+
+The `ct_server` binary added the following flags:
+-   `disable_align_getentries` - See GetEntries section above for details
 
 ### Libraries
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,8 @@ Client B --|-X---------|---------|-------...
              `-- Requests truncated
 </pre>
 
-This behaviour can be disabled by setting the `--disable_align_getentries`
-flag to true.
+This behaviour can be disabled by setting the `--align_getentries`
+flag to false.
 
 #### Flags
 
@@ -53,7 +53,7 @@ The `ct_server` binary changed the default of these flags:
 -   `by_range` - Now defaults to `true`
 
 The `ct_server` binary added the following flags:
--   `disable_align_getentries` - See GetEntries section above for details
+-   `align_getentries` - See GetEntries section above for details
 
 ### Libraries
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,37 @@ The CTFE now includes a Cache-Control header in responses containing purely
 immutable data, e.g. those for get-entries and get-proof-by-hash. This allows
 clients and proxies to cache these responses for up to 24 hours.
 
+#### GetEntries
+Calls to `get-entries` which are at (or above) the maximum permitted number of
+entries whose `start` parameter does not fall on a multiple of the maximum
+permitted number of entries, will have their responses truncated such that
+subsequent requests will align with this boundary.
+This is intended to coerce callers of `get-entries` into all using the same
+`start` and `end` parameters and thereby increase the cachability of
+these requests.
+
+e.g.:
+
+<pre>
+Old behaviour:
+             1         2         3
+             0         0         0
+Entries>-----|---------|---------|----...
+Client A -------|---------|----------|...
+Client B --|--------|---------|-------...
+           ^        ^         ^
+           `--------`---------`---- requests
+
+With coercion (max batch = 10 entries):
+             1         2         3
+             0         0         0
+Entries>-----|---------|---------|----...
+Client A ----X---------|---------|...
+Client B --|-X---------|---------|-------...
+             ^
+             `-- Requests truncated
+</pre>
+
 #### Flags
 
 The `ct_server` binary changed the default of these flags:

--- a/trillian/ctfe/handlers.go
+++ b/trillian/ctfe/handlers.go
@@ -722,7 +722,7 @@ func getEntries(ctx context.Context, li *logInfo, w http.ResponseWriter, r *http
 	// The first job is to parse the params and make sure they're sensible. We just make
 	// sure the range is valid. We don't do an extra roundtrip to get the current tree
 	// size and prefer to let the backend handle this case
-	start, end, err := parseGetEntriesRange(r, MaxGetEntriesAllowed, strconv.FormatInt(li.logID, 10))
+	start, end, err := parseGetEntriesRange(r, MaxGetEntriesAllowed, li.logID)
 	if err != nil {
 		return http.StatusBadRequest, fmt.Errorf("bad range on get-entries request: %s", err)
 	}
@@ -986,7 +986,7 @@ func marshalAndWriteAddChainResponse(sct *ct.SignedCertificateTimestamp, signer 
 	return nil
 }
 
-func parseGetEntriesRange(r *http.Request, maxRange int64, logIDLabel string) (int64, int64, error) {
+func parseGetEntriesRange(r *http.Request, maxRange, logID int64) (int64, int64, error) {
 	start, err := strconv.ParseInt(r.FormValue(getEntriesParamStart), 10, 64)
 	if err != nil {
 		return 0, 0, err
@@ -1015,7 +1015,7 @@ func parseGetEntriesRange(r *http.Request, maxRange int64, logIDLabel string) (i
 			// thereby making the responses more readily cachable.
 			d := (end + 1) % maxRange
 			end = end - d
-			alignedGetEntries.Inc(logIDLabel, strconv.FormatBool(d == 0))
+			alignedGetEntries.Inc(strconv.FormatInt(logID, 10), strconv.FormatBool(d == 0))
 		}
 	}
 

--- a/trillian/ctfe/handlers.go
+++ b/trillian/ctfe/handlers.go
@@ -47,8 +47,8 @@ import (
 
 var (
 	// TODO(drysdale): remove this flag once everything has migrated to ByRange
-	getByRange             = flag.Bool("by_range", true, "Use trillian.GetEntriesByRange for get-entries processing")
-	disableAlignGetEntries = flag.Bool("disable_align_getentries", false, "Disable get-entries request alignment")
+	getByRange      = flag.Bool("by_range", true, "Use trillian.GetEntriesByRange for get-entries processing")
+	alignGetEntries = flag.Bool("align_getentries", true, "Enable get-entries request alignment")
 )
 
 const (
@@ -1007,7 +1007,7 @@ func parseGetEntriesRange(r *http.Request, maxRange int64, logIDLabel string) (i
 	count := end - start + 1
 	if count > maxRange {
 		end = start + maxRange - 1
-		if !*disableAlignGetEntries {
+		if *alignGetEntries {
 			// Truncate a "maximally sized" get-entries request at the next multiple
 			// of MaxGetEntriesAllowed.
 			// This is intended to coerce large runs of get-entries requests (e.g. by

--- a/trillian/ctfe/handlers.go
+++ b/trillian/ctfe/handlers.go
@@ -1007,16 +1007,16 @@ func parseGetEntriesRange(r *http.Request, maxRange, logID int64) (int64, int64,
 	count := end - start + 1
 	if count > maxRange {
 		end = start + maxRange - 1
-		if *alignGetEntries {
-			// Truncate a "maximally sized" get-entries request at the next multiple
-			// of MaxGetEntriesAllowed.
-			// This is intended to coerce large runs of get-entries requests (e.g. by
-			// monitors/mirrors) into all requesting the same start/end ranges,
-			// thereby making the responses more readily cachable.
-			d := (end + 1) % maxRange
-			end = end - d
-			alignedGetEntries.Inc(strconv.FormatInt(logID, 10), strconv.FormatBool(d == 0))
-		}
+	}
+	if *alignGetEntries && count >= maxRange {
+		// Truncate a "maximally sized" get-entries request at the next multiple
+		// of MaxGetEntriesAllowed.
+		// This is intended to coerce large runs of get-entries requests (e.g. by
+		// monitors/mirrors) into all requesting the same start/end ranges,
+		// thereby making the responses more readily cachable.
+		d := (end + 1) % maxRange
+		end = end - d
+		alignedGetEntries.Inc(strconv.FormatInt(logID, 10), strconv.FormatBool(d == 0))
 	}
 
 	return start, end, nil

--- a/trillian/ctfe/handlers.go
+++ b/trillian/ctfe/handlers.go
@@ -45,8 +45,8 @@ import (
 	ct "github.com/google/certificate-transparency-go"
 )
 
-// TODO(drysdale): remove this flag once everything has migrated to ByRange
 var (
+	// TODO(drysdale): remove this flag once everything has migrated to ByRange
 	getByRange             = flag.Bool("by_range", true, "Use trillian.GetEntriesByRange for get-entries processing")
 	disableAlignGetEntries = flag.Bool("disable_align_getentries", false, "Disable get-entries request alignment")
 )

--- a/trillian/ctfe/handlers_test.go
+++ b/trillian/ctfe/handlers_test.go
@@ -1179,6 +1179,14 @@ func runTestGetEntriesRanges(t *testing.T) {
 			rpcEnd: MaxGetEntriesAllowed + MaxGetEntriesAllowed - 1,
 			rpc:    true,
 		},
+		{
+			desc:   "small range straddling boundary, not coerced",
+			start:  MaxGetEntriesAllowed - 2,
+			end:    MaxGetEntriesAllowed + 2,
+			want:   http.StatusInternalServerError,
+			rpcEnd: MaxGetEntriesAllowed + 2,
+			rpc:    true,
+		},
 	}
 
 	// This tests that only valid ranges make it to the backend for get-entries.

--- a/trillian/ctfe/handlers_test.go
+++ b/trillian/ctfe/handlers_test.go
@@ -1164,11 +1164,19 @@ func runTestGetEntriesRanges(t *testing.T) {
 			want:  http.StatusBadRequest,
 		},
 		{
-			desc:   "range too large, truncated",
-			start:  1000,
+			desc:   "range too large, coerced into alignment",
+			start:  14,
 			end:    50000,
-			rpcEnd: 1000 + MaxGetEntriesAllowed - 1,
 			want:   http.StatusInternalServerError,
+			rpcEnd: MaxGetEntriesAllowed - 1,
+			rpc:    true,
+		},
+		{
+			desc:   "range too large, already in alignment",
+			start:  MaxGetEntriesAllowed,
+			end:    5000,
+			want:   http.StatusInternalServerError,
+			rpcEnd: MaxGetEntriesAllowed + MaxGetEntriesAllowed - 1,
 			rpc:    true,
 		},
 	}


### PR DESCRIPTION
This PR attempts to truncate incoming `get-entries` requests into order to coerce these requests into alignment on multiples of the maximum permitted block size.  This should result in subsequent requests/responses being more cache friendly.

### Checklist

- [X] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
