### PR TITLE
Add a VerifySCT method taking a SignatureVerifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,10 @@ The `ct_server` binary added the following flags:
 
 Merged upstream Go 1.13 changes.
 
+#### ctutil
+
+Added VerifySCTWithVerifier() to verify SCTs using a given ct.SignatureVerifier.
+
 ### Configuration Files
 
 Configuration files that previously had to be text-encoded Protobuf messages can

--- a/ctutil/ctutil.go
+++ b/ctutil/ctutil.go
@@ -122,6 +122,46 @@ func VerifySCT(pubKey crypto.PublicKey, chain []*x509.Certificate, sct *ct.Signe
 	return s.VerifySCTSignature(*sct, entry)
 }
 
+// VerifySCTWithVerifier takes a ct.SignatureVerifier, a certificate chain, and
+// an SCT and verifies whether the SCT is a valid SCT for the certificate at
+// chain[0], signed by the Log whose public key was used to set up the
+// ct.SignatureVerifier.  If the SCT does not verify, an error will be returned.
+//
+// This function can be used with three different types of leaf certificate:
+//   - X.509 Certificate:
+//       If using this function to verify an SCT for a normal X.509 certificate
+//       then it is enough to just provide the end entity certificate in chain.
+//       This case assumes that the SCT being provided is not embedded within
+//       the leaf certificate provided, i.e. the certificate is what was
+//       submitted to the Certificate Transparency Log in order to obtain the
+//       SCT.  For this case, set embedded to false.
+//   - Precertificate:
+//       If using this function to verify an SCT for a precertificate then the
+//       issuing certificate must also be provided in chain.  The precertificate
+//       should be at chain[0], and its issuer at chain[1].  For this case, set
+//       embedded to false.
+//   - X.509 Certificate containing the SCT embedded within it:
+//       If the SCT you wish to verify is embedded within the certificate you
+//       are providing at chain[0], set embedded to true.  VerifySCT will
+//       verify the provided SCT by building the corresponding precertificate.
+//       VerifySCT will return an error if the provided SCT cannot be found
+//       embedded within chain[0].  As with the precertificate case, the issuing
+//       certificate must also be provided in chain.  The certificate containing
+//       the embedded SCT should be at chain[0], and its issuer at chain[1].
+func VerifySCTWithVerifier(sv *ct.SignatureVerifier, chain []*x509.Certificate, sct *ct.SignedCertificateTimestamp, embedded bool) error {
+	if sv == nil {
+		return errors.New("ct.SignatureVerifier is nil")
+	}
+
+	leaf, err := createLeaf(chain, sct, embedded)
+	if err != nil {
+		return err
+	}
+
+	entry := ct.LogEntry{Leaf: *leaf}
+	return sv.VerifySCTSignature(*sct, entry)
+}
+
 func createLeaf(chain []*x509.Certificate, sct *ct.SignedCertificateTimestamp, embedded bool) (*ct.MerkleTreeLeaf, error) {
 	if len(chain) == 0 {
 		return nil, errors.New("chain is empty")

--- a/ctutil/ctutil.go
+++ b/ctutil/ctutil.go
@@ -118,8 +118,7 @@ func VerifySCT(pubKey crypto.PublicKey, chain []*x509.Certificate, sct *ct.Signe
 		return fmt.Errorf("error creating signature verifier: %s", err)
 	}
 
-	entry := ct.LogEntry{Leaf: *leaf}
-	return s.VerifySCTSignature(*sct, entry)
+	return s.VerifySCTSignature(*sct, ct.LogEntry{Leaf: *leaf})
 }
 
 // VerifySCTWithVerifier takes a ct.SignatureVerifier, a certificate chain, and
@@ -158,8 +157,7 @@ func VerifySCTWithVerifier(sv *ct.SignatureVerifier, chain []*x509.Certificate, 
 		return err
 	}
 
-	entry := ct.LogEntry{Leaf: *leaf}
-	return sv.VerifySCTSignature(*sct, entry)
+	return sv.VerifySCTSignature(*sct, ct.LogEntry{Leaf: *leaf})
 }
 
 func createLeaf(chain []*x509.Certificate, sct *ct.SignedCertificateTimestamp, embedded bool) (*ct.MerkleTreeLeaf, error) {

--- a/ctutil/ctutil.go
+++ b/ctutil/ctutil.go
@@ -108,17 +108,12 @@ func LeafHash(chain []*x509.Certificate, sct *ct.SignedCertificateTimestamp, emb
 //       certificate must also be provided in chain.  The certificate containing
 //       the embedded SCT should be at chain[0], and its issuer at chain[1].
 func VerifySCT(pubKey crypto.PublicKey, chain []*x509.Certificate, sct *ct.SignedCertificateTimestamp, embedded bool) error {
-	leaf, err := createLeaf(chain, sct, embedded)
-	if err != nil {
-		return err
-	}
-
 	s, err := ct.NewSignatureVerifier(pubKey)
 	if err != nil {
 		return fmt.Errorf("error creating signature verifier: %s", err)
 	}
 
-	return s.VerifySCTSignature(*sct, ct.LogEntry{Leaf: *leaf})
+	return VerifySCTWithVerifier(s, chain, sct, embedded)
 }
 
 // VerifySCTWithVerifier takes a ct.SignatureVerifier, a certificate chain, and


### PR DESCRIPTION
Adding for use by tools that have already created a ct.SignatureVerifier for verifying all sorts of signatures, and would prefer to use that rather than have a new one spun up every time they want to verify an SCT.

### Checklist

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
