### PR TITLE
Tighten up ratelimiter test

### DIFF
--- a/fixchain/ratelimiter/limiter_test.go
+++ b/fixchain/ratelimiter/limiter_test.go
@@ -16,59 +16,54 @@ package ratelimiter
 
 import (
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 )
 
 var testlimits = []int{1, 10, 50, 100, 1000}
 
-func checkTicker(t *testing.T, tick *time.Ticker, count *int64, i, limit int) {
-	for range tick.C {
-		// Allow a count up to slightly more than the limit as scheduling of
-		// goroutine vs the main thread could cause this check to not be
-		// run quite in time for limit.
-		allowed := int(float64(limit)*1.05) + 1
-		v := atomic.LoadInt64(count)
-		if v > int64(allowed) {
-			t.Errorf("#%d: Too many operations per second. Expected ~%d, got %d", i, limit, v)
-		}
-		atomic.StoreInt64(count, 0)
-	}
-}
-
 func TestRateLimiterSingleThreaded(t *testing.T) {
 	for i, limit := range testlimits {
 		l := NewLimiter(limit)
-		count := int64(0)
-		tick := time.NewTicker(time.Second)
-		go checkTicker(t, tick, &count, i, limit)
 
-		for i := 0; i < 3*limit; i++ {
+		numOps := 3 * limit
+		start := time.Now()
+		// Need to call the limiter one extra time to ensure that the throughput
+		// calulation is correct (because e.g. at 1 qps you can do 3 calls in
+		// 2+epsilon seconds)
+		for i := 0; i < numOps+1; i++ {
 			l.Wait()
-			atomic.AddInt64(&count, 1)
 		}
-		tick.Stop()
+		ds := float64(time.Since(start) / time.Second)
+		qps := float64(numOps) / ds
+		if qps > float64(limit) {
+			t.Errorf("#%d: Too many operations per second. Expected ~%d, got %f", i, limit, qps)
+		}
 	}
 }
 
 func TestRateLimiterGoroutines(t *testing.T) {
 	for i, limit := range testlimits {
 		l := NewLimiter(limit)
-		count := int64(0)
-		tick := time.NewTicker(time.Second)
-		go checkTicker(t, tick, &count, i, limit)
 
+		numOps := 3 * limit
 		var wg sync.WaitGroup
-		for i := 0; i < 3*limit; i++ {
+		start := time.Now()
+		// Need to call the limiter one extra time to ensure that the throughput
+		// calulation is correct (because e.g. at 1 qps you can do 3 calls in
+		// 2+epsilon seconds)
+		for i := 0; i < numOps+1; i++ {
 			wg.Add(1)
 			go func() {
 				l.Wait()
-				atomic.AddInt64(&count, 1)
 				wg.Done()
 			}()
 		}
 		wg.Wait()
-		tick.Stop()
+		ds := float64(time.Since(start) / time.Second)
+		qps := float64(numOps) / ds
+		if qps > float64(limit) {
+			t.Errorf("#%d: Too many operations per second. Expected ~%d, got %f", i, limit, qps)
+		}
 	}
 }

--- a/fixchain/ratelimiter/limiter_test.go
+++ b/fixchain/ratelimiter/limiter_test.go
@@ -32,7 +32,7 @@ func TestRateLimiterSingleThreaded(t *testing.T) {
 			numOps := 3 * limit
 			start := time.Now()
 			// Need to call the limiter one extra time to ensure that the throughput
-			// calulation is correct (because e.g. at 1 qps you can do 3 calls in
+			// calculation is correct (because e.g. at 1 qps you can do 3 calls in
 			// 2+epsilon seconds)
 			for i := 0; i < numOps+1; i++ {
 				l.Wait()
@@ -56,7 +56,7 @@ func TestRateLimiterGoroutines(t *testing.T) {
 			var wg sync.WaitGroup
 			start := time.Now()
 			// Need to call the limiter one extra time to ensure that the throughput
-			// calulation is correct (because e.g. at 1 qps you can do 3 calls in
+			// calculation is correct (because e.g. at 1 qps you can do 3 calls in
 			// 2+epsilon seconds)
 			for i := 0; i < numOps+1; i++ {
 				wg.Add(1)


### PR DESCRIPTION
Makes the test less flakey - removes the fudge factor, and speeds up testing.

### Checklist


- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
