### PR TITLE
Allow Hammer to perform more consistency checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 Not yet released; provisionally v1.2.0 (may change).
 
+### Tools
+
+#### CT Hammer
+
+Added a flag (--strict_sth_consistency_sizes) which when set to true enforces the current behaviour of only request consistency proofs between tree sizes for which the hammer has seen valid STHs.
+When setting this flag to false, if no two usable STHs are available the hammer will attempt to request a consistency proof between the latest STH it's seen and a random smaller (but > 0) tree size.
+
+
 ### CTFE
 
 #### Caching

--- a/trillian/integration/ct_hammer/main.go
+++ b/trillian/integration/ct_hammer/main.go
@@ -79,16 +79,17 @@ var (
 	reqDeadline         = flag.Duration("req_deadline", 10*time.Second, "Deadline to set on individual requests")
 )
 var (
-	addChainBias          = flag.Int("add_chain", 20, "Bias for add-chain operations")
-	addPreChainBias       = flag.Int("add_pre_chain", 20, "Bias for add-pre-chain operations")
-	getSTHBias            = flag.Int("get_sth", 2, "Bias for get-sth operations")
-	getSTHConsistencyBias = flag.Int("get_sth_consistency", 2, "Bias for get-sth-consistency operations")
-	getProofByHashBias    = flag.Int("get_proof_by_hash", 2, "Bias for get-proof-by-hash operations")
-	getEntriesBias        = flag.Int("get_entries", 2, "Bias for get-entries operations")
-	getRootsBias          = flag.Int("get_roots", 1, "Bias for get-roots operations")
-	getEntryAndProofBias  = flag.Int("get_entry_and_proof", 0, "Bias for get-entry-and-proof operations")
-	invalidChance         = flag.Int("invalid_chance", 10, "Chance of generating an invalid operation, as the N in 1-in-N (0 for never)")
-	dupeChance            = flag.Int("duplicate_chance", 10, "Chance of generating a duplicate submission, as the N in 1-in-N (0 for never)")
+	addChainBias             = flag.Int("add_chain", 20, "Bias for add-chain operations")
+	addPreChainBias          = flag.Int("add_pre_chain", 20, "Bias for add-pre-chain operations")
+	getSTHBias               = flag.Int("get_sth", 2, "Bias for get-sth operations")
+	getSTHConsistencyBias    = flag.Int("get_sth_consistency", 2, "Bias for get-sth-consistency operations")
+	getProofByHashBias       = flag.Int("get_proof_by_hash", 2, "Bias for get-proof-by-hash operations")
+	getEntriesBias           = flag.Int("get_entries", 2, "Bias for get-entries operations")
+	getRootsBias             = flag.Int("get_roots", 1, "Bias for get-roots operations")
+	getEntryAndProofBias     = flag.Int("get_entry_and_proof", 0, "Bias for get-entry-and-proof operations")
+	invalidChance            = flag.Int("invalid_chance", 10, "Chance of generating an invalid operation, as the N in 1-in-N (0 for never)")
+	dupeChance               = flag.Int("duplicate_chance", 10, "Chance of generating a duplicate submission, as the N in 1-in-N (0 for never)")
+	strictSTHConsistencySize = flag.Bool("strict_sth_consistency_size", true, "If set to true, hammer will use only tree sizes from STHs it's seen for consistency proofs, otherwise it'll choose a random size for the smaller tree")
 )
 
 func newLimiter(rate int) integration.Limiter {
@@ -290,22 +291,23 @@ func main() {
 		}
 
 		cfg := integration.HammerConfig{
-			LogCfg:              c,
-			MetricFactory:       mf,
-			MMD:                 mmd,
-			ChainGenerator:      generator,
-			ClientPool:          pool,
-			EPBias:              bias,
-			MinGetEntries:       *minGetEntries,
-			MaxGetEntries:       *maxGetEntries,
-			OversizedGetEntries: *oversizedGetEntries,
-			Operations:          *operations,
-			Limiter:             newLimiter(*limit),
-			MaxParallelChains:   *maxParallelChains,
-			IgnoreErrors:        *ignoreErrors,
-			MaxRetryDuration:    *maxRetry,
-			RequestDeadline:     *reqDeadline,
-			DuplicateChance:     *dupeChance,
+			LogCfg:                   c,
+			MetricFactory:            mf,
+			MMD:                      mmd,
+			ChainGenerator:           generator,
+			ClientPool:               pool,
+			EPBias:                   bias,
+			MinGetEntries:            *minGetEntries,
+			MaxGetEntries:            *maxGetEntries,
+			OversizedGetEntries:      *oversizedGetEntries,
+			Operations:               *operations,
+			Limiter:                  newLimiter(*limit),
+			MaxParallelChains:        *maxParallelChains,
+			IgnoreErrors:             *ignoreErrors,
+			MaxRetryDuration:         *maxRetry,
+			RequestDeadline:          *reqDeadline,
+			DuplicateChance:          *dupeChance,
+			StrictSTHConsistencySize: *strictSTHConsistencySize,
 		}
 		go func(cfg integration.HammerConfig) {
 			defer wg.Done()

--- a/trillian/integration/hammer_test.go
+++ b/trillian/integration/hammer_test.go
@@ -426,6 +426,9 @@ func TestStrictSTHConsistencySize(t *testing.T) {
 				ClientPool:               RandomPool{lc},
 				LogCfg:                   &configpb.LogConfig{},
 			})
+			if err != nil {
+				t.Fatalf("Failed to create HammerState: %v", err)
+			}
 
 			err = hs.getSTHConsistency(ctx)
 			_, gotSkip := err.(errSkip)

--- a/trillian/integration/hammer_test.go
+++ b/trillian/integration/hammer_test.go
@@ -174,6 +174,9 @@ type fakeCTServer struct {
 	server *http.Server
 
 	addedCerts []*x509.Certificate
+	sthNow     ct.SignedTreeHead
+
+	getConsistencyCalled bool
 }
 
 func (s *fakeCTServer) addChain(w http.ResponseWriter, req *http.Request) {
@@ -232,6 +235,45 @@ func (s *fakeCTServer) serve() {
 	s.server.Serve(s.lis)
 }
 
+func (s *fakeCTServer) getSTH(w http.ResponseWriter, req *http.Request) {
+	resp := &ct.GetSTHResponse{
+		TreeSize:       s.sthNow.TreeSize,
+		Timestamp:      s.sthNow.Timestamp,
+		SHA256RootHash: []byte(s.sthNow.SHA256RootHash[:]),
+	}
+	var err error
+	resp.TreeHeadSignature, err = tls.Marshal(s.sthNow.TreeHeadSignature)
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	respBytes, err := json.Marshal(resp)
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(respBytes)
+}
+
+func (s *fakeCTServer) getConsistency(w http.ResponseWriter, req *http.Request) {
+	cp := &ct.GetSTHConsistencyResponse{
+		Consistency: [][]byte{[]byte("bogus")},
+	}
+	respBytes, err := json.Marshal(cp)
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(respBytes)
+
+	s.getConsistencyCalled = true
+}
+
 func writeErr(w http.ResponseWriter, status int, err error) {
 	w.WriteHeader(status)
 	io.WriteString(w, err.Error())
@@ -252,6 +294,8 @@ func newFakeCTServer(t *testing.T) (*fakeCTServer, *client.LogClient) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/ct/v1/add-chain", s.addChain)
 	mux.HandleFunc("/ct/v1/add-pre-chain", s.addChain)
+	mux.HandleFunc("/ct/v1/get-sth", s.getSTH)
+	mux.HandleFunc("/ct/v1/get-sth-consistency", s.getConsistency)
 
 	s.server = &http.Server{Handler: mux}
 	go s.serve()
@@ -356,5 +400,48 @@ func TestChooseCertToAdd(t *testing.T) {
 			}
 		})
 	}
+}
 
+func TestStrictSTHConsistencySize(t *testing.T) {
+	ctx := context.Background()
+
+	for _, test := range []struct {
+		name       string
+		strict     bool
+		sthNowSize uint64
+		wantSkip   bool
+	}{
+		{name: "strict", strict: true, wantSkip: true},
+		{name: "relaxed_too_small", sthNowSize: 1, wantSkip: true},
+		{name: "relaxed_invent_size", sthNowSize: 10, wantSkip: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			s, lc := newFakeCTServer(t)
+			defer s.close()
+
+			s.sthNow.TreeSize = test.sthNowSize
+
+			hs, err := newHammerState(&HammerConfig{
+				StrictSTHConsistencySize: test.strict,
+				ClientPool:               RandomPool{lc},
+				LogCfg:                   &configpb.LogConfig{},
+			})
+
+			err = hs.getSTHConsistency(ctx)
+			_, gotSkip := err.(errSkip)
+			if gotSkip != test.wantSkip {
+				t.Fatalf("got err %v, wanted Skip=%v", err, test.wantSkip)
+			}
+			if err != nil && !gotSkip {
+				t.Fatalf("got unexpected err %v", err)
+			}
+			if test.wantSkip {
+				return
+			}
+
+			if !s.getConsistencyCalled {
+				t.Fatal("hammer failed to request a consistency proof for invented tree size")
+			}
+		})
+	}
 }


### PR DESCRIPTION
This PR adds a flag (`--strict_sth_consistency_sizes`) which when set to true enforces the current behaviour of only request consistency proofs between tree sizes for which the hammer has seen valid STHs.

When setting this flag to false, if no two usable STHs are available the hammer will attempt to request a consistency proof between the latest STH it's seen and a random smaller (but > 0) tree size.

### Checklist

- [X] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
