### PR TITLE
Adding debug logs

### DIFF
--- a/submission/distributor.go
+++ b/submission/distributor.go
@@ -191,10 +191,10 @@ func incErrCounter(logURL string, endpoint string, rspErr error) {
 	err, ok := rspErr.(client.RspError)
 	switch {
 	case !ok:
-		glog.Errorf("unknown_error (%s, %s) => %v", logURL, endpoint, err)
+		glog.Errorf("unknown_error (%s, %s) => %v", logURL, endpoint, rspErr)
 		errCounter.Inc(logURL, endpoint, "unknown_error")
 	case err.Err != nil && err.StatusCode == http.StatusOK:
-		glog.Errorf("Invalid_sct (%s, %s) => HTTP details: status=%d, body:\n%s", logURL, endpoint, err.StatusCode, err.Body)
+		glog.Errorf("invalid_sct (%s, %s) => HTTP details: status=%d, body:\n%s", logURL, endpoint, err.StatusCode, err.Body)
 		errCounter.Inc(logURL, endpoint, "invalid_sct")
 	case err.Err != nil: // err.StatusCode != http.StatusOK.
 		glog.Errorf("connection_error (%s, %s) => HTTP details: status=%d, body:\n%s", logURL, endpoint, err.StatusCode, err.Body)

--- a/submission/distributor.go
+++ b/submission/distributor.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/golang/glog"
 	"github.com/google/certificate-transparency-go/client"
 	"github.com/google/certificate-transparency-go/ctpolicy"
 	"github.com/google/certificate-transparency-go/jsonclient"
@@ -190,10 +191,13 @@ func incErrCounter(logURL string, endpoint string, rspErr error) {
 	err, ok := rspErr.(client.RspError)
 	switch {
 	case !ok:
+		glog.Errorf("unknown_error (%s, %s) => %v", logURL, endpoint, err)
 		errCounter.Inc(logURL, endpoint, "unknown_error")
 	case err.Err != nil && err.StatusCode == http.StatusOK:
+		glog.Errorf("Invalid_sct (%s, %s) => HTTP details: status=%d, body:\n%s", logURL, endpoint, err.StatusCode, err.Body)
 		errCounter.Inc(logURL, endpoint, "invalid_sct")
 	case err.Err != nil: // err.StatusCode != http.StatusOK.
+		glog.Errorf("connection_error (%s, %s) => HTTP details: status=%d, body:\n%s", logURL, endpoint, err.StatusCode, err.Body)
 		errCounter.Inc(logURL, endpoint, "connection_error")
 	}
 }


### PR DESCRIPTION
Add debug logs for the log submit failure.

Currently it does not have enough information to debug the issue for the
failure to submit to some logs.
To debug the problem more easily, we need more information about the
http response body and http status.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
