### PR TITLE
Travis: go mod tidy allowed to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ jobs:
   allow_failures:
     - name: "go mod tidy"
 
+
 cache:
   directories:
     - "$HOME/gopath/pkg/mod"

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ jobs:
       - GOFLAGS="-race --tags=pkcs11"
       - PRESUBMIT_OPTS="--no-linters"
   allow_failures:
-    - name "go mod tidy"
+    - name: "go mod tidy"
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,8 @@ jobs:
       - WITH_PKCS11=true
       - GOFLAGS="-race --tags=pkcs11"
       - PRESUBMIT_OPTS="--no-linters"
+  allow_failures:
+    - name "go.mod check"
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   fast_finish: true
   include:
-    - name: "go.mod check"
+    - name: "go mod tidy"
       before_install: skip
       install: skip
       before_script: go mod tidy -v
@@ -44,7 +44,7 @@ jobs:
       - GOFLAGS="-race --tags=pkcs11"
       - PRESUBMIT_OPTS="--no-linters"
   allow_failures:
-    - name "go.mod check"
+    - name "go mod tidy"
 
 cache:
   directories:


### PR DESCRIPTION
Make the travis `go mod tidy` job an advisory.

### Checklist

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
