### PR TITLE
loglist2: update URLs to v2 (from v2_beta)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ The main parts of the repository are:
  - Other libraries related to CT:
    - `ctutil/` holds utility functions for validating and verifying CT data
      structures.
-   - `loglist/` has a library for reading
-     [JSON lists of CT Logs](https://www.certificate-transparency.org/known-logs).
+   - `loglist/` has a library for reading v1 JSON lists of CT Logs.
+   - `loglist2/` has a library for reading
+     [v2 JSON lists of CT Logs](https://www.certificate-transparency.org/known-logs).
 
 
 ## Trillian CT Personality

--- a/loglist2/loglist2.go
+++ b/loglist2/loglist2.go
@@ -36,11 +36,11 @@ import (
 
 const (
 	// LogListURL has the master URL for Google Chrome's log list.
-	LogListURL = "https://www.gstatic.com/ct/log_list/v2beta/log_list.json"
+	LogListURL = "https://www.gstatic.com/ct/log_list/v2/log_list.json"
 	// LogListSignatureURL has the URL for the signature over Google Chrome's log list.
-	LogListSignatureURL = "https://www.gstatic.com/ct/log_list/v2beta/log_list.sig"
+	LogListSignatureURL = "https://www.gstatic.com/ct/log_list/v2/log_list.sig"
 	// AllLogListURL has the URL for the list of all known logs (which isn't signed).
-	AllLogListURL = "https://www.gstatic.com/ct/log_list/v2beta/all_logs_list.json"
+	AllLogListURL = "https://www.gstatic.com/ct/log_list/v2/all_logs_list.json"
 )
 
 // Manually mapped from https://www.gstatic.com/ct/log_list/v2beta/log_list_schema.json


### PR DESCRIPTION
The LogList/LogListSignature/AllLogList URLs were still from v2_beta
which is no longer available. Update to v2 URLs.

Also mention `loglist2` in the main repo README and tweak `loglist`
description.