### PR TITLE
remove the -by_range flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## HEAD
 
+### CTFE
+
+Removed the `-by_range` flag.
+
 ## v1.1.1
 [Published 2020-10-06](https://github.com/google/certificate-transparency-go/releases/tag/v1.1.1)
 

--- a/trillian/ctfe/handlers.go
+++ b/trillian/ctfe/handlers.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -1063,23 +1062,6 @@ func (ll byLeafIndex) Swap(i, j int) {
 }
 func (ll byLeafIndex) Less(i, j int) bool {
 	return ll[i].LeafIndex < ll[j].LeafIndex
-}
-
-// sortLeafRange re-orders the leaves in rsp to be in ascending order by LeafIndex.  It also
-// checks that the resulting range of leaves in rsp is valid, starting at start and finishing
-// at end (or before) without duplicates.
-func sortLeafRange(rsp *trillian.GetLeavesByIndexResponse, start, end int64) error {
-	if got := int64(len(rsp.Leaves)); got > (end + 1 - start) {
-		return fmt.Errorf("backend returned too many leaves: %d v [%d,%d]", got, start, end)
-	}
-	sort.Sort(byLeafIndex(rsp.Leaves))
-	for i, leaf := range rsp.Leaves {
-		if leaf.LeafIndex != (start + int64(i)) {
-			return fmt.Errorf("backend returned unexpected leaf index: rsp.Leaves[%d].LeafIndex=%d for range [%d,%d]", i, leaf.LeafIndex, start, end)
-		}
-	}
-
-	return nil
 }
 
 // marshalGetEntriesResponse does the conversion from the backend response to the one we need for


### PR DESCRIPTION
Remove the `-by_range` flag, which was only necessary for backward compatibility with old versions of Trillian.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
