### PR TITLE
Use QueueLeaf instead of QueueLeaves.

### DIFF
--- a/trillian/ctfe/handlers.go
+++ b/trillian/ctfe/handlers.go
@@ -484,6 +484,9 @@ func addChainInternal(ctx context.Context, li *logInfo, w http.ResponseWriter, r
 	if rsp == nil {
 		return http.StatusInternalServerError, errors.New("missing QueueLeaves response")
 	}
+	if rsp.QueuedLeaf == nil {
+		return http.StatusInternalServerError, errors.New("QueueLeaf did not return the leaf")
+	}
 
 	// Always use the returned leaf as the basis for an SCT.
 	var loggedLeaf ct.MerkleTreeLeaf


### PR DESCRIPTION
CTFE only ever needs to queue a single leaf at a time.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
