### PR TITLE
Fixes a problem for saving more SCTs than required.

### DIFF
--- a/submission/races.go
+++ b/submission/races.go
@@ -107,10 +107,6 @@ func (sub *safeSubmissionState) setResult(logURL string, sct *ct.SignedCertifica
 		sub.results[logURL] = &submissionResult{sct: sct, err: err}
 		return
 	}
-	// already processed.
-	if sub.results[logURL].sct != nil {
-		return
-	}
 	// If at least one group needs that SCT, result is set. Otherwise dumped.
 	for groupName := range sub.logToGroups[logURL] {
 		// Ignore the base group (All-logs) here to check separately.

--- a/submission/races.go
+++ b/submission/races.go
@@ -124,10 +124,7 @@ func (sub *safeSubmissionState) setResult(logURL string, sct *ct.SignedCertifica
 	}
 
 	// Check the base group (All-logs) only
-	for groupName := range sub.logToGroups[logURL] {
-		if groupName != ctpolicy.BaseName {
-			continue
-		}
+	if sub.logToGroups[logURL][ctpolicy.BaseName] {
 		if sub.results[logURL].sct != nil {
 			// It is already processed in a non-base group, so we can reduce the groupNeeds for the base group as well.
 			sub.groupNeeds[ctpolicy.BaseName]--


### PR DESCRIPTION
New logic prevents saving more SCTs than what the policy requires
by handling non-base groups and base group separately.

Issue description:
I found a root cause for this issue in setResult method in race.go

Let's say we have two groups and base group which includes all logs.

A group: a1.com, a2.com, a3.com, a4.com and minimum SCTs: 1

B group: b1.com, b2.com, b3.com, b4.com and minimum SCTs: 1

Base group: a1.com, a2.com, a3.com, a4.com, b1.com, b2.com, b3.com, b4.com and minimum SCTs: 2 (which is the total SCTs required for the certificate).

We save the SCT from a log server only if minimum SCTs of any group which has the log server url is greater than 0.

If we get SCT from a1.com a2.com continuously, when receiving SCT from a1.com,

save the SCT because minimum SCTs of A group is 1.
set minimum SCTs of A group to 0.
set minimum SCTs of Base group to 1.
When receiving SCT from a2.com,

save the SCT because minimum SCTs of Base group is 1.
set minimum SCTs of A group to -1.
set minimum SCTs of Base group to 0.
After that, if we get SCT from b1.com,

save the SCT because minimum SCTs of B group is 1.
set minimum SCTs of B group to 0.
set minimum SCTs of Base group to -1.
Eventually we ended up saving 3 SCTs for the certificate even though we only need 2 SCTs.

Fixes #775
<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
