### PR TITLE
Doc update: LogListV2

### DIFF
--- a/loglist2/loglist2.go
+++ b/loglist2/loglist2.go
@@ -82,7 +82,7 @@ type Log struct {
 	// log list distributor.
 	State *LogStates `json:"state,omitempty"`
 	// TemporalInterval, if set, indicates that this log only accepts
-	// certificates with a NotBefore date in this time range.
+	// certificates with a NotAfter date in this time range.
 	TemporalInterval *TemporalInterval `json:"temporal_interval,omitempty"`
 	// Type indicates the purpose of this log, e.g. "test" or "prod".
 	Type string `json:"log_type,omitempty"`


### PR DESCRIPTION
In LogListV2 documentation, log temporal sharding is said to rely on NotBefore, but it's really using NotAfter... ie Argon2021 contains certificates that expire in 2021, not certificates that were issued in 2021.

### Checklist

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
- Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [X] I have updated [documentation](docs/) accordingly.
