### PR TITLE
Replace juju/ratelimit with x/time/rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
  * update `google.golang.org/grpc` to v1.46.0
  * `ctclient` tool now uses Cobra for better CLI experience (#901).
+ * #800: Remove dependency from `ratelimit`.
 
 ## v1.1.2
 
@@ -32,7 +33,6 @@
 
  * Trillian from v1.3.11 to v1.4.0
  * protobuf to v2
-
 
 ## v1.1.1
 [Published 2020-10-06](https://github.com/google/certificate-transparency-go/releases/tag/v1.1.1)

--- a/fixchain/ratelimiter/limiter.go
+++ b/fixchain/ratelimiter/limiter.go
@@ -16,21 +16,24 @@
 package ratelimiter
 
 import (
-	"github.com/juju/ratelimit"
+	"context"
+	"golang.org/x/time/rate"
 )
 
 // Limiter is a simple rate limiter.
 type Limiter struct {
-	bucket *ratelimit.Bucket
+	ctx context.Context
+	bucket *rate.Limiter
 }
 
 // Wait blocks for the amount of time required by the Limiter so as to not
 // exceed its rate.
 func (l *Limiter) Wait() {
-	l.bucket.Wait(1)
+	l.bucket.Wait(l.ctx)
 }
 
 // NewLimiter creates a new Limiter with a rate of limit per second.
 func NewLimiter(limit int) *Limiter {
-	return &Limiter{bucket: ratelimit.NewBucketWithRate(float64(limit), 1)}
+	return &Limiter{ctx: context.Background(),
+		bucket: rate.NewLimiter(rate.Limit(limit), 1)}
 }

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/google/trillian v1.4.0
 	github.com/gorilla/mux v1.8.0
 	github.com/jonboulle/clockwork v0.3.0 // indirect
-	github.com/juju/ratelimit v1.0.1
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/mattn/go-sqlite3 v1.14.10
@@ -38,7 +37,7 @@ require (
 	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4
 	golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4
 	golang.org/x/sys v0.0.0-20220422013727-9388b58f7150 // indirect
-	golang.org/x/time v0.0.0-20220411224347-583f2d630306 // indirect
+	golang.org/x/time v0.0.0-20220411224347-583f2d630306
 	google.golang.org/genproto v0.0.0-20220426171045-31bebdecfb46 // indirect
 	google.golang.org/grpc v1.46.0
 	google.golang.org/protobuf v1.28.0

--- a/go.sum
+++ b/go.sum
@@ -487,7 +487,6 @@ github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHm
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
-github.com/juju/ratelimit v1.0.1 h1:+7AIFJVQ0EQgq/K9+0Krm7m530Du7tIz0METWzN0RgY=
 github.com/juju/ratelimit v1.0.1/go.mod h1:qapgC/Gy+xNh9UxzV13HGGl/6UXNN+ct+vwSgWNm/qk=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=


### PR DESCRIPTION
The consequences of the LGPL static linking exception in juju/ratelimit
aren't terribly well understood, and it's the only component in the
certificate-transparency chain that's not under something well-studied like
MIT or Apache. There's now ratelimit support in x/time, so porting over to
use that instead simplifies licensing analysis.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
