### PR TITLE
Remove a dependency on trillian/crypto/keys/testonly from a Migrillian test.

### DIFF
--- a/trillian/migrillian/core/config_test.go
+++ b/trillian/migrillian/core/config_test.go
@@ -15,12 +15,12 @@
 package core
 
 import (
+	"encoding/pem"
 	"strings"
 	"testing"
 
 	"github.com/google/certificate-transparency-go/trillian/ctfe/testonly"
 	"github.com/google/certificate-transparency-go/trillian/migrillian/configpb"
-	kto "github.com/google/trillian/crypto/keys/testonly"
 	"github.com/google/trillian/crypto/keyspb"
 )
 
@@ -75,9 +75,8 @@ func TestLoadConfigFromFileErrors(t *testing.T) {
 }
 
 func TestValidateMigrationConfig(t *testing.T) {
-	pubKey := &keyspb.PublicKey{
-		Der: kto.MustMarshalPublicPEMToDER(testonly.CTLogPublicKeyPEM),
-	}
+	block, _ := pem.Decode([]byte(testonly.CTLogPublicKeyPEM))
+	pubKey := &keyspb.PublicKey{Der: block.Bytes}
 
 	for _, tc := range []struct {
 		desc    string


### PR DESCRIPTION
<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
