### PR TITLE
Clean up: remove unused byLeafIndex type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/google/certificate-transparency-go
 go 1.16
 
 require (
+	bitbucket.org/creachadair/shell v0.0.6 // indirect
 	github.com/fullstorydev/grpcurl v1.8.1
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/mock v1.5.0

--- a/trillian/ctfe/handlers.go
+++ b/trillian/ctfe/handlers.go
@@ -1041,29 +1041,6 @@ func parseGetSTHConsistencyRange(r *http.Request) (int64, int64, error) {
 	return first, second, nil
 }
 
-// buildIndicesForRange expands the range out, the backend allows for non contiguous leaf fetches
-// but the CT spec doesn't. The input values should have been checked for consistency before calling
-// this.
-func buildIndicesForRange(start, end int64) []int64 {
-	indices := make([]int64, 0, end-start+1)
-	for i := start; i <= end; i++ {
-		indices = append(indices, i)
-	}
-	return indices
-}
-
-type byLeafIndex []*trillian.LogLeaf
-
-func (ll byLeafIndex) Len() int {
-	return len(ll)
-}
-func (ll byLeafIndex) Swap(i, j int) {
-	ll[i], ll[j] = ll[j], ll[i]
-}
-func (ll byLeafIndex) Less(i, j int) bool {
-	return ll[i].LeafIndex < ll[j].LeafIndex
-}
-
 // marshalGetEntriesResponse does the conversion from the backend response to the one we need for
 // an RFC compliant JSON response to the client.
 func marshalGetEntriesResponse(li *logInfo, leaves []*trillian.LogLeaf) (ct.GetEntriesResponse, error) {


### PR DESCRIPTION
Remove unused type in ctfe, and add missing dep.

### Checklist

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
