### PR TITLE
first commit for CT witness

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,10 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/google/go-cmp v0.5.6
 	github.com/google/trillian v1.4.0
+	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/juju/ratelimit v1.0.1
 	github.com/kylelemons/godebug v1.1.0
+	github.com/mattn/go-sqlite3 v1.14.8 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
 	github.com/prometheus/client_golang v1.11.0
 	github.com/rs/cors v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -387,6 +387,8 @@ github.com/goreleaser/nfpm v1.2.1/go.mod h1:TtWrABZozuLOttX2uDlYyECfQX7x5XYkVxhj
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
@@ -520,6 +522,8 @@ github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m
 github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-shellwords v1.0.10/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
+github.com/mattn/go-sqlite3 v1.14.8 h1:gDp86IdQsN/xWjIEmr9MF6o9mpksUgh0fu+9ByFxzIU=
+github.com/mattn/go-sqlite3 v1.14.8/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/mattn/go-zglob v0.0.1/go.mod h1:9fxibJccNxU2cnpIKLRRFA7zX7qhkJIQWBb449FYHOo=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=

--- a/witness/witness/README.md
+++ b/witness/witness/README.md
@@ -11,10 +11,10 @@ compatible with the specific formats used by CT.
 
 Once up and running, the witness provides three API endpoints (as defined in
 [api/http.go](api/http.go)):
-- `/witness/v0/logs` returns a list of all logs for which the witness is
+- `/ctwitness/v0/logs` returns a list of all logs for which the witness is
   currently storing an STH.
-- `/witness/v0/logs/<logid>/update` acts to update the STH stored for `logid`.
-- `/witness/v0/logs/<logid>/sth` returns the latest STH for `logid`.
+- `/ctwitness/v0/logs/<logid>/update` acts to update the STH stored for `logid`.
+- `/ctwitness/v0/logs/<logid>/sth` returns the latest STH for `logid`.
 
 Running the witness
 --------------------
@@ -26,9 +26,9 @@ can be found in the `cmd/witness` directory), with the following flags:
   use of sqlite limits the scalability and reliability of the witness (because
   this is a local file), so if that is required a different database backend
   would be needed.
-- `config_file`, which specifies configuration information for the logs.  A 
-  sample configuration file is at `cmd/witness/example.conf`, and in general it
-  is necessary to specify the following fields for each log:
+- `config_file`, which specifies configuration information for the logs.  This
+  repository contains a [sample configuration file](cmd/witness/example.conf), 
+  and in general it is necessary to specify the following fields for each log:
     - `logID`, which is the identifier for the log.
     - `pubKey`, which is the public key of the log.
 - `private_key`, which specifies the private signing key of the witness.

--- a/witness/witness/README.md
+++ b/witness/witness/README.md
@@ -5,7 +5,8 @@ The witness is an HTTP service that stores STHs it has seen from
 a configurable list of Certificate Transparency logs in a sqlite database.  This 
 is a lightweight way to help detect or even prevent split-view attacks.  An 
 overview of witnessing can be found in 
-[trillian-examples](https://github.com/google/trillian-examples/tree/master/witness), along with "generic" witness implementations.  This witness is designed to be 
+[trillian-examples](https://github.com/google/trillian-examples/tree/master/witness), 
+along with "generic" witness implementations.  This witness is designed to be 
 compatible with the specific formats used by CT.
 
 Once up and running, the witness provides three API endpoints (as defined in

--- a/witness/witness/README.md
+++ b/witness/witness/README.md
@@ -1,0 +1,33 @@
+CT Witness
+==============
+
+The witness is an HTTP service that stores STHs it has seen from
+a configurable list of Certificate Transparency logs in a sqlite database.  This 
+is a lightweight way to help detect or even prevent split-view attacks.  An 
+overview of witnessing can be found in 
+[trillian-examples](https://github.com/google/trillian-examples/tree/master/witness), along with "generic" witness implementations.  This witness is designed to be 
+compatible with the specific formats used by CT.
+
+Once up and running, the witness provides three API endpoints (as defined in
+[api/http.go](api/http.go)):
+- `/witness/v0/logs` returns a list of all logs for which the witness is
+  currently storing an STH.
+- `/witness/v0/logs/<logid>/update` acts to update the STH stored for `logid`.
+- `/witness/v0/logs/<logid>/sth` returns the latest STH for `logid`.
+
+Running the witness
+--------------------
+
+Running the witness is as simple as running `go run main.go` (where `main.go`
+can be found in the `cmd/witness` directory), with the following flags:
+- `listen`, which specifies the address and port to listen on.
+- `db_file`, which specifies the desired location of the sqlite database.  The
+  use of sqlite limits the scalability and reliability of the witness (because
+  this is a local file), so if that is required a different database backend
+  would be needed.
+- `config_file`, which specifies configuration information for the logs.  A 
+  sample configuration file is at `cmd/witness/example.conf`, and in general it
+  is necessary to specify the following fields for each log:
+    - `logID`, which is the identifier for the log.
+    - `pubKey`, which is the public key of the log.
+- `private_key`, which specifies the private signing key of the witness.

--- a/witness/witness/README.md
+++ b/witness/witness/README.md
@@ -19,8 +19,8 @@ Once up and running, the witness provides three API endpoints (as defined in
 Running the witness
 --------------------
 
-Running the witness is as simple as running `go run main.go` (where `main.go`
-can be found in the `cmd/witness` directory), with the following flags:
+Running the witness is as simple as running `go run ./cmd/witness/main.go` from
+this directory, with the following flags:
 - `listen`, which specifies the address and port to listen on.
 - `db_file`, which specifies the desired location of the sqlite database.  The
   use of sqlite limits the scalability and reliability of the witness (because
@@ -31,4 +31,7 @@ can be found in the `cmd/witness` directory), with the following flags:
   and in general it is necessary to specify the following fields for each log:
     - `logID`, which is the identifier for the log.
     - `pubKey`, which is the public key of the log.
-- `private_key`, which specifies the private signing key of the witness.
+  Both of these fields should be populated using an "official" 
+  [CT log list](https://www.gstatic.com/ct/log_list/v2/log_list.json).
+- `private_key`, which specifies the private signing key of the witness.  In its
+  current state the witness does not sign STHs so this can exist in any form.

--- a/witness/witness/api/http.go
+++ b/witness/witness/api/http.go
@@ -12,18 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package api provides the API endpoints for the witness.
 package api
 
 const (
 	// HTTPGetSTH is the path of the URL to get an STH.  The
 	// placeholder is for the logID (an alphanumeric string).
-	HTTPGetSTH = "/witness/v0/logs/%s/checkpoint"
+	HTTPGetSTH = "/ctwitness/v0/logs/%s/checkpoint"
 	// HTTPUpdate is the path of the URL to update to a new checkpoint.
 	// Again the placeholder is for the logID.
-	HTTPUpdate = "/witness/v0/logs/%s/update"
+	HTTPUpdate = "/ctwitness/v0/logs/%s/update"
 	// HTTPGetLogs is the path of the URL to get a list of all logs the
 	// witness is aware of.
-	HTTPGetLogs = "/witness/v0/logs"
+	HTTPGetLogs = "/ctwitness/v0/logs"
 )
 
 // UpdateRequest encodes the inputs to the witness Update function: a (raw)

--- a/witness/witness/api/http.go
+++ b/witness/witness/api/http.go
@@ -1,0 +1,35 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+const (
+	// HTTPGetSTH is the path of the URL to get an STH.  The
+	// placeholder is for the logID (an alphanumeric string).
+	HTTPGetSTH = "/witness/v0/logs/%s/checkpoint"
+	// HTTPUpdate is the path of the URL to update to a new checkpoint.
+	// Again the placeholder is for the logID.
+	HTTPUpdate = "/witness/v0/logs/%s/update"
+	// HTTPGetLogs is the path of the URL to get a list of all logs the
+	// witness is aware of.
+	HTTPGetLogs = "/witness/v0/logs"
+)
+
+// UpdateRequest encodes the inputs to the witness Update function: a (raw)
+// STH byte slice and a consistency proof (slice of slices).  The logID
+// is part of the request URL.
+type UpdateRequest struct {
+	STH   []byte
+	Proof [][]byte
+}

--- a/witness/witness/client/http/witness_client.go
+++ b/witness/witness/client/http/witness_client.go
@@ -1,0 +1,105 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package http is a simple client for interacting with witnesses over HTTP.
+package http
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+
+	ct "github.com/google/certificate-transparency-go"
+	wit_api "github.com/google/certificate-transparency-go/witness/witness/api"
+)
+
+// ErrSTHTooOld is returned if the STH passed to Update needs to be updated.
+var ErrSTHTooOld error = errors.New("STH too old")
+
+// Witness is a simple client for interacting with witnesses over HTTP.
+type Witness struct {
+	URL      *url.URL
+	Verifier ct.SignatureVerifier
+}
+
+// SigVerifier returns a Verifier to verify signatures from the witness.
+func (w Witness) SigVerifier() ct.SignatureVerifier {
+	return w.Verifier
+}
+
+// GetLatestSTH returns a recent STH from the witness for the specified log ID.
+func (w Witness) GetLatestSTH(ctx context.Context, logID string) ([]byte, error) {
+	u, err := w.URL.Parse(fmt.Sprintf(wit_api.HTTPGetSTH, logID))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse URL: %v", err)
+	}
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req.WithContext(ctx))
+	if err != nil {
+		return nil, fmt.Errorf("failed to do http request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == 404 {
+		return nil, os.ErrNotExist
+	} else if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("bad status response: %s", resp.Status)
+	}
+	return ioutil.ReadAll(resp.Body)
+}
+
+// Update attempts to clock the witness forward for the given logID.
+// The latest signed STH will be returned if this succeeds, or if the error is
+// http.ErrSTHTooOld. In all other cases no STH should be expected.
+func (w Witness) Update(ctx context.Context, logID string, sth []byte, proof [][]byte) ([]byte, error) {
+	reqBody, err := json.MarshalIndent(&wit_api.UpdateRequest{
+		STH:   sth,
+		Proof: proof,
+	}, "", " ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal update request: %v", err)
+	}
+	u, err := w.URL.Parse(fmt.Sprintf(wit_api.HTTPUpdate, logID))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse URL: %v", err)
+	}
+	req, err := http.NewRequest("PUT", u.String(), bytes.NewReader(reqBody))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req.WithContext(ctx))
+	if err != nil {
+		return nil, fmt.Errorf("failed to do http request: %v", err)
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read body: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		if resp.StatusCode == 409 {
+			return body, ErrSTHTooOld
+		}
+		return nil, fmt.Errorf("bad status response (%s): %q", resp.Status, body)
+	}
+	return body, nil
+}

--- a/witness/witness/cmd/witness/Dockerfile
+++ b/witness/witness/cmd/witness/Dockerfile
@@ -1,0 +1,25 @@
+FROM golang:buster AS builder
+
+ARG GOFLAGS=""
+ENV GOFLAGS=$GOFLAGS
+ENV GO111MODULE=on
+
+# Move to working directory /build
+WORKDIR /build
+
+# Copy and download dependency using go mod
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
+# Copy the code into the container
+COPY . .
+
+# Build the application
+RUN go build -o /build/bin/witness ./witness/golang/cmd/witness
+
+# Build release image
+FROM golang:buster
+
+COPY --from=builder /build/bin/witness /bin/witness
+ENTRYPOINT ["/bin/witness"]

--- a/witness/witness/cmd/witness/example.conf
+++ b/witness/witness/cmd/witness/example.conf
@@ -1,9 +1,0 @@
-{
-    "logs": [
-        {
-	    "description": "Google 'Argon2021' log",
-	    "logID": "9lyUL9F3MCIUVBgIMJRWjuNNExkzv98MLyALzE7xZOM=",
-	    "pubKey": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAETeBmZOrzZKo4xYktx9gI2chEce3cw/tbr5xkoQlmhB18aKfsxD+MnILgGNl0FOm0eYGilFVi85wLRIOhK8lxKw=="
-        }
-    ]
-}

--- a/witness/witness/cmd/witness/example.conf
+++ b/witness/witness/cmd/witness/example.conf
@@ -1,0 +1,9 @@
+{
+    "logs": [
+        {
+	    "description": "Google 'Argon2021' log",
+	    "logID": "9lyUL9F3MCIUVBgIMJRWjuNNExkzv98MLyALzE7xZOM=",
+	    "pubKey": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAETeBmZOrzZKo4xYktx9gI2chEce3cw/tbr5xkoQlmhB18aKfsxD+MnILgGNl0FOm0eYGilFVi85wLRIOhK8lxKw=="
+        }
+    ]
+}

--- a/witness/witness/cmd/witness/example_config.yaml
+++ b/witness/witness/cmd/witness/example_config.yaml
@@ -1,0 +1,4 @@
+Logs: 
+    Description: Google 'Argon2021' log
+    LogID: 9lyUL9F3MCIUVBgIMJRWjuNNExkzv98MLyALzE7xZOM=
+    PubKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAETeBmZOrzZKo4xYktx9gI2chEce3cw/tbr5xkoQlmhB18aKfsxD+MnILgGNl0FOm0eYGilFVi85wLRIOhK8lxKw==

--- a/witness/witness/cmd/witness/impl/witness.go
+++ b/witness/witness/cmd/witness/impl/witness.go
@@ -1,0 +1,112 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package impl is the implementation of the witness server.
+package impl
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/golang/glog"
+	ct "github.com/google/certificate-transparency-go"
+	ih "github.com/google/certificate-transparency-go/witness/witness/cmd/witness/internal/http"
+	"github.com/google/certificate-transparency-go/witness/witness/cmd/witness/internal/witness"
+	"github.com/gorilla/mux"
+	_ "github.com/mattn/go-sqlite3" // Load drivers for sqlite3
+)
+
+// LogConfig contains a list of LogInfo (configuration options for a log).
+type LogConfig struct {
+	Logs []LogInfo `json:"logs"`
+}
+
+// LogInfo contains the configuration options for a log: its identifier and public key.
+type LogInfo struct {
+	LogID  string `json:"log_id"`
+	PubKey string `json:"key"`
+}
+
+// ServerOpts provides the options for a server (specified in main.go).
+type ServerOpts struct {
+	// Where to listen for requests.
+	ListenAddr string
+	// The file for sqlite3 storage.
+	DBFile string
+	// The signing key for the witness.
+	PrivKey string
+	// The log configuration information.
+	Config LogConfig
+}
+
+// buildLogMap loads the log configuration information into a map.
+func buildLogMap(config LogConfig) (map[string]ct.SignatureVerifier, error) {
+	logMap := make(map[string]ct.SignatureVerifier)
+	for _, log := range config.Logs {
+		logV, err := ct.NewSignatureVerifier(log.PubKey)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create signature verifier: %v", err)
+		}
+		logMap[log.LogID] = *logV
+	}
+	return logMap, nil
+}
+
+// Main sets up and runs the witness given the options.
+func Main(ctx context.Context, opts ServerOpts) error {
+	if len(opts.DBFile) == 0 {
+		return errors.New("DBFile is required")
+	}
+	// Start up local database.
+	glog.Infof("Connecting to local DB at %q", opts.DBFile)
+	db, err := sql.Open("sqlite3", opts.DBFile)
+	if err != nil {
+		return fmt.Errorf("failed to connect to DB: %w", err)
+	}
+	// Load log configuration into the map.
+	logMap, err := buildLogMap(opts.Config)
+	if err != nil {
+		return fmt.Errorf("failed to load configurations: %v", err)
+	}
+
+	w, err := witness.New(witness.Opts{
+		DB:        db,
+		PrivKey:   opts.PrivKey,
+		KnownLogs: logMap,
+	})
+	if err != nil {
+		return fmt.Errorf("error creating witness: %v", err)
+	}
+
+	glog.Infof("Starting witness server...")
+	srv := ih.NewServer(w)
+	r := mux.NewRouter()
+	srv.RegisterHandlers(r)
+	hServer := &http.Server{
+		Addr:    opts.ListenAddr,
+		Handler: r,
+	}
+	e := make(chan error, 1)
+	go func() {
+		e <- hServer.ListenAndServe()
+		close(e)
+	}()
+	<-ctx.Done()
+	glog.Info("Server shutting down")
+	hServer.Shutdown(ctx)
+	return <-e
+}

--- a/witness/witness/cmd/witness/internal/http/server.go
+++ b/witness/witness/cmd/witness/internal/http/server.go
@@ -1,0 +1,127 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package http contains private implementation details for the witness server.
+package http
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/google/certificate-transparency-go/witness/witness/api"
+	"github.com/google/certificate-transparency-go/witness/witness/cmd/witness/internal/witness"
+	"github.com/gorilla/mux"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Server is the core handler implementation of the witness.
+type Server struct {
+	w *witness.Witness
+}
+
+// NewServer creates a new server.
+func NewServer(witness *witness.Witness) *Server {
+	return &Server{
+		w: witness,
+	}
+}
+
+// update handles requests to update STHs.
+// It expects a POSTed body containing a JSON-formatted api.UpdateRequest
+// statement and returns a JSON-formatted api.UpdateResponse statement.
+func (s *Server) update(w http.ResponseWriter, r *http.Request) {
+	v := mux.Vars(r)
+	logID := v["logid"]
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("cannot read request body: %v", err.Error()), http.StatusBadRequest)
+		return
+	}
+	var req api.UpdateRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		http.Error(w, fmt.Sprintf("cannot parse request body as proper JSON struct: %v", err.Error()), http.StatusBadRequest)
+		return
+	}
+	// Get the output from the witness.
+	sth, err := s.w.Update(r.Context(), logID, req.STH, req.Proof)
+	if err != nil {
+		// If there was a failed precondition it's possible the caller was
+		// just out of date.  Give the returned STH to help them
+		// form a new request.
+		if status.Code(err) == codes.FailedPrecondition {
+			// This is the implementation of http.Error except we don't add any trailing newline chars.
+			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+			w.Header().Set("X-Content-Type-Options", "nosniff")
+			w.WriteHeader(http.StatusConflict)
+			fmt.Fprint(w, err)
+			return
+		}
+		http.Error(w, fmt.Sprintf("failed to update to new checkpoint: %v", err), httpForCode(http.StatusInternalServerError))
+		return
+	}
+	w.Header().Set("Content-Type", "text/plain")
+	w.Write(sth)
+}
+
+// getSTH returns an STH stored for a given log.
+func (s *Server) getSTH(w http.ResponseWriter, r *http.Request) {
+	v := mux.Vars(r)
+	logID := v["logid"]
+	// Get the STH from the witness.
+	sth, err := s.w.GetSTH(logID)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("failed to get STH: %v", err), httpForCode(status.Code(err)))
+		return
+	}
+	w.Header().Set("Content-Type", "text/plain")
+	w.Write(sth)
+}
+
+// getLogs returns a list of all logs the witness is aware of.
+func (s *Server) getLogs(w http.ResponseWriter, r *http.Request) {
+	logs, err := s.w.GetLogs()
+	if err != nil {
+		http.Error(w, fmt.Sprintf("failed to get log list: %v", err), http.StatusInternalServerError)
+		return
+	}
+	logList, err := json.Marshal(logs)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("failed to convert log list to JSON: %v", err), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/json")
+	w.Write(logList)
+}
+
+// RegisterHandlers registers HTTP handlers for witness endpoints.
+func (s *Server) RegisterHandlers(r *mux.Router) {
+	logStr := "{logid:[a-zA-Z0-9-]+}"
+	r.HandleFunc(fmt.Sprintf(api.HTTPGetSTH, logStr), s.getSTH).Methods("GET")
+	r.HandleFunc(fmt.Sprintf(api.HTTPUpdate, logStr), s.update).Methods("PUT")
+	r.HandleFunc(api.HTTPGetLogs, s.getLogs).Methods("GET")
+}
+
+func httpForCode(c codes.Code) int {
+	switch c {
+	case codes.NotFound:
+		return http.StatusNotFound
+	case codes.FailedPrecondition:
+		return http.StatusConflict
+	default:
+		return http.StatusInternalServerError
+	}
+}

--- a/witness/witness/cmd/witness/internal/http/server_test.go
+++ b/witness/witness/cmd/witness/internal/http/server_test.go
@@ -1,0 +1,360 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package http
+
+import (
+	"context"
+	"crypto"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"testing"
+
+	ct "github.com/google/certificate-transparency-go"
+	"github.com/google/certificate-transparency-go/witness/witness/api"
+	"github.com/google/certificate-transparency-go/witness/witness/cmd/witness/internal/witness"
+	"github.com/gorilla/mux"
+
+	_ "github.com/mattn/go-sqlite3" // Load drivers for sqlite3
+)
+
+var (
+	// https://play.golang.org/p/gCY2Zi2BJ8G to generate keys and
+	// https://play.golang.org/p/KUXRShKdYTb to sign things with loaded keys.
+	mSK = `-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIECRHc4ORynd+lpqWYmjCIAmDjyLEJZSuvv4KdcIi+hEoAoGCCqGSM49
+AwEHoUQDQgAEn1Ahe5/kYQgqYk1kSzp0ZCvL1Cf/tOZ+GUrGjNC0CrTqSylMuU1f
+AcWDaKYB/Yr3fq/5lNqJBRjsOnI4KkaEtw==
+-----END EC PRIVATE KEY-----`
+	mPK = mustCreatePK(`-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEn1Ahe5/kYQgqYk1kSzp0ZCvL1Cf/
+tOZ+GUrGjNC0CrTqSylMuU1fAcWDaKYB/Yr3fq/5lNqJBRjsOnI4KkaEtw==
+-----END PUBLIC KEY-----`)
+	bSK = `-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIICRst6QhwffAkeOQGIhcCSmB7/LYQXevwrv8TD9FjU7oAoGCCqGSM49
+AwEHoUQDQgAE5FTw9vYXDEFiZb9kS1LV7GzU1Mo/xQ8D2Vnkl7WqNTB2kJ45aTtl
+F2bBk8i50oWNRlRLyi5MVl7j+6LVhMiBeA==
+-----END EC PRIVATE KEY-----`
+	bPK = mustCreatePK(`-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE5FTw9vYXDEFiZb9kS1LV7GzU1Mo/
+xQ8D2Vnkl7WqNTB2kJ45aTtlF2bBk8i50oWNRlRLyi5MVl7j+6LVhMiBeA==
+-----END PUBLIC KEY-----`)
+	wPK       = "witness+f13a86db+AdYV1Ztajd9BvyjP2HgpwrqYL6TjOwIjGMOq8Bu42xbN"
+	wSK       = "PRIVATE+KEY+witness+f13a86db+AaLa/dfyBhyo/m0Z7WCi98ENVZWtrP8pxgRNrx7tIWiA"
+	mInit     = []byte(`{"tree_size":5,"timestamp":0,"sha256_root_hash":"41smjBUiAU70EtKlT6lIOIYtRTYxYXsDB+XHfcvu/BE=","tree_head_signature":"BAMARzBFAiEA4CEXH2Z+T4Rcj3YTvgK5qM9NuFYHipI13Il6A/ozTFUCIBDY1VDFy8ZezXsuWNs+iLzkyO5I5kCZldGeMvspHOof"}`)
+	bInit     = []byte(`{"tree_size":5,"timestamp":0,"sha256_root_hash":"41smjBUiAU70EtKlT6lIOIYtRTYxYXsDB+XHfcvu/BE=","tree_head_signature":"BAMASDBGAiEAjSUy1d7/n1MOYWCnx2DzU3nQk1OUHzRtFJl+eDCquBsCIQDEG2vk1A+LmHZfyt/BN4by2324rxWFFzAeG1f2EyXk9w=="}`)
+	mNext     = []byte(`{"tree_size":8,"timestamp":1,"sha256_root_hash":"V8K9aklZ4EPB+RMOk1/8VsJUdFZR77GDtZUQq84vSbo=","tree_head_signature":"BAMARjBEAiB9SZfr3JJbLsSE4mhnHE9hbcbu97nsbKcONnXeJXeigwIgJTWVh5FLNfUre5uCRLY4B1KEyS8tcGbaaHdEMk2WAmc="}`)
+	consProof = [][]byte{
+		dh("b9e1d62618f7fee8034e4c5010f727ab24d8e4705cb296c374bf2025a87a10d2", 32),
+		dh("aac66cd7a79ce4012d80762fe8eec3a77f22d1ca4145c3f4cee022e7efcd599d", 32),
+		dh("89d0f753f66a290c483b39cd5e9eafb12021293395fad3d4a2ad053cfbcfdc9e", 32),
+		dh("29e40bb79c966f4c6fe96aff6f30acfce5f3e8d84c02215175d6e018a5dee833", 32),
+	}
+	_ = mSK
+	_ = bSK
+	_ = wPK
+)
+
+type logOpts struct {
+	ID string
+	PK crypto.PublicKey
+}
+
+func newWitness(t *testing.T, d *sql.DB, logs []logOpts) *witness.Witness {
+	// Set up Opts for the witness.
+	logMap := make(map[string]ct.SignatureVerifier)
+	for _, log := range logs {
+		logV, err := ct.NewSignatureVerifier(log.PK)
+		if err != nil {
+			t.Fatalf("couldn't create a log verifier: %v", err)
+		}
+		logMap[log.ID] = *logV
+	}
+	opts := witness.Opts{
+		DB:        d,
+		PrivKey:   wSK,
+		KnownLogs: logMap,
+	}
+	// Create the witness
+	w, err := witness.New(opts)
+	if err != nil {
+		t.Fatalf("couldn't create witness: %v", err)
+	}
+	return w
+}
+
+func dh(h string, expLen int) []byte {
+	r, err := hex.DecodeString(h)
+	if err != nil {
+		panic(err)
+	}
+	if got := len(r); got != expLen {
+		panic(fmt.Sprintf("decode %q: len=%d, want %d", h, got, expLen))
+	}
+	return r
+}
+
+func mustCreateDB(t *testing.T) (*sql.DB, func() error) {
+	t.Helper()
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open temporary in-memory DB: %v", err)
+	}
+	return db, db.Close
+}
+
+func mustCreatePK(pkPem string) crypto.PublicKey {
+	pk, _, _, err := ct.PublicKeyFromPEM([]byte(pkPem))
+	if err != nil {
+		panic(err)
+	}
+	return pk
+}
+
+func createTestEnv(w *witness.Witness) (*httptest.Server, func()) {
+	r := mux.NewRouter()
+	server := NewServer(w)
+	server.RegisterHandlers(r)
+	ts := httptest.NewServer(r)
+	return ts, ts.Close
+}
+
+func TestGetLogs(t *testing.T) {
+	for _, test := range []struct {
+		desc       string
+		logIDs     []string
+		logPKs     []crypto.PublicKey
+		sths       [][]byte
+		wantStatus int
+		wantBody   []string
+	}{
+		{
+			desc:       "no logs",
+			logIDs:     []string{},
+			wantStatus: http.StatusOK,
+			wantBody:   []string{},
+		}, {
+			desc:       "one log",
+			logIDs:     []string{"monkeys"},
+			logPKs:     []crypto.PublicKey{mPK},
+			sths:       [][]byte{mInit},
+			wantStatus: http.StatusOK,
+			wantBody:   []string{"monkeys"},
+		}, {
+			desc:       "two logs",
+			logIDs:     []string{"bananas", "monkeys"},
+			logPKs:     []crypto.PublicKey{bPK, mPK},
+			sths:       [][]byte{bInit, mInit},
+			wantStatus: http.StatusOK,
+			wantBody:   []string{"bananas", "monkeys"},
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			d, closeFn := mustCreateDB(t)
+			defer closeFn()
+			ctx := context.Background()
+			// Set up witness and give it some checkpoints.
+			logs := make([]logOpts, len(test.logIDs))
+			for i, logID := range test.logIDs {
+				logs[i] = logOpts{ID: logID,
+					PK: test.logPKs[i],
+				}
+			}
+			w := newWitness(t, d, logs)
+			for i, logID := range test.logIDs {
+				if _, err := w.Update(ctx, logID, test.sths[i], nil); err != nil {
+					t.Errorf("failed to set checkpoint: %v", err)
+				}
+			}
+			// Now set up the http server.
+			ts, tsCloseFn := createTestEnv(w)
+			defer tsCloseFn()
+			client := ts.Client()
+			url := fmt.Sprintf("%s%s", ts.URL, api.HTTPGetLogs)
+			resp, err := client.Get(url)
+			if err != nil {
+				t.Errorf("error response: %v", err)
+			}
+			if got, want := resp.StatusCode, test.wantStatus; got != want {
+				t.Errorf("status code got %d, want %d", got, want)
+			}
+			if len(test.wantBody) > 0 {
+				body, err := ioutil.ReadAll(resp.Body)
+				if err != nil {
+					t.Fatalf("failed to read body: %v", err)
+				}
+				var logs []string
+				if err := json.Unmarshal(body, &logs); err != nil {
+					t.Fatalf("failed to unmarshal body: %v", err)
+				}
+				if len(logs) != len(test.wantBody) {
+					t.Fatalf("got %d logs, want %d", len(logs), len(test.wantBody))
+				}
+				sort.Strings(logs)
+				for i := range logs {
+					if logs[i] != test.wantBody[i] {
+						t.Fatalf("got %q, want %q", logs[i], test.wantBody[i])
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestGetChkpt(t *testing.T) {
+	for _, test := range []struct {
+		desc       string
+		setID      string
+		setPK      crypto.PublicKey
+		queryID    string
+		queryPK    crypto.PublicKey
+		sth        []byte
+		wantStatus int
+	}{
+		{
+			desc:       "happy path",
+			setID:      "monkeys",
+			setPK:      mPK,
+			queryID:    "monkeys",
+			queryPK:    mPK,
+			sth:        mInit,
+			wantStatus: http.StatusOK,
+		}, {
+			desc:       "other log",
+			setID:      "monkeys",
+			setPK:      mPK,
+			queryID:    "bananas",
+			sth:        mInit,
+			wantStatus: http.StatusNotFound,
+		}, {
+			desc:       "nothing there",
+			setID:      "monkeys",
+			setPK:      mPK,
+			queryID:    "monkeys",
+			sth:        nil,
+			wantStatus: http.StatusNotFound,
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			d, closeFn := mustCreateDB(t)
+			defer closeFn()
+			ctx := context.Background()
+			// Set up witness.
+			w := newWitness(t, d, []logOpts{{ID: test.setID,
+				PK: test.setPK}})
+			// Set a checkpoint for the log if we want to for this test.
+			if test.sth != nil {
+				if _, err := w.Update(ctx, test.setID, test.sth, nil); err != nil {
+					t.Errorf("failed to set checkpoint: %v", err)
+				}
+			}
+			// Now set up the http server.
+			ts, tsCloseFn := createTestEnv(w)
+			defer tsCloseFn()
+			client := ts.Client()
+			chkptQ := fmt.Sprintf(api.HTTPGetSTH, test.queryID)
+			url := fmt.Sprintf("%s%s", ts.URL, chkptQ)
+			resp, err := client.Get(url)
+			if err != nil {
+				t.Errorf("error response: %v", err)
+			}
+			if got, want := resp.StatusCode, test.wantStatus; got != want {
+				t.Errorf("status code got %d, want %d", got, want)
+			}
+		})
+	}
+}
+
+func TestUpdate(t *testing.T) {
+	for _, test := range []struct {
+		desc       string
+		initC      []byte
+		initSize   uint64
+		body       api.UpdateRequest
+		wantStatus int
+	}{
+		{
+			desc:       "vanilla consistency happy path",
+			initC:      mInit,
+			initSize:   5,
+			body:       api.UpdateRequest{STH: mNext, Proof: consProof},
+			wantStatus: http.StatusOK,
+		}, {
+			desc:       "vanilla consistency smaller checkpoint",
+			initC:      mNext,
+			initSize:   8,
+			body:       api.UpdateRequest{STH: mInit, Proof: consProof},
+			wantStatus: http.StatusConflict,
+		}, {
+			desc:     "vanilla consistency garbage proof",
+			initC:    mInit,
+			initSize: 5,
+			body: api.UpdateRequest{STH: mNext, Proof: [][]byte{
+				dh("aaaa", 2),
+				dh("bbbb", 2),
+				dh("cccc", 2),
+				dh("dddd", 2),
+			}},
+			wantStatus: http.StatusConflict,
+		}, {
+			desc:       "vanilla consistency garbage checkpoint",
+			initC:      mInit,
+			initSize:   5,
+			body:       api.UpdateRequest{STH: []byte("aaa"), Proof: consProof},
+			wantStatus: http.StatusInternalServerError,
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			d, closeFn := mustCreateDB(t)
+			defer closeFn()
+			ctx := context.Background()
+			logID := "monkeys"
+			// Set up witness.
+			w := newWitness(t, d, []logOpts{{ID: logID,
+				PK: mPK}})
+			// Set an initial STH for the log.
+			if _, err := w.Update(ctx, logID, test.initC, nil); err != nil {
+				t.Errorf("failed to set checkpoint: %v", err)
+			}
+			// Now set up the http server.
+			ts, tsCloseFn := createTestEnv(w)
+			defer tsCloseFn()
+			// Update to a newer checkpoint.
+			client := ts.Client()
+			reqBody, err := json.Marshal(test.body)
+			if err != nil {
+				t.Fatalf("couldn't parse request: %v", err)
+			}
+			url := fmt.Sprintf("%s%s", ts.URL, fmt.Sprintf(api.HTTPUpdate, logID))
+			req, err := http.NewRequest(http.MethodPut, url, strings.NewReader(string(reqBody)))
+			if err != nil {
+				t.Fatalf("couldn't form http request: %v", err)
+			}
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Errorf("error response: %v", err)
+			}
+			if got, want := resp.StatusCode, test.wantStatus; got != want {
+				t.Errorf("status code got %d, want %d", got, want)
+			}
+		})
+	}
+}

--- a/witness/witness/cmd/witness/internal/witness/witness.go
+++ b/witness/witness/cmd/witness/internal/witness/witness.go
@@ -1,0 +1,217 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package witness is designed to make sure the STHs of CT logs are consistent
+// and store/serve/sign them if so.  It is expected that a separate feeder
+// component would be responsible for the actual interaction with logs.
+package witness
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+
+	ct "github.com/google/certificate-transparency-go"
+	"github.com/google/trillian/merkle/logverifier"
+	"github.com/google/trillian/merkle/rfc6962"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Opts is the options passed to a witness.
+type Opts struct {
+	DB        *sql.DB
+	PrivKey   string
+	KnownLogs map[string]ct.SignatureVerifier
+}
+
+// Witness consists of a database for storing STHs, a signing key, and a list
+// of logs for which it stores and verifies STHs.
+type Witness struct {
+	db   *sql.DB
+	sk   string
+	Logs map[string]ct.SignatureVerifier
+}
+
+// New creates a new witness, which initially has no logs to follow.
+func New(wo Opts) (*Witness, error) {
+	// Create the sths table if needed.
+	_, err := wo.DB.Exec(`CREATE TABLE IF NOT EXISTS sths (logID BLOB PRIMARY KEY, sth BLOB)`)
+	if err != nil {
+		return nil, err
+	}
+	return &Witness{
+		db:   wo.DB,
+		sk:   wo.PrivKey,
+		Logs: wo.KnownLogs,
+	}, nil
+}
+
+// parse verifies the STH under the appropriate key for logID and returns
+// the parsed STH.
+func (w *Witness) parse(sthRaw []byte, logID string) (*ct.SignedTreeHead, error) {
+	sv, ok := w.Logs[logID]
+	if !ok {
+		return nil, fmt.Errorf("log %q not found", logID)
+	}
+	var sthJSON ct.GetSTHResponse
+	if err := json.Unmarshal(sthRaw, &sthJSON); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal json: %v", err)
+	}
+	sth, err := sthJSON.ToSignedTreeHead()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create STH: %v", err)
+	}
+	if err := sv.VerifySTHSignature(*sth); err != nil {
+		return nil, fmt.Errorf("failed to verify STH signature: %v", err)
+	}
+	return sth, nil
+}
+
+// GetLogs returns a list of all logs the witness is aware of.
+func (w *Witness) GetLogs() ([]string, error) {
+	rows, err := w.db.Query("SELECT logID FROM sths")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var logs []string
+	for rows.Next() {
+		var logID string
+		err := rows.Scan(&logID)
+		if err != nil {
+			return nil, err
+		}
+		logs = append(logs, logID)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return logs, nil
+}
+
+// GetSTH gets an STH for a given log, which is consistent with all
+// other STHs for the same log signed by this witness.
+func (w *Witness) GetSTH(logID string) ([]byte, error) {
+	sth, err := w.getLatestSTH(w.db.QueryRow, logID)
+	if err != nil {
+		return nil, err
+	}
+	return sth, nil
+}
+
+// Update updates the latest STH if nextRaw is consistent with the current
+// latest one for this log. It returns the latest cosigned STH held by
+// the witness, which is a signed version of nextRaw if the update was applied.
+func (w *Witness) Update(ctx context.Context, logID string, nextRaw []byte, proof [][]byte) ([]byte, error) {
+	// If we don't witness this log then no point in going further.
+	_, ok := w.Logs[logID]
+	if !ok {
+		return nil, status.Errorf(codes.NotFound, "log %q not found", logID)
+	}
+	// Check the signatures on the raw STH and parse it into the STH format.
+	next, err := w.parse(nextRaw, logID)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't parse input STH: %v", err)
+	}
+	// Optimistically sign the new STH now.
+	signed, err := w.signSTH(next)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't sign input STH: %v", err)
+	}
+	// Get the latest one for the log because we don't want consistency proofs
+	// with respect to older STHs.  Bind this all in a transaction to
+	// avoid race conditions when updating the database.
+	tx, err := w.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't create db tx: %v", err)
+	}
+	// Get the latest STH (if one exists).
+	prevRaw, err := w.getLatestSTH(tx.QueryRow, logID)
+	if err != nil {
+		// If there was nothing stored already then treat this new
+		// STH as trust-on-first-use (TOFU).
+		if status.Code(err) == codes.NotFound {
+			if err := w.setSTH(tx, logID, signed); err != nil {
+				return nil, fmt.Errorf("couldn't set TOFU STH: %v", err)
+			}
+			return signed, nil
+		}
+		return nil, fmt.Errorf("couldn't retrieve latest STH: %w", err)
+	}
+	// Parse the raw retrieved STH into the STH format.
+	prev, err := w.parse(prevRaw, logID)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't parse stored STH: %v", err)
+	}
+	if next.TreeSize < prev.TreeSize {
+		// Complain if prev is bigger than next.
+		return prevRaw, status.Errorf(codes.FailedPrecondition, "cannot prove consistency backwards (%d < %d)", next.TreeSize, prev.TreeSize)
+	}
+	if next.TreeSize == prev.TreeSize {
+		if !bytes.Equal(next.SHA256RootHash[:], prev.SHA256RootHash[:]) {
+			return prevRaw, status.Errorf(codes.FailedPrecondition, "STH for same size log with differing hash (got %x, have %x)", next.SHA256RootHash, prev.SHA256RootHash)
+		}
+		// If it's identical to the previous one do nothing.
+		return prevRaw, nil
+	}
+	// The only remaining option is next.Size > prev.Size. This might be
+	// valid so we verify the consistency proof.
+	logV := logverifier.New(rfc6962.DefaultHasher)
+	if err := logV.VerifyConsistencyProof(int64(prev.TreeSize), int64(next.TreeSize), prev.SHA256RootHash[:], next.SHA256RootHash[:], proof); err != nil {
+		// Complain if the STHs aren't consistent.
+		return prevRaw, status.Errorf(codes.FailedPrecondition, "failed to verify consistency proof: %v", err)
+	}
+	// If the consistency proof is good we store nextRaw.
+	if err := w.setSTH(tx, logID, signed); err != nil {
+		return nil, fmt.Errorf("failed to store new STH: %v", err)
+	}
+	return signed, nil
+}
+
+// signSTH adds the witness' signature to an STH.
+func (w *Witness) signSTH(sth *ct.SignedTreeHead) ([]byte, error) {
+	sthRaw, err := json.Marshal(sth)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't marshal STH: %v", err)
+	}
+	return sthRaw, nil
+}
+
+// getLatestSTH returns the raw stored data for the latest STH of a given log.
+func (w *Witness) getLatestSTH(queryRow func(query string, args ...interface{}) *sql.Row, logID string) ([]byte, error) {
+	row := queryRow("SELECT sth FROM sths WHERE logID = ?", logID)
+	if err := row.Err(); err != nil {
+		return nil, err
+	}
+	var sth []byte
+	if err := row.Scan(&sth); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, status.Errorf(codes.NotFound, "no STH for log %q", logID)
+		}
+		return nil, err
+	}
+	return sth, nil
+}
+
+// setSTH writes the STH to the database for a given log.
+func (w *Witness) setSTH(tx *sql.Tx, logID string, sth []byte) error {
+	tx.Exec(`INSERT INTO sths (logID, sth) VALUES (?, ?)
+		 ON CONFLICT(logID) DO UPDATE SET sth=excluded.sth`,
+		logID, sth)
+	return tx.Commit()
+}

--- a/witness/witness/cmd/witness/internal/witness/witness_test.go
+++ b/witness/witness/cmd/witness/internal/witness/witness_test.go
@@ -1,0 +1,307 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package witness
+
+import (
+	"context"
+	"crypto"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"testing"
+
+	ct "github.com/google/certificate-transparency-go"
+	_ "github.com/mattn/go-sqlite3" // Load drivers for sqlite3
+)
+
+var (
+	// https://play.golang.org/p/gCY2Zi2BJ8G to generate keys and
+	// https://play.golang.org/p/KUXRShKdYTb to sign things with loaded keys.
+	mSK = `-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIECRHc4ORynd+lpqWYmjCIAmDjyLEJZSuvv4KdcIi+hEoAoGCCqGSM49
+AwEHoUQDQgAEn1Ahe5/kYQgqYk1kSzp0ZCvL1Cf/tOZ+GUrGjNC0CrTqSylMuU1f
+AcWDaKYB/Yr3fq/5lNqJBRjsOnI4KkaEtw==
+-----END EC PRIVATE KEY-----`
+	mPK = mustCreatePK(`-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEn1Ahe5/kYQgqYk1kSzp0ZCvL1Cf/
+tOZ+GUrGjNC0CrTqSylMuU1fAcWDaKYB/Yr3fq/5lNqJBRjsOnI4KkaEtw==
+-----END PUBLIC KEY-----`)
+	bSK = `-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIICRst6QhwffAkeOQGIhcCSmB7/LYQXevwrv8TD9FjU7oAoGCCqGSM49
+AwEHoUQDQgAE5FTw9vYXDEFiZb9kS1LV7GzU1Mo/xQ8D2Vnkl7WqNTB2kJ45aTtl
+F2bBk8i50oWNRlRLyi5MVl7j+6LVhMiBeA==
+-----END EC PRIVATE KEY-----`
+	bPK = mustCreatePK(`-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE5FTw9vYXDEFiZb9kS1LV7GzU1Mo/
+xQ8D2Vnkl7WqNTB2kJ45aTtlF2bBk8i50oWNRlRLyi5MVl7j+6LVhMiBeA==
+-----END PUBLIC KEY-----`)
+	wPK       = "EnIuhhgmkYrL9e7pUigaIWDJsoaL0SyaOhVhVJUospc="
+	wSK       = "u63EoQc3SiU57kNbmPYVHf5lhEfWLUWrxobCDoYIvfUSci6GGCaRisv17ulSKBohYMmyhovRLJo6FWFUlSiylw=="
+	mInit     = []byte(`{"tree_size":5,"timestamp":0,"sha256_root_hash":"41smjBUiAU70EtKlT6lIOIYtRTYxYXsDB+XHfcvu/BE=","tree_head_signature":"BAMARzBFAiEA4CEXH2Z+T4Rcj3YTvgK5qM9NuFYHipI13Il6A/ozTFUCIBDY1VDFy8ZezXsuWNs+iLzkyO5I5kCZldGeMvspHOof"}`)
+	bInit     = []byte(`{"tree_size":5,"timestamp":0,"sha256_root_hash":"41smjBUiAU70EtKlT6lIOIYtRTYxYXsDB+XHfcvu/BE=","tree_head_signature":"BAMASDBGAiEAjSUy1d7/n1MOYWCnx2DzU3nQk1OUHzRtFJl+eDCquBsCIQDEG2vk1A+LmHZfyt/BN4by2324rxWFFzAeG1f2EyXk9w=="}`)
+	mNext     = []byte(`{"tree_size":8,"timestamp":1,"sha256_root_hash":"V8K9aklZ4EPB+RMOk1/8VsJUdFZR77GDtZUQq84vSbo=","tree_head_signature":"BAMARjBEAiB9SZfr3JJbLsSE4mhnHE9hbcbu97nsbKcONnXeJXeigwIgJTWVh5FLNfUre5uCRLY4B1KEyS8tcGbaaHdEMk2WAmc="}`)
+	consProof = [][]byte{
+		dh("b9e1d62618f7fee8034e4c5010f727ab24d8e4705cb296c374bf2025a87a10d2", 32),
+		dh("aac66cd7a79ce4012d80762fe8eec3a77f22d1ca4145c3f4cee022e7efcd599d", 32),
+		dh("89d0f753f66a290c483b39cd5e9eafb12021293395fad3d4a2ad053cfbcfdc9e", 32),
+		dh("29e40bb79c966f4c6fe96aff6f30acfce5f3e8d84c02215175d6e018a5dee833", 32),
+	}
+	_ = mSK
+	_ = bSK
+	_ = wPK
+)
+
+type logOpts struct {
+	ID string
+	PK crypto.PublicKey
+}
+
+func mustCreatePK(pkPem string) crypto.PublicKey {
+	pk, _, _, err := ct.PublicKeyFromPEM([]byte(pkPem))
+	if err != nil {
+		panic(err)
+	}
+	return pk
+}
+
+func newWitness(t *testing.T, d *sql.DB, logs []logOpts) *Witness {
+	// Set up Opts for the witness.
+	logMap := make(map[string]ct.SignatureVerifier)
+	for _, log := range logs {
+		sigV, err := ct.NewSignatureVerifier(log.PK)
+		if err != nil {
+			t.Fatalf("couldn't create a log verifier: %v", err)
+		}
+		logMap[log.ID] = *sigV
+	}
+	opts := Opts{
+		DB:        d,
+		PrivKey:   wSK,
+		KnownLogs: logMap,
+	}
+	// Create the witness.
+	w, err := New(opts)
+	if err != nil {
+		t.Fatalf("couldn't create witness: %v", err)
+	}
+	return w
+}
+
+func dh(h string, expLen int) []byte {
+	r, err := hex.DecodeString(h)
+	if err != nil {
+		panic(err)
+	}
+	if got := len(r); got != expLen {
+		panic(fmt.Sprintf("decode %q: len=%d, want %d", h, got, expLen))
+	}
+	return r
+}
+
+func mustCreateDB(t *testing.T) (*sql.DB, func() error) {
+	t.Helper()
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open temporary in-memory DB: %v", err)
+	}
+	return db, db.Close
+}
+
+func TestGetLogs(t *testing.T) {
+	for _, test := range []struct {
+		desc   string
+		logIDs []string
+		logPKs []crypto.PublicKey
+		sths   [][]byte
+	}{
+		{
+			desc:   "no logs",
+			logIDs: []string{},
+		}, {
+			desc:   "one log",
+			logIDs: []string{"monkeys"},
+			logPKs: []crypto.PublicKey{mPK},
+			sths:   [][]byte{mInit},
+		}, {
+			desc:   "two logs",
+			logIDs: []string{"bananas", "monkeys"},
+			logPKs: []crypto.PublicKey{bPK, mPK},
+			sths:   [][]byte{bInit, mInit},
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			d, closeFn := mustCreateDB(t)
+			defer closeFn()
+			ctx := context.Background()
+			// Set up witness.
+			logs := make([]logOpts, len(test.logIDs))
+			for i, logID := range test.logIDs {
+				logs[i] = logOpts{ID: logID,
+					PK: test.logPKs[i],
+				}
+			}
+			w := newWitness(t, d, logs)
+			// Update to an STH for all logs.
+			for i, logID := range test.logIDs {
+				if _, err := w.Update(ctx, logID, test.sths[i], nil); err != nil {
+					t.Errorf("failed to set STH: %v", err)
+				}
+			}
+			// Now see if the witness knows about these logs.
+			knownLogs, err := w.GetLogs()
+			if err != nil {
+				t.Fatalf("couldn't get logs from witness: %v", err)
+			}
+			if len(knownLogs) != len(test.logIDs) {
+				t.Fatalf("got %d logs, want %d", len(knownLogs), len(test.logIDs))
+			}
+			sort.Strings(knownLogs)
+			for i := range knownLogs {
+				if knownLogs[i] != test.logIDs[i] {
+					t.Fatalf("got %q, want %q", test.logIDs[i], knownLogs[i])
+				}
+			}
+		})
+	}
+}
+
+func TestGetSTH(t *testing.T) {
+	for _, test := range []struct {
+		desc      string
+		setID     string
+		setPK     crypto.PublicKey
+		queryID   string
+		queryPK   crypto.PublicKey
+		sth       []byte
+		wantThere bool
+	}{
+		{
+			desc:      "happy path",
+			setID:     "monkeys",
+			setPK:     mPK,
+			queryID:   "monkeys",
+			queryPK:   mPK,
+			sth:       mInit,
+			wantThere: true,
+		}, {
+			desc:      "other log",
+			setID:     "monkeys",
+			setPK:     mPK,
+			queryID:   "bananas",
+			queryPK:   bPK,
+			sth:       mInit,
+			wantThere: false,
+		}, {
+			desc:      "nothing there",
+			setID:     "monkeys",
+			setPK:     mPK,
+			queryID:   "monkeys",
+			queryPK:   mPK,
+			sth:       nil,
+			wantThere: false,
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			d, closeFn := mustCreateDB(t)
+			defer closeFn()
+			ctx := context.Background()
+			// Set up witness.
+			w := newWitness(t, d, []logOpts{{ID: test.setID,
+				PK: test.setPK}})
+			// Set an STH for the log if we want to for this test.
+			if test.sth != nil {
+				if _, err := w.Update(ctx, test.setID, test.sth, nil); err != nil {
+					t.Errorf("failed to set STH: %v", err)
+				}
+			}
+			// Try to get the latest STH.
+			_, err := w.GetSTH(test.queryID)
+			if !test.wantThere && err == nil {
+				t.Fatalf("returned a checkpoint but shouldn't have")
+			}
+			// Check to see if we got something.
+			// TODO(meiklejohn): check witness signature once those
+			// have been implemented.
+			if test.wantThere && err != nil {
+				t.Fatalf("failed to get latest: %v", err)
+			}
+		})
+	}
+}
+
+func TestUpdate(t *testing.T) {
+	for _, test := range []struct {
+		desc     string
+		initSTH  []byte
+		initSize uint64
+		newSTH   []byte
+		pf       [][]byte
+		isGood   bool
+	}{
+		{
+			desc:     "happy path",
+			initSTH:  mInit,
+			initSize: 5,
+			newSTH:   mNext,
+			pf:       consProof,
+			isGood:   true,
+		}, {
+			desc:     "smaller checkpoint",
+			initSTH:  mNext,
+			initSize: 8,
+			newSTH:   mInit,
+			pf:       consProof,
+			isGood:   false,
+		}, {
+			desc:     "garbage proof",
+			initSTH:  mInit,
+			initSize: 5,
+			newSTH:   mNext,
+			pf: [][]byte{
+				dh("aaaa", 2),
+				dh("bbbb", 2),
+				dh("cccc", 2),
+				dh("dddd", 2),
+			},
+			isGood: false,
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			d, closeFn := mustCreateDB(t)
+			defer closeFn()
+			ctx := context.Background()
+			logID := "monkeys"
+			// Set up witness.
+			w := newWitness(t, d, []logOpts{{ID: logID,
+				PK: mPK}})
+			// Set an initial STH for the log.
+			if _, err := w.Update(ctx, logID, test.initSTH, nil); err != nil {
+				t.Errorf("failed to set STH: %v", err)
+			}
+			// Now update from this STH to a newer one.
+			_, err := w.Update(ctx, logID, test.newSTH, test.pf)
+			if test.isGood {
+				if err != nil {
+					t.Fatalf("can't update to new STH: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Fatal("should have gotten an error but didn't")
+				}
+			}
+		})
+	}
+}

--- a/witness/witness/cmd/witness/main.go
+++ b/witness/witness/cmd/witness/main.go
@@ -41,7 +41,7 @@ func main() {
 		glog.Exit("--private_key must not be empty")
 	}
 
-	if len(*configFile) == 0 {
+	if *configFile == "" {
 		glog.Exit("--config_file must not be empty")
 	}
 	fileData, err := ioutil.ReadFile(*configFile)

--- a/witness/witness/cmd/witness/main.go
+++ b/witness/witness/cmd/witness/main.go
@@ -1,0 +1,65 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package witness is designed to make sure the checkpoints of verifiable logs
+// are consistent and store/serve/sign them if so.  It is expected that a separate
+// feeder component would be responsible for the actual interaction with logs.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"io/ioutil"
+
+	"github.com/golang/glog"
+	"github.com/google/certificate-transparency-go/witness/witness/cmd/witness/impl"
+)
+
+var (
+	listenAddr = flag.String("listen", ":8000", "address:port to listen for requests on")
+	dbFile     = flag.String("db_file", ":memory:", "path to a file to be used as sqlite3 storage for checkpoints, e.g. /tmp/chkpts.db")
+	configFile = flag.String("config_file", "example.conf", "path to a JSON config file that specifies the logs followed by this witness")
+	witnessSK  = flag.String("private_key", "", "private signing key for the witness")
+)
+
+func main() {
+	flag.Parse()
+
+	if *witnessSK == "" {
+		glog.Exit("--private_key must not be empty")
+	}
+
+	if len(*configFile) == 0 {
+		glog.Exit("--config_file must not be empty")
+	}
+	fileData, err := ioutil.ReadFile(*configFile)
+	if err != nil {
+		glog.Exitf("Failed to read from config file: %v", err)
+	}
+	var js impl.LogConfig
+	if err := json.Unmarshal(fileData, &js); err != nil {
+		glog.Exitf("Failed to parse config file as proper JSON: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := impl.Main(ctx, impl.ServerOpts{
+		ListenAddr: *listenAddr,
+		DBFile:     *dbFile,
+		PrivKey:    *witnessSK,
+		Config:     js,
+	}); err != nil {
+		glog.Exitf("Error running witness: %v", err)
+	}
+}


### PR DESCRIPTION
This adds a witness that can be used to support CT.  It is similar to the generic witness in trillian-examples, but uses the specific formats required by CT for STHs, signatures, and more.

Things not yet implemented for this first PR are:
- Witness cosigning (currently the witness' secret key is not used).
- A feeder (which is the reason behind the`witness/witness` directory structure; eventually there will be a `witness/feeder` directory too).
