### PR TITLE
[k8s] Use new dry-run flag format

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -188,7 +188,7 @@ steps:
   name: gcr.io/cloud-builders/kubectl
   args:
   - apply
-  - --server-dry-run
+  - --dry-run=server
   - -f=trillian/examples/deployment/kubernetes/ctfe-deployment.yaml
   - -f=trillian/examples/deployment/kubernetes/ctfe-service.yaml
   - -f=trillian/examples/deployment/kubernetes/ctfe-ingress.yaml


### PR DESCRIPTION
Update cloudbuild config to use the new style k8s dry-run flag.

### Checklist

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
