### PR TITLE
[witness] witness and feeder derive logID themselves

### DIFF
--- a/internal/witness/cmd/feeder/main.go
+++ b/internal/witness/cmd/feeder/main.go
@@ -17,26 +17,29 @@ package main
 
 import (
 	"context"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
+	"regexp"
 	"time"
 
 	"github.com/golang/glog"
 	ct "github.com/google/certificate-transparency-go"
 	"github.com/google/certificate-transparency-go/client"
-	"github.com/google/certificate-transparency-go/jsonclient"
 	wh "github.com/google/certificate-transparency-go/internal/witness/client/http"
+	"github.com/google/certificate-transparency-go/jsonclient"
 )
 
 var (
 	logURL   = flag.String("log_url", "", "The endpoint of the log HTTP API")
-	logPK    = flag.String("log_pk", "", "A file containing the PEM-encoded log public key")
-	logID    = flag.String("log_id", "", "The log ID")
+	logPK    = flag.String("log_pk", "", "The base64-encoded log public key")
 	witness  = flag.String("witness_url", "", "The endpoint of the witness HTTP API")
 	interval = flag.Duration("poll", 10*time.Second, "How quickly to poll the log to get updates")
 )
@@ -56,11 +59,11 @@ func main() {
 		glog.Exit("--log_pk must not be empty")
 	}
 	var w wh.Witness
-	pemPK, err := ioutil.ReadFile(*logPK)
+	der, err := base64.StdEncoding.DecodeString(*logPK)
 	if err != nil {
-		glog.Exitf("Failed to read public key from file: %v", err)
+		glog.Exitf("Failed to decode public key: %v", err)
 	}
-	pk, _, _, err := ct.PublicKeyFromPEM(pemPK)
+	pk, err := x509.ParsePKIXPublicKey(der)
 	if err != nil {
 		glog.Exitf("Failed to create public key: %v", err)
 	}
@@ -77,14 +80,20 @@ func main() {
 		}
 	}
 	// Now set up the log client.
-	// TODO(smeiklej): This should be optional as it can be
-	// deterministically derived from the public key.
-	if *logID == "" {
-		glog.Exit("--log_id must not be empty")
+	sha := sha256.Sum256(der)
+	b64 := base64.StdEncoding.EncodeToString(sha[:])
+	reg, err := regexp.Compile("[^a-zA-Z0-9]+")
+	if err != nil {
+		glog.Exitf("failed to create regexp: %v", err)
 	}
+	logID := reg.ReplaceAllString(b64, "")
 	if *logURL == "" {
 		glog.Exit("--log_url must not be empty")
 	}
+	pemPK := pem.EncodeToMemory(&pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: der,
+	})
 	opts := jsonclient.Options{PublicKey: string(pemPK)}
 	c, err := client.New(*logURL, http.DefaultClient, opts)
 	if err != nil {
@@ -92,7 +101,7 @@ func main() {
 	}
 	// Create the feeder with no initial witness STH.
 	feeder := feeder{
-		logID: *logID,
+		logID: logID,
 		c:     c,
 		w:     w,
 	}

--- a/internal/witness/cmd/witness/example_config.yaml
+++ b/internal/witness/cmd/witness/example_config.yaml
@@ -1,4 +1,3 @@
 Logs: 
   - Description: Google 'Argon2021' log
-    LogID: 9lyUL9F3MCIUVBgIMJRWjuNNExkzv98MLyALzE7xZOM
     PubKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAETeBmZOrzZKo4xYktx9gI2chEce3cw/tbr5xkoQlmhB18aKfsxD+MnILgGNl0FOm0eYGilFVi85wLRIOhK8lxKw==


### PR DESCRIPTION
This seems safer than having it be optional for the user to specify the logID, as it ensures the logID always matches the one used by CT.