### PR TITLE
[witness] feeder for all usable CT logs

### DIFF
--- a/internal/witness/client/http/witness_client.go
+++ b/internal/witness/client/http/witness_client.go
@@ -45,7 +45,7 @@ type Witness struct {
 
 // GetLatestSTH returns a recent STH from the witness for the specified log ID.
 func (w Witness) GetLatestSTH(ctx context.Context, logID string) ([]byte, error) {
-	u, err := w.URL.Parse(fmt.Sprintf(wit_api.HTTPGetSTH, url.QueryEscape(logID)))
+	u, err := w.URL.Parse(fmt.Sprintf(wit_api.HTTPGetSTH, url.PathEscape(logID)))
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse URL: %v", err)
 	}
@@ -77,7 +77,7 @@ func (w Witness) Update(ctx context.Context, logID string, sth []byte, proof [][
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal update request: %v", err)
 	}
-	u, err := w.URL.Parse(fmt.Sprintf(wit_api.HTTPUpdate, url.QueryEscape(logID)))
+	u, err := w.URL.Parse(fmt.Sprintf(wit_api.HTTPUpdate, url.PathEscape(logID)))
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse URL: %v", err)
 	}

--- a/internal/witness/cmd/feeder/Dockerfile
+++ b/internal/witness/cmd/feeder/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:buster AS builder
+FROM golang:1.17-alpine AS builder
 
 ARG GOFLAGS=""
 ENV GOFLAGS=$GOFLAGS
@@ -16,10 +16,10 @@ RUN go mod download
 COPY . .
 
 # Build the application
-RUN go build -o /build/bin/witness ./internal/witness/cmd/witness
+RUN go build -o /build/bin/feeder ./internal/witness/cmd/feeder
 
 # Build release image
-FROM golang:buster
+FROM alpine
 
-COPY --from=builder /build/bin/witness /bin/witness
-ENTRYPOINT ["/bin/witness"]
+COPY --from=builder /build/bin/feeder /bin/feeder
+ENTRYPOINT ["/bin/feeder"]

--- a/internal/witness/cmd/feeder/main.go
+++ b/internal/witness/cmd/feeder/main.go
@@ -39,15 +39,12 @@ import (
 var (
 	logList  = flag.String("log_list_url", "https://www.gstatic.com/ct/log_list/v3/log_list.json", "The location of the log list")
 	witness  = flag.String("witness_url", "", "The endpoint of the witness HTTP API")
-	interval = flag.Duration("poll", 10*time.Second, "How quickly to poll the log to get updates")
+	interval = flag.Duration("poll", 30*time.Second, "How quickly to poll the log to get updates")
 )
 
 // feeder contains a map from log IDs to logData and a witness client.
 type feeder struct {
 	logs map[string]logData
-	//logID string
-	//wsth  *ct.SignedTreeHead
-	//c     *client.LogClient
 	w wh.Witness
 }
 
@@ -92,6 +89,7 @@ func populateLogs(logListURL string) (map[string]logData, error) {
 	return logs, nil
 }
 
+// createLogClient creates a CT log client from a public key and URL.
 func createLogClient(key []byte, url string) (*client.LogClient, error) {
 	pemPK := pem.EncodeToMemory(&pem.Block{
 		Type:  "PUBLIC KEY",

--- a/internal/witness/cmd/feeder/main.go
+++ b/internal/witness/cmd/feeder/main.go
@@ -39,13 +39,13 @@ import (
 var (
 	logList  = flag.String("log_list_url", "https://www.gstatic.com/ct/log_list/v3/log_list.json", "The location of the log list")
 	witness  = flag.String("witness_url", "", "The endpoint of the witness HTTP API")
-	interval = flag.Duration("poll", 30*time.Second, "How quickly to poll the log to get updates")
+	interval = flag.Duration("poll", 10*time.Second, "How quickly to poll the log to get updates")
 )
 
 // feeder contains a map from log IDs to logData and a witness client.
 type feeder struct {
 	logs map[string]logData
-	w wh.Witness
+	w    wh.Witness
 }
 
 // logData contains the latest witnessed STH for a log and a log client.

--- a/internal/witness/cmd/witness/example_config.yaml
+++ b/internal/witness/cmd/witness/example_config.yaml
@@ -1,3 +1,57 @@
 Logs: 
   - Description: Google 'Argon2021' log
     PubKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAETeBmZOrzZKo4xYktx9gI2chEce3cw/tbr5xkoQlmhB18aKfsxD+MnILgGNl0FOm0eYGilFVi85wLRIOhK8lxKw==
+  - Description: Google 'Argon2022' log
+    PubKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEeIPc6fGmuBg6AJkv/z7NFckmHvf/OqmjchZJ6wm2qN200keRDg352dWpi7CHnSV51BpQYAj1CQY5JuRAwrrDwg==
+  - Description: Google 'Argon2023' log
+    PubKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE0JCPZFJOQqyEti5M8j13ALN3CAVHqkVM4yyOcKWCu2yye5yYeqDpEXYoALIgtM3TmHtNlifmt+4iatGwLpF3eA==
+  - Description: Google 'Xenon2021' log
+    PubKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAER+1MInu8Q39BwDZ5Rp9TwXhwm3ktvgJzpk/r7dDgGk7ZacMm3ljfcoIvP1E72T8jvyLT1bvdapylajZcTH6W5g==
+  - Description: Google 'Xenon2022' log
+    PubKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE+WS9FSxAYlCVEzg8xyGwOrmPonoV14nWjjETAIdZvLvukPzIWBMKv6tDNlQjpIHNrUcUt1igRPpqoKDXw2MeKw==
+  - Description: Google 'Xenon2023' log
+    PubKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEchY+C+/vzj5g3ZXLY3q5qY1Kb2zcYYCmRV4vg6yU84WI0KV00HuO/8XuQqLwLZPjwtCymeLhQunSxgAnaXSuzg==
+  - Description: Cloudflare 'Nimbus2021' Log
+    PubKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAExpon7ipsqehIeU1bmpog9TFo4Pk8+9oN8OYHl1Q2JGVXnkVFnuuvPgSo2Ep+6vLffNLcmEbxOucz03sFiematg==
+  - Description: Cloudflare 'Nimbus2022' Log
+    PubKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAESLJHTlAycmJKDQxIv60pZG8g33lSYxYpCi5gteI6HLevWbFVCdtZx+m9b+0LrwWWl/87mkNN6xE0M4rnrIPA/w==
+  - Description: Cloudflare 'Nimbus2023' Log
+    PubKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEi/8tkhjLRp0SXrlZdTzNkTd6HqmcmXiDJz3fAdWLgOhjmv4mohvRhwXul9bgW0ODgRwC9UGAgH/vpGHPvIS1qA==
+  - Description: DigiCert Yeti2021 Log
+    PubKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE6J4EbcpIAl1+AkSRsbhoY5oRTj3VoFfaf1DlQkfi7Rbe/HcjfVtrwN8jaC+tQDGjF+dqvKhWJAQ6Q6ev6q9Mew==
+  - Description: DigiCert Yeti2023 Log
+    PubKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEfQ0DsdWYitzwFTvG3F4Nbj8Nv5XIVYzQpkyWsU4nuSYlmcwrAp6m092fsdXEw6w1BAeHlzaqrSgNfyvZaJ9y0Q==
+  - Description: Google 'Icarus' log
+    PubKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAETtK8v7MICve56qTHHDhhBOuV4IlUaESxZryCfk9QbG9co/CqPvTsgPDbCpp6oFtyAHwlDhnvr7JijXRD9Cb2FA==
+  - Description: Google 'Pilot' log
+    PubKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEfahLEimAoz2t01p3uMziiLOl/fHTDM0YDOhBRuiBARsV4UvxG2LdNgoIGLrtCzWE0J5APC2em4JlvR8EEEFMoA==
+  - Description: Google 'Rocketeer' log
+    PubKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIFsYyDzBi7MxCAC/oJBXK7dHjG+1aLCOkHjpoHPqTyghLpzA9BYbqvnV16mAw04vUjyYASVGJCUoI3ctBcJAeg==
+  - Description: Google 'Skydiver' log
+    PubKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEEmyGDvYXsRJsNyXSrYc9DjHsIa2xzb4UR7ZxVoV6mrc9iZB7xjI6+NrOiwH+P/xxkRmOFG6Jel20q37hTh58rA==
+  - Description: DigiCert Log Server
+    PubKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEAkbFvhu7gkAW6MHSrBlpE1n4+HCFRkC5OLAjgqhkTH+/uzSfSl8ois8ZxAD2NgaTZe1M9akhYlrYkes4JECs6A==
+  - Description: DigiCert Log Server 2
+    PubKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEzF05L2a4TH/BLgOhNKPoioYCrkoRxvcmajeb8Dj4XQmNY+gxa4Zmz3mzJTwe33i0qMVp+rfwgnliQ/bM/oFmhA==
+  - Description: DigiCert Nessie2021 Log
+    PubKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE9o7AiwrbGBIX6Lnc47I6OfLMdZnRzKoP5u072nBi6vpIOEooktTi1gNwlRPzGC2ySGfuc1xLDeaA/wSFGgpYFg==
+  - Description: DigiCert Nessie2022 Log
+    PubKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEJyTdaAMoy/5jvg4RR019F2ihEV1McclBKMe2okuX7MCv/C87v+nxsfz1Af+p+0lADGMkmNd5LqZVqxbGvlHYcQ==
+  - Description: DigiCert Nessie2023 Log
+    PubKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEEXu8iQwSCRSf2CbITGpUpBtFVt8+I0IU0d1C36Lfe1+fbwdaI0Z5FktfM2fBoI1bXBd18k2ggKGYGgdZBgLKTg==
+  - Description: Sectigo 'Sabre' CT log
+    PubKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE8m/SiQ8/xfiHHqtls9m7FyOMBg4JVZY9CgiixXGz0akvKD6DEL8S0ERmFe9U4ZiA0M4kbT5nmuk3I85Sk4bagA==
+  - Description: Sectigo 'Mammoth' CT log
+    PubKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE7+R9dC4VFbbpuyOL+yy14ceAmEf7QGlo/EmtYU6DRzwat43f/3swtLr/L8ugFOOt1YU/RFmMjGCL17ixv66MZw==
+  - Description: Let's Encrypt 'Oak2021' log
+    PubKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAELsYzGMNwo8rBIlaklBIdmD2Ofn6HkfrjK0Ukz1uOIUC6Lm0jTITCXhoIdjs7JkyXnwuwYiJYiH7sE1YeKu8k9w==
+  - Description: Let's Encrypt 'Oak2022' log
+    PubKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEhjyxDVIjWt5u9sB/o2S8rcGJ2pdZTGA8+IpXhI/tvKBjElGE5r3de4yAfeOPhqTqqc+o7vPgXnDgu/a9/B+RLg==
+  - Description: Let's Encrypt 'Oak2023' log
+    PubKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEsz0OeL7jrVxEXJu+o4QWQYLKyokXHiPOOKVUL3/TNFFquVzDSer7kZ3gijxzBp98ZTgRgMSaWgCmZ8OD74mFUQ==
+  - Description: Trust Asia CT2021
+    PubKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAESdAfC+h1SZNsSARs188n/dCiNYjGSgkT7avLYe1mmXJzzHhsmxmAorHtOzhDkFgaCSCrUPrXdunK946eyIeSmA==
+  - Description: Trust Asia Log2022
+    PubKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEu1LyFs+SC8555lRtwjdTpPX5OqmzBewdvRbsMKwu+HliNRWOGtgWLuRIa/bGE/GWLlwQ/hkeqBi4Dy3DpIZRlw==
+  - Description: Trust Asia Log2023
+    PubKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEpBFS2xdBTpDUVlESMFL4mwPPTJ/4Lji18Vq6+ji50o8agdqVzDPsIShmxlY+YDYhINnUrF36XBmhBX3+ICP89Q==

--- a/internal/witness/cmd/witness/impl/witness.go
+++ b/internal/witness/cmd/witness/impl/witness.go
@@ -66,7 +66,7 @@ func buildLogMap(config LogConfig) (map[string]ct.SignatureVerifier, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to create signature verifier: %v", err)
 		}
-		// And then to create the (alphanumeric) logID.
+		// And then to create the logID.
 		logID, err := api.LogIDFromPubKey(log.PubKey)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create log id: %v", err)
@@ -104,7 +104,9 @@ func Main(ctx context.Context, opts ServerOpts) error {
 
 	glog.Infof("Starting witness server...")
 	srv := ih.NewServer(w)
-	r := mux.NewRouter()
+	// These options are required as some logID values contain forward
+	// slashes, and will be PathUnescape-d later.
+	r := mux.NewRouter().UseEncodedPath()
 	srv.RegisterHandlers(r)
 	hServer := &http.Server{
 		Addr:    opts.ListenAddr,

--- a/internal/witness/cmd/witness/internal/http/server.go
+++ b/internal/witness/cmd/witness/internal/http/server.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 
 	"github.com/google/certificate-transparency-go/internal/witness/api"
 	"github.com/google/certificate-transparency-go/internal/witness/cmd/witness/internal/witness"
@@ -45,7 +46,10 @@ func NewServer(witness *witness.Witness) *Server {
 // statement and returns a JSON-formatted api.UpdateResponse statement.
 func (s *Server) update(w http.ResponseWriter, r *http.Request) {
 	v := mux.Vars(r)
-	logID := v["logid"]
+	logID, err := url.PathUnescape(v["logid"])
+	if err != nil {
+		http.Error(w, fmt.Sprintf("cannot parse URL: %v", err.Error()), http.StatusBadRequest)
+	}
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("cannot read request body: %v", err.Error()), http.StatusBadRequest)
@@ -80,7 +84,10 @@ func (s *Server) update(w http.ResponseWriter, r *http.Request) {
 // getSTH returns an STH stored for a given log.
 func (s *Server) getSTH(w http.ResponseWriter, r *http.Request) {
 	v := mux.Vars(r)
-	logID := v["logid"]
+	logID, err := url.PathUnescape(v["logid"])
+	if err != nil {
+		http.Error(w, fmt.Sprintf("cannot parse URL: %v", err.Error()), http.StatusBadRequest)
+	}
 	// Get the STH from the witness.
 	sth, err := s.w.GetSTH(logID)
 	if err != nil {

--- a/internal/witness/cmd/witness/main.go
+++ b/internal/witness/cmd/witness/main.go
@@ -29,7 +29,10 @@ import (
 
 var (
 	listenAddr = flag.String("listen", ":8000", "address:port to listen for requests on")
-	dbFile     = flag.String("db_file", ":memory:", "path to a file to be used as sqlite3 storage for STHs, e.g. /tmp/chkpts.db")
+	// If this is run with an in-memory database there is a good chance of the
+	// witness occasionally hitting a race condition and returning a 500.  If
+	// a file is specified this won't happen.
+	dbFile     = flag.String("db_file", ":memory:", "path to a file to be used as sqlite3 storage for STHs, e.g. /tmp/sths.db")
 	configFile = flag.String("config_file", "example_config.yaml", "path to a YAML config file that specifies the logs followed by this witness")
 	witnessSK  = flag.String("private_key", "", "private signing key for the witness")
 )


### PR DESCRIPTION
The previous implementation fed STHs for only one log, but this one fetches all usable logs from a log list and gets/feeds STHs for all of them.  The witness has also been updated to accept STHs for all of these logs (currently hard-coded in its config file).

Aside from the obvious changes in the feeder, this means that to handle logIDs with forward slashes (which weren't tested before 😳), the mux router now keeps the logID in its encoded form (`UseEncodedPath()` in `cmd/witness/impl/witness.go`), and the witness server now decodes these itself (`url.PathUnescape(v["logid"])` in `cmd/witness/internal/http/server.go`).
