### PR TITLE
Use the library in the new merkle repository

### DIFF
--- a/client/ctclient/ctclient.go
+++ b/client/ctclient/ctclient.go
@@ -40,8 +40,8 @@ import (
 	"github.com/google/certificate-transparency-go/loglist"
 	"github.com/google/certificate-transparency-go/x509"
 	"github.com/google/certificate-transparency-go/x509util"
-	"github.com/google/trillian/merkle/logverifier"
-	"github.com/google/trillian/merkle/rfc6962"
+	"github.com/transparency-dev/merkle"
+	"github.com/transparency-dev/merkle/rfc6962"
 )
 
 var (
@@ -347,7 +347,7 @@ func getInclusionProofForHash(ctx context.Context, logClient client.CheckLogClie
 	}
 	if sth != nil {
 		// If we retrieved an STH we can verify the proof.
-		verifier := logverifier.New(rfc6962.DefaultHasher)
+		verifier := merkle.NewLogVerifier(rfc6962.DefaultHasher)
 		if err := verifier.VerifyInclusionProof(rsp.LeafIndex, int64(sth.TreeSize), rsp.AuditPath, sth.SHA256RootHash[:], hash); err != nil {
 			glog.Exitf("Failed to VerifyInclusionProof(%d, %d)=%v", rsp.LeafIndex, sth.TreeSize, err)
 		}
@@ -396,7 +396,7 @@ func getConsistencyProofBetween(ctx context.Context, logClient client.CheckLogCl
 		return
 	}
 	// We have tree hashes so we can verify the proof.
-	verifier := logverifier.New(rfc6962.DefaultHasher)
+	verifier := merkle.NewLogVerifier(rfc6962.DefaultHasher)
 	if err := verifier.VerifyConsistencyProof(first, second, prevHash, treeHash, proof); err != nil {
 		glog.Exitf("Failed to VerifyConsistencyProof(%x @size=%d, %x @size=%d): %v", prevHash, first, treeHash, second, err)
 	}

--- a/ctutil/loginfo.go
+++ b/ctutil/loginfo.go
@@ -28,8 +28,8 @@ import (
 	"github.com/google/certificate-transparency-go/jsonclient"
 	"github.com/google/certificate-transparency-go/loglist"
 	"github.com/google/certificate-transparency-go/x509"
-	"github.com/google/trillian/merkle/logverifier"
-	"github.com/google/trillian/merkle/rfc6962"
+	"github.com/transparency-dev/merkle"
+	"github.com/transparency-dev/merkle/rfc6962"
 )
 
 // LogInfo holds the objects needed to perform per-log verification and
@@ -165,7 +165,7 @@ func (li *LogInfo) VerifyInclusionAt(ctx context.Context, leaf ct.MerkleTreeLeaf
 		return -1, fmt.Errorf("failed to GetProofByHash(sct,size=%d): %v", treeSize, err)
 	}
 
-	verifier := logverifier.New(rfc6962.DefaultHasher)
+	verifier := merkle.NewLogVerifier(rfc6962.DefaultHasher)
 	if err := verifier.VerifyInclusionProof(rsp.LeafIndex, int64(treeSize), rsp.AuditPath, rootHash, leafHash[:]); err != nil {
 		return -1, fmt.Errorf("failed to verify inclusion proof at size %d: %v", treeSize, err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/rs/cors v1.8.0
 	github.com/sergi/go-diff v1.2.0
 	github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce
+	github.com/transparency-dev/merkle v0.0.0-20220104141048-2fe6541b4c0d // indirect
 	go.etcd.io/etcd/client/v3 v3.5.1
 	go.etcd.io/etcd/etcdctl/v3 v3.5.1
 	go.etcd.io/etcd/v3 v3.5.1

--- a/go.sum
+++ b/go.sum
@@ -729,6 +729,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802 h1:uruHq4
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce h1:fb190+cK2Xz/dvi9Hv8eCYJYvIGUTN2/KLq1pT6CjEc=
 github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoik09Xen7gje4m9ERNah1d1PPsVq1VEx9vE4=
+github.com/transparency-dev/merkle v0.0.0-20220104141048-2fe6541b4c0d h1:HZKFUT8f3kjIxyJ1IdJZ8Rw0p2rSu0H1URpS2U0Amac=
+github.com/transparency-dev/merkle v0.0.0-20220104141048-2fe6541b4c0d/go.mod h1:B8FIw5LTq6DaULoHsVFRzYIUDkl8yuSwCdZnOZGKL/A=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=

--- a/internal/witness/cmd/witness/internal/witness/witness.go
+++ b/internal/witness/cmd/witness/internal/witness/witness.go
@@ -32,8 +32,8 @@ import (
 	ct "github.com/google/certificate-transparency-go"
 	"github.com/google/certificate-transparency-go/internal/witness/api"
 	"github.com/google/certificate-transparency-go/tls"
-	"github.com/google/trillian/merkle/logverifier"
-	"github.com/google/trillian/merkle/rfc6962"
+	"github.com/transparency-dev/merkle"
+	"github.com/transparency-dev/merkle/rfc6962"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -202,7 +202,7 @@ func (w *Witness) Update(ctx context.Context, logID string, nextRaw []byte, proo
 	}
 	// The only remaining option is next.Size > prev.Size. This might be
 	// valid so we verify the consistency proof.
-	logV := logverifier.New(rfc6962.DefaultHasher)
+	logV := merkle.NewLogVerifier(rfc6962.DefaultHasher)
 	if err := logV.VerifyConsistencyProof(int64(prev.TreeSize), int64(next.TreeSize), prev.SHA256RootHash[:], next.SHA256RootHash[:], proof); err != nil {
 		// Complain if the STHs aren't consistent.
 		return prevRaw, status.Errorf(codes.FailedPrecondition, "failed to verify consistency proof: %v", err)

--- a/trillian/integration/ct_integration.go
+++ b/trillian/integration/ct_integration.go
@@ -44,9 +44,9 @@ import (
 	"github.com/google/certificate-transparency-go/x509/pkix"
 	"github.com/google/trillian"
 	"github.com/google/trillian/crypto/keyspb"
-	"github.com/google/trillian/merkle/logverifier"
-	"github.com/google/trillian/merkle/rfc6962"
 	"github.com/kylelemons/godebug/pretty"
+	"github.com/transparency-dev/merkle"
+	"github.com/transparency-dev/merkle/rfc6962"
 	"golang.org/x/net/context/ctxhttp"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
@@ -124,7 +124,7 @@ type testInfo struct {
 	adminServer    string
 	stats          *logStats
 	pool           ClientPool
-	verifier       logverifier.LogVerifier
+	verifier       merkle.LogVerifier
 }
 
 func (t *testInfo) checkStats() error {
@@ -264,7 +264,7 @@ func RunCTIntegrationForLog(cfg *configpb.LogConfig, servers, metricsServers, te
 		metricsServers: metricsServers,
 		stats:          stats,
 		pool:           pool,
-		verifier:       logverifier.New(rfc6962.DefaultHasher),
+		verifier:       merkle.NewLogVerifier(rfc6962.DefaultHasher),
 	}
 
 	if err := t.checkStats(); err != nil {
@@ -630,7 +630,7 @@ func RunCTLifecycleForLog(cfg *configpb.LogConfig, servers, metricsServers, admi
 		adminServer:    adminServer,
 		stats:          stats,
 		pool:           pool,
-		verifier:       logverifier.New(rfc6962.DefaultHasher),
+		verifier:       merkle.NewLogVerifier(rfc6962.DefaultHasher),
 	}
 
 	if err := t.checkStats(); err != nil {

--- a/trillian/integration/hammer.go
+++ b/trillian/integration/hammer.go
@@ -32,9 +32,9 @@ import (
 	"github.com/google/certificate-transparency-go/trillian/ctfe"
 	"github.com/google/certificate-transparency-go/trillian/ctfe/configpb"
 	"github.com/google/certificate-transparency-go/x509"
-	"github.com/google/trillian/merkle/logverifier"
-	"github.com/google/trillian/merkle/rfc6962"
 	"github.com/google/trillian/monitoring"
+	"github.com/transparency-dev/merkle"
+	"github.com/transparency-dev/merkle/rfc6962"
 
 	ct "github.com/google/certificate-transparency-go"
 )
@@ -304,7 +304,7 @@ type hammerState struct {
 	// Operations that are required to fix dependencies.
 	nextOp []ctfe.EntrypointName
 	// verifier is the verifier to be used for this log.
-	verifier logverifier.LogVerifier
+	verifier merkle.LogVerifier
 }
 
 func newHammerState(cfg *HammerConfig) (*hammerState, error) {
@@ -338,7 +338,7 @@ func newHammerState(cfg *HammerConfig) (*hammerState, error) {
 	state := hammerState{
 		cfg:      cfg,
 		nextOp:   make([]ctfe.EntrypointName, 0),
-		verifier: logverifier.New(rfc6962.DefaultHasher),
+		verifier: merkle.NewLogVerifier(rfc6962.DefaultHasher),
 	}
 	return &state, nil
 }

--- a/trillian/migrillian/core/controller.go
+++ b/trillian/migrillian/core/controller.go
@@ -30,11 +30,11 @@ import (
 	"github.com/google/certificate-transparency-go/scanner"
 	"github.com/google/certificate-transparency-go/trillian/migrillian/configpb"
 
-	"github.com/google/trillian/merkle/logverifier"
-	"github.com/google/trillian/merkle/rfc6962"
 	"github.com/google/trillian/monitoring"
 	"github.com/google/trillian/util/clock"
 	"github.com/google/trillian/util/election2"
+	"github.com/transparency-dev/merkle"
+	"github.com/transparency-dev/merkle/rfc6962"
 )
 
 var (
@@ -344,7 +344,7 @@ func (c *Controller) verifyConsistency(ctx context.Context, treeSize uint64, roo
 	if err != nil {
 		return err
 	}
-	return logverifier.New(rfc6962.DefaultHasher).VerifyConsistencyProof(
+	return merkle.NewLogVerifier(rfc6962.DefaultHasher).VerifyConsistencyProof(
 		int64(treeSize), int64(sth.TreeSize),
 		rootHash, sth.SHA256RootHash[:], proof)
 }


### PR DESCRIPTION
The version inside we were using in trillian will be deprecated soon. This change keeps us ahead of the curve.
