### PR TITLE
[witness] adding log ID

### DIFF
--- a/internal/witness/cmd/witness/internal/witness/witness.go
+++ b/internal/witness/cmd/witness/internal/witness/witness.go
@@ -101,9 +101,9 @@ func (w *Witness) parse(sthRaw []byte, logID string) (*ct.SignedTreeHead, error)
 		return nil, fmt.Errorf("failed to decode logID: %v", err)
 	}
 	var empty ct.SHA256Hash
-	if reflect.DeepEqual(sth.LogID, empty) {
+	if bytes.Equal(sth.LogID[:], empty[:]) {
 		sth.LogID = idHash
-	} else if !reflect.DeepEqual(sth.LogID, idHash) {
+	} else if !bytes.Equal(sth.LogID[:], idHash[:]) {
 		return nil, status.Errorf(codes.FailedPrecondition, "STH logID = %q, input logID = %q", sth.LogID.Base64String(), logID)
 	}
 	if err := sv.VerifySTHSignature(sth); err != nil {

--- a/internal/witness/cmd/witness/internal/witness/witness.go
+++ b/internal/witness/cmd/witness/internal/witness/witness.go
@@ -92,13 +92,9 @@ func (w *Witness) parse(sthRaw []byte, logID string) (*ct.SignedTreeHead, error)
 	if !ok {
 		return nil, fmt.Errorf("log %q not found", logID)
 	}
-	var sthJSON ct.GetSTHResponse
-	if err := json.Unmarshal(sthRaw, &sthJSON); err != nil {
+	var sth ct.SignedTreeHead
+	if err := json.Unmarshal(sthRaw, &sth); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal json: %v", err)
-	}
-	sth, err := sthJSON.ToSignedTreeHead()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create STH: %v", err)
 	}
 	var idHash ct.SHA256Hash
 	if err := idHash.FromBase64String(logID); err != nil {
@@ -110,10 +106,10 @@ func (w *Witness) parse(sthRaw []byte, logID string) (*ct.SignedTreeHead, error)
 	} else if !reflect.DeepEqual(sth.LogID, idHash) {
 		return nil, status.Errorf(codes.FailedPrecondition, "STH logID = %q, input logID = %q", sth.LogID.Base64String(), logID)
 	}
-	if err := sv.VerifySTHSignature(*sth); err != nil {
+	if err := sv.VerifySTHSignature(sth); err != nil {
 		return nil, fmt.Errorf("failed to verify STH signature: %v", err)
 	}
-	return sth, nil
+	return &sth, nil
 }
 
 // GetLogs returns a list of all logs the witness is aware of.

--- a/internal/witness/cmd/witness/internal/witness/witness_test.go
+++ b/internal/witness/cmd/witness/internal/witness/witness_test.go
@@ -309,19 +309,18 @@ func TestUpdate(t *testing.T) {
 			isGood: false,
 		}, {
 			desc:     "right logID",
-			initSTH:  []byte(`{"log_id":"fRThG/6Ymon8NnpRMQJIgCMgjtrBVnOidYenOB0n6FI=","tree_size":5,"timestamp":0,"sha256_root_hash":"41smjBUiAU70EtKlT6lIOIYtRTYxYXsDB+XHfcvu/BE=","tree_head_signature":"BAMARzBFAiEA0aOuKMp6aXwb5TJiJ6H3nWVxsMgYajyAvbuY5/dkcTUCIBt1VOnAwMfzreOu3RgVs8Xt8XicgaEVH8Vm+TqpXisO"}`),
+			initSTH:  mInit,
 			initSize: 5,
-			newSTH:   mNext,
+			newSTH:   []byte(`{"log_id":"fRThG/6Ymon8NnpRMQJIgCMgjtrBVnOidYenOB0n6FI=","tree_size":8,"timestamp":1,"sha256_root_hash":"V8K9aklZ4EPB+RMOk1/8VsJUdFZR77GDtZUQq84vSbo=","tree_head_signature":"BAMARzBFAiEA2yPvkeRF0cvGOAxx0s+NUf7LT9gumx3MDYob3swzgHgCICGN1tbbu8FqagkE5kV0DSL3CsQWjv095AeL7b+iFMOu"}`),
 			pf:       consProof,
 			isGood:   true,
 		}, {
 			desc:     "wrong logID",
-			initSTH:  []byte(`{"log_id":"aaaaa/6Ymon8NnpRMQJIgCMgjtrBVnOidYenOB0n6FI=","tree_size":5,"timestamp":0,"sha256_root_hash":"41smjBUiAU70EtKlT6lIOIYtRTYxYXsDB+XHfcvu/BE=","tree_head_signature":"BAMARzBFAiEA0aOuKMp6aXwb5TJiJ6H3nWVxsMgYajyAvbuY5/dkcTUCIBt1VOnAwMfzreOu3RgVs8Xt8XicgaEVH8Vm+TqpXisO"}`),
+			initSTH:  mInit,
 			initSize: 5,
-			newSTH:   mNext,
+			newSTH:   []byte(`{"log_id":"aaaaa/6Ymon8NnpRMQJIgCMgjtrBVnOidYenOB0n6FI=","tree_size":8,"timestamp":1,"sha256_root_hash":"V8K9aklZ4EPB+RMOk1/8VsJUdFZR77GDtZUQq84vSbo=","tree_head_signature":"BAMARzBFAiEA2yPvkeRF0cvGOAxx0s+NUf7LT9gumx3MDYob3swzgHgCICGN1tbbu8FqagkE5kV0DSL3CsQWjv095AeL7b+iFMOu"}`),
 			pf:       consProof,
-			// Right now this is fine because ToSignedTreeHead ignores any input logID.
-			isGood: true,
+			isGood:   false,
 		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {


### PR DESCRIPTION
When parsing an STH, the witness now checks if its `LogID` field matches its own idea of what the log ID should be and either returns an error (if they don't match), leaves it alone (if they do match), or fills it in if it was empty.  This makes it easier for a client who is given a (cosigned) STH to know which log public key to use to verify (client code forthcoming).