### PR TITLE
Terminate hammer early if the context is cancelled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 ### Integration
 
- * Breaking change to API for  `integration.HammerCTLog`:
+ * Breaking change to API for `integration.HammerCTLog`:
     * Added `ctx` as first argument, and terminate loop if it becomes cancelled
+
 ## v1.1.2
 
 ### CTFE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## HEAD
 
+### Integration
+
+ * Breaking change to API for  `integration.HammerCTLog`:
+    * Added `ctx` as first argument, and terminate loop if it becomes cancelled
 ## v1.1.2
 
 ### CTFE

--- a/trillian/integration/ct_hammer/main.go
+++ b/trillian/integration/ct_hammer/main.go
@@ -311,7 +311,7 @@ func main() {
 		}
 		go func(cfg integration.HammerConfig) {
 			defer wg.Done()
-			err := integration.HammerCTLog(cfg)
+			err := integration.HammerCTLog(ctx, cfg)
 			results <- result{prefix: cfg.LogCfg.Prefix, err: err}
 		}(cfg)
 	}


### PR DESCRIPTION
This is a breaking change to the API, but I feel OK with that as it is in an integration package, and the fix is simple enough - just pass in a context.
