### PR TITLE
[witness] improving feeder / witness interactions

### DIFF
--- a/internal/witness/cmd/witness/internal/http/server.go
+++ b/internal/witness/cmd/witness/internal/http/server.go
@@ -63,11 +63,10 @@ func (s *Server) update(w http.ResponseWriter, r *http.Request) {
 	// Get the output from the witness.
 	sth, err := s.w.Update(r.Context(), logID, req.STH, req.Proof)
 	if err != nil {
-		c := status.Code(err)
 		// If there was a failed precondition it's possible the caller was
 		// just out of date.  Give the returned STH to help them
 		// form a new request.
-		if c == codes.FailedPrecondition {
+		if c := status.Code(err); c == codes.FailedPrecondition {
 			w.Header().Set("X-Content-Type-Options", "nosniff")
 			w.WriteHeader(httpForCode(c))
 			// The returned STH gets written a few lines below.

--- a/internal/witness/cmd/witness/internal/http/server.go
+++ b/internal/witness/cmd/witness/internal/http/server.go
@@ -63,19 +63,18 @@ func (s *Server) update(w http.ResponseWriter, r *http.Request) {
 	// Get the output from the witness.
 	sth, err := s.w.Update(r.Context(), logID, req.STH, req.Proof)
 	if err != nil {
+		c := status.Code(err)
 		// If there was a failed precondition it's possible the caller was
 		// just out of date.  Give the returned STH to help them
 		// form a new request.
-		if status.Code(err) == codes.FailedPrecondition {
-			// This is the implementation of http.Error except we don't add any trailing newline chars.
-			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		if c == codes.FailedPrecondition {
 			w.Header().Set("X-Content-Type-Options", "nosniff")
-			w.WriteHeader(http.StatusConflict)
-			fmt.Fprint(w, err)
+			w.WriteHeader(httpForCode(c))
+			// The returned STH gets written a few lines below.
+		} else {
+			http.Error(w, fmt.Sprintf("failed to update to new STH: %v", err), httpForCode(http.StatusInternalServerError))
 			return
 		}
-		http.Error(w, fmt.Sprintf("failed to update to new STH: %v", err), httpForCode(http.StatusInternalServerError))
-		return
 	}
 	w.Header().Set("Content-Type", "text/plain")
 	w.Write(sth)


### PR DESCRIPTION
This improves the feeder in two important ways:
- The feeder reaches out to the witness at the start to get its latest STH (as opposed to just assuming it doesn't have one and then failing in its first interaction).
- The witness now properly gives back the latest STH in error cases, which the feeder can use to move forward.  Still need to look into why these errors arise in the first place.