### PR TITLE
[Witness] Catch and avoid DB errors

### DIFF
--- a/internal/witness/cmd/feeder/main.go
+++ b/internal/witness/cmd/feeder/main.go
@@ -198,6 +198,7 @@ func (l *ctLog) feedOnce(ctx context.Context, w *wh.Witness) error {
 	}
 	if errors.Is(err, wh.ErrSTHTooOld) {
 		glog.Infof("STH mismatch at log size %d for %s", wSize, l.name)
+		glog.Infof("%s", wsthRaw)
 	}
 	// Parse the STH it returns.
 	var wsthJSON ct.GetSTHResponse

--- a/internal/witness/cmd/witness/impl/witness.go
+++ b/internal/witness/cmd/witness/impl/witness.go
@@ -98,6 +98,10 @@ func Main(ctx context.Context, opts ServerOpts) error {
 	if err != nil {
 		return fmt.Errorf("failed to connect to DB: %w", err)
 	}
+
+	// Avoid multiple writes colliding and resulting in a "database locked" error.
+	db.SetMaxOpenConns(1)
+
 	// Load log configuration into the map.
 	logMap, err := buildLogMap(opts.Config)
 	if err != nil {


### PR DESCRIPTION
Catch errors when executing update statements, and limit the number of concurrent connections to avoid `database locked` errors.

### Checklist


- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
