### PR TITLE
Make ct_server dockerfile more consistent with other dockerfiles

### DIFF
--- a/trillian/examples/deployment/docker/ctfe/Dockerfile
+++ b/trillian/examples/deployment/docker/ctfe/Dockerfile
@@ -1,15 +1,20 @@
 FROM golang:buster as build
 
-ADD . /go/src/github.com/google/certificate-transparency-go
-WORKDIR /go/src/github.com/google/certificate-transparency-go
-
 ARG GOFLAGS=""
 ENV GOFLAGS=$GOFLAGS
 ENV GO111MODULE=on
-RUN go get ./trillian/ctfe/ct_server
+
+WORKDIR /build
+
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+COPY . .
+
+RUN go build ./trillian/ctfe/ct_server
 
 FROM gcr.io/distroless/base
 
-COPY --from=build /go/bin/ct_server /
+COPY --from=build /build/ct_server /
 
 ENTRYPOINT ["/ct_server"]


### PR DESCRIPTION
The previous implementation was adding code into /go/src/ which hasn't been necessary since modules have been in use.
