### PR TITLE
jsonclient: retry POSTs after getting HTTP 429

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
  * Breaking change to API for `integration.HammerCTLog`:
     * Added `ctx` as first argument, and terminate loop if it becomes cancelled
 
+### JSONClient
+
+  * PostAndParseWithRetry now does backoff-and-retry upon receiving HTTP 429.
+
 ## v1.1.2
 
 ### CTFE

--- a/jsonclient/client.go
+++ b/jsonclient/client.go
@@ -295,6 +295,8 @@ func (c *JSONClient) PostAndParseWithRetry(ctx context.Context, path string, req
 				// Request timeout, retry immediately
 				c.logger.Printf("Request to %s timed out, retrying immediately", c.uri)
 			case httpRsp.StatusCode == http.StatusServiceUnavailable:
+				fallthrough
+			case httpRsp.StatusCode == http.StatusTooManyRequests:
 				var backoff *time.Duration
 				// Retry-After may be either a number of seconds as a int or a RFC 1123
 				// date string (RFC 7231 Section 7.1.3)


### PR DESCRIPTION
Update `PostAndParseWithRetry`, which is used by the `AddChain`
and `AddPreChain` codepaths, to perform its backoff-and-retry logic
when it receives an HTTP 429 (Too Many Requests) rate-limit response,
rather than treating that status code as a fatal error.

### Checklist

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
- [ ] I have updated [documentation](docs/) accordingly.