### PR TITLE
Set `is_master` metric to 0 for when starting up

### DIFF
--- a/trillian/migrillian/core/controller.go
+++ b/trillian/migrillian/core/controller.go
@@ -162,6 +162,7 @@ func (c *Controller) RunWhenMaster(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	metrics.isMaster.Set(0, c.label)
 	defer func(ctx context.Context) {
 		metrics.isMaster.Set(0, c.label)
 		if err := el.Close(ctx); err != nil {


### PR DESCRIPTION
Without this, no metric is exported if the goroutine never gets elected,
so the alerting for "no leader" doesn't work correctly.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
