### PR TITLE
ctclient fails if any unexpected arguments are found

### DIFF
--- a/client/ctclient/cmd/bisect.go
+++ b/client/ctclient/cmd/bisect.go
@@ -29,6 +29,7 @@ func init() {
 		Use:     fmt.Sprintf("bisect %s --timestamp=ts [--chain] [--text=false]", connectionFlags),
 		Aliases: []string{"find-timestamp"},
 		Short:   "Find a log entry by timestamp",
+		Args:    cobra.MaximumNArgs(0),
 		Run: func(cmd *cobra.Command, _ []string) {
 			runBisect(cmd.Context())
 		},

--- a/client/ctclient/cmd/get_consistency_proof.go
+++ b/client/ctclient/cmd/get_consistency_proof.go
@@ -39,6 +39,7 @@ func init() {
 		Use:     fmt.Sprintf("get-consistency-proof %s --size=N --tree_hash=hash --prev_size=N --prev_hash=hash", connectionFlags),
 		Aliases: []string{"getconsistencyproof", "consistency-proof", "consistency"},
 		Short:   "Fetch and verify a consistency proof between two tree states",
+		Args:    cobra.MaximumNArgs(0),
 		Run: func(cmd *cobra.Command, _ []string) {
 			runGetConsistencyProof(cmd.Context())
 		},

--- a/client/ctclient/cmd/get_entries.go
+++ b/client/ctclient/cmd/get_entries.go
@@ -39,6 +39,7 @@ func init() {
 		Use:     fmt.Sprintf("get-entries %s --first=idx [--last=idx]", connectionFlags),
 		Aliases: []string{"getentries", "entries"},
 		Short:   "Fetch a range of entries in the log",
+		Args:    cobra.MaximumNArgs(0),
 		Run: func(cmd *cobra.Command, _ []string) {
 			runGetEntries(cmd.Context())
 		},

--- a/client/ctclient/cmd/get_inclusion_proof.go
+++ b/client/ctclient/cmd/get_inclusion_proof.go
@@ -46,6 +46,7 @@ func init() {
 		Use:     fmt.Sprintf("get-inclusion-proof %s {--leaf_hash=hash | --cert_chain=file} [--timestamp=ts] [--size=N]", connectionFlags),
 		Aliases: []string{"getinclusionproof", "inclusion-proof", "inclusion"},
 		Short:   "Fetch and verify the inclusion proof for an entry",
+		Args:    cobra.MaximumNArgs(0),
 		Run: func(cmd *cobra.Command, _ []string) {
 			runGetInclusionProof(cmd.Context())
 		},

--- a/client/ctclient/cmd/get_roots.go
+++ b/client/ctclient/cmd/get_roots.go
@@ -26,6 +26,7 @@ func init() {
 		Use:     fmt.Sprintf("get-roots %s", connectionFlags),
 		Aliases: []string{"getroots", "roots"},
 		Short:   "Fetch the root certificates accepted by the log",
+		Args:    cobra.MaximumNArgs(0),
 		Run: func(cmd *cobra.Command, _ []string) {
 			runGetRoots(cmd.Context())
 		},

--- a/client/ctclient/cmd/get_sth.go
+++ b/client/ctclient/cmd/get_sth.go
@@ -27,6 +27,7 @@ func init() {
 		Use:     fmt.Sprintf("get-sth %s", connectionFlags),
 		Aliases: []string{"sth"},
 		Short:   "Fetch the latest STH of the log",
+		Args:    cobra.MaximumNArgs(0),
 		Run: func(cmd *cobra.Command, _ []string) {
 			runGetSTH(cmd.Context())
 		},

--- a/client/ctclient/cmd/upload.go
+++ b/client/ctclient/cmd/upload.go
@@ -33,6 +33,7 @@ func init() {
 		Use:     fmt.Sprintf("upload %s --cert_chain=file [--log_mmd=dur]", connectionFlags),
 		Aliases: []string{"add-chain"},
 		Short:   "Submit a certificate (pre-)chain to the log",
+		Args:    cobra.MaximumNArgs(0),
 		Run: func(cmd *cobra.Command, _ []string) {
 			runUpload(cmd.Context())
 		},


### PR DESCRIPTION
All of the parameterization to the subcommands is performed by flags. However, as the subcommands themselves are selected via normal arguments (no hyphens), this can lead to newcomers (e.g. me) believing that the log to fetch from could also be a bare argument. On something like get-entries, there was no way to know that the logname was ignored. Now, this will explode and the user gets the option to reconsider how they are specifying the parameters.

e.g. `go run github.com/google/certificate-transparency-go/client/ctclient@master get-entries submariner --first 35494500 --last 35494590` looks very reasonable and returns data, but it isn't from submariner.

#900