### PR TITLE
Do not print context canceled errors.

### DIFF
--- a/trillian/integration/hammer.go
+++ b/trillian/integration/hammer.go
@@ -1067,7 +1067,7 @@ func (s *hammerState) retryOneOp(ctx context.Context) error {
 	deadline := time.Now().Add(s.cfg.MaxRetryDuration)
 
 	for {
-		if err := ctx.Err(); err == context.Canceled {
+		if err := ctx.Err(); err != nil {
 			return err
 		}
 		start := time.Now()

--- a/trillian/integration/hammer.go
+++ b/trillian/integration/hammer.go
@@ -1088,7 +1088,12 @@ func (s *hammerState) retryOneOp(ctx context.Context) error {
 					glog.Warningf("%s: gave up retrying failed op %v after %v, returning last err: %v", s.cfg.LogCfg.Prefix, ep, s.cfg.MaxRetryDuration, err)
 					return err
 				}
-				glog.Warningf("%s: op %v failed after %v (will retry for %v more): %v", s.cfg.LogCfg.Prefix, ep, period, left, err)
+				// Do not log context canceled errors as this is expected for running
+				// operations when an earlier operation fails. This makes makes logs
+				// easier to sift through.
+				if err != context.Canceled {
+					glog.Warningf("%s: op %v failed after %v (will retry for %v more): %v", s.cfg.LogCfg.Prefix, ep, period, left, err)
+				}
 			} else {
 				return err
 			}

--- a/trillian/integration/hammer.go
+++ b/trillian/integration/hammer.go
@@ -1091,9 +1091,6 @@ func (s *hammerState) retryOneOp(ctx context.Context) error {
 					glog.Warningf("%s: gave up retrying failed op %v after %v, returning last err: %v", s.cfg.LogCfg.Prefix, ep, s.cfg.MaxRetryDuration, err)
 					return err
 				}
-				// Do not log context canceled errors as this is expected for running
-				// operations when an earlier operation fails. This makes makes logs
-				// easier to sift through.
 				glog.Warningf("%s: op %v failed after %v (will retry for %v more): %v", s.cfg.LogCfg.Prefix, ep, period, left, err)
 			} else {
 				return err


### PR DESCRIPTION
When the hammer runs, there are many operations in parallel. When one of them fails, the others are canceled. These are expected errors, and I'd like to remove them from being logged to make the logs easier to sift through.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
