### PR TITLE
Format codes using gofmt with Go version 1.18.1

### DIFF
--- a/fixchain/ratelimiter/limiter.go
+++ b/fixchain/ratelimiter/limiter.go
@@ -22,7 +22,7 @@ import (
 
 // Limiter is a simple rate limiter.
 type Limiter struct {
-	ctx context.Context
+	ctx    context.Context
 	bucket *rate.Limiter
 }
 

--- a/tools.go
+++ b/tools.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build tools
 // +build tools
 
 package tools
@@ -19,9 +20,9 @@ package tools
 import (
 	_ "github.com/fullstorydev/grpcurl/cmd/grpcurl"
 	_ "github.com/golang/mock/mockgen"
+	_ "github.com/google/trillian/cmd/createtree"
 	_ "go.etcd.io/etcd/etcdctl/v3"
 	_ "go.etcd.io/etcd/v3"
 	_ "google.golang.org/protobuf/cmd/protoc-gen-go"
 	_ "google.golang.org/protobuf/proto"
-	_ "github.com/google/trillian/cmd/createtree"
 )

--- a/x509/ptr_sysptr_windows.go
+++ b/x509/ptr_sysptr_windows.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build go1.11
 // +build go1.11
 
 package x509

--- a/x509/ptr_uint_windows.go
+++ b/x509/ptr_uint_windows.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !go1.11
 // +build !go1.11
 
 package x509

--- a/x509/root_bsd.go
+++ b/x509/root_bsd.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build dragonfly || freebsd || netbsd || openbsd
 // +build dragonfly freebsd netbsd openbsd
 
 package x509

--- a/x509/root_cgo_darwin.go
+++ b/x509/root_cgo_darwin.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build cgo && !arm && !arm64 && !ios
 // +build cgo,!arm,!arm64,!ios
 
 package x509

--- a/x509/root_darwin_arm_gen.go
+++ b/x509/root_darwin_arm_gen.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build ignore
 // +build ignore
 
 // Generates root_darwin_armx.go.

--- a/x509/root_darwin_armx.go
+++ b/x509/root_darwin_armx.go
@@ -4,6 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build cgo && darwin && (arm || arm64 || ios)
 // +build cgo
 // +build darwin
 // +build arm arm64 ios

--- a/x509/root_js.go
+++ b/x509/root_js.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build js && wasm
 // +build js,wasm
 
 package x509

--- a/x509/root_nocgo_darwin.go
+++ b/x509/root_nocgo_darwin.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !cgo
 // +build !cgo
 
 package x509

--- a/x509/root_plan9.go
+++ b/x509/root_plan9.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build plan9
 // +build plan9
 
 package x509

--- a/x509/root_unix.go
+++ b/x509/root_unix.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build dragonfly || freebsd || linux || netbsd || openbsd || solaris
 // +build dragonfly freebsd linux netbsd openbsd solaris
 
 package x509

--- a/x509/root_unix_test.go
+++ b/x509/root_unix_test.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build dragonfly || freebsd || linux || netbsd || openbsd || solaris
 // +build dragonfly freebsd linux netbsd openbsd solaris
 
 package x509

--- a/x509/x509_test_import.go
+++ b/x509/x509_test_import.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build ignore
 // +build ignore
 
 // This file is run by the x509 tests to ensure that a program with minimal


### PR DESCRIPTION
`go fmt ./...` was executed to format codes using Go version 1.18.1.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
