### PR TITLE
Replace deprecated golint with revive

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -21,7 +21,7 @@ linters:
     - gocyclo
     - gofmt
     - goimports
-    - golint
+    - revive
     - megacheck
     - misspell
     - govet


### PR DESCRIPTION
This PR replaces the deprecated `golint` tool.

Currently, when the presubmit script is executed, the following warning message appears:
```
running golangci-lint
WARN [runner] The linter 'golint' is deprecated (since v1.41.0) due to: The repository of the linter has been archived by the owner.  Replaced by revive. 
```

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
