### PR TITLE
Remove vendor code section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,12 +127,3 @@ With tools installed, run the following:
 ```bash
 go generate -x ./...  # hunts for //go:generate comments and runs them
 ```
-
-### Updating Vendor Code
-
-The codebase includes a couple of external projects under the `vendor/`
-subdirectory, to ensure that builds use a fixed version (typically because the
-upstream repository does not guarantee back-compatibility between the tip
-`master` branch and the current stable release).  See
-[instructions in the Trillian repo](https://github.com/google/trillian#updating-vendor-code)
-for how to update vendored subtrees.


### PR DESCRIPTION
This PR removes `Updating Vendor Code` section in `README.md` because the `vendor/` subdirectory does not exist anymore.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
