### PR TITLE
Moved tools.go to its own directory to be consistent with other repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Re-generating mock or protobuffer files is only needed if you're changing
 the original files; if you do, you'll need to install the prerequisites:
 
 - tools written in `go` can be installed with a single run of `go install`
-  (courtesy of [`tools.go`](tools.go) and `go.mod`).
+  (courtesy of [`tools.go`](./tools/tools.go) and `go.mod`).
 - `protoc` tool: you'll need [version 3.12.4](https://github.com/protocolbuffers/protobuf/releases/tag/v3.12.4) installed, and `PATH` updated to include its `bin/` directory.
 
 With tools installed, run the following:

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -15,6 +15,8 @@
 //go:build tools
 // +build tools
 
+// Package tools tracks dependencies on binaries not otherwise referenced in this codebase.
+// https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
 package tools
 
 import (


### PR DESCRIPTION
As reported in #936 this should help with vendored directories too.

Fixes #936.