### PR TITLE
Skip consistency check when root is size zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
  * `ctfe.PEMCertPool` type has been moved to `x509util.PEMCertPool` to reduce
    dependencies (#903).
 
+### Migrillian
+
+* #960: Skip consistency check when root is size zero.
+
 ### Misc
 
  * updated golangci-lint to v1.46.1 (developers should update to this version)

--- a/trillian/migrillian/core/controller.go
+++ b/trillian/migrillian/core/controller.go
@@ -337,6 +337,10 @@ func (c *Controller) fetchTail(ctx context.Context, begin uint64) (uint64, error
 // verifyConsistency checks that the provided verified Trillian root is
 // consistent with the CT log's STH.
 func (c *Controller) verifyConsistency(ctx context.Context, treeSize uint64, rootHash []byte, sth *ct.SignedTreeHead) error {
+	if treeSize == 0 {
+		// Any head is consistent with empty root -- unnecessary to request empty proof.
+		return nil
+	}
 	if c.opts.NoConsistencyCheck {
 		glog.Warningf("%s: skipping consistency check", c.label)
 		return nil

--- a/trillian/migrillian/core/controller_test.go
+++ b/trillian/migrillian/core/controller_test.go
@@ -1,0 +1,15 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	ct "github.com/google/certificate-transparency-go"
+)
+
+func TestVerifyConsistencyEmptyHead(t *testing.T) {
+	controller := new(Controller)
+	if controller.verifyConsistency(context.Background(), 0, []byte("abc"), &ct.SignedTreeHead{TreeSize: 100}) != nil {
+		t.Errorf("verifyConsistency should always succeed given empty root")
+	}
+}


### PR DESCRIPTION
Any head is consistent with empty root.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
