### PR TITLE
Migrate off of deprecated ioutil

### DIFF
--- a/client/ctclient/cmd/get_inclusion_proof.go
+++ b/client/ctclient/cmd/get_inclusion_proof.go
@@ -19,7 +19,7 @@ import (
 	"crypto/sha256"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -140,7 +140,7 @@ func getInclusionProofForHash(ctx context.Context, logClient client.CheckLogClie
 }
 
 func chainFromFile(filename string) ([]ct.ASN1Cert, int64) {
-	contents, err := ioutil.ReadFile(filename)
+	contents, err := os.ReadFile(filename)
 	if err != nil {
 		glog.Exitf("Failed to read certificate file: %v", err)
 	}

--- a/client/ctclient/cmd/root.go
+++ b/client/ctclient/cmd/root.go
@@ -21,8 +21,8 @@ import (
 	"crypto/tls"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -108,7 +108,7 @@ func connect(ctx context.Context) *client.LogClient {
 	}
 	opts := jsonclient.Options{UserAgent: "ct-go-ctclient/1.0"}
 	if pubKey != "" {
-		pubkey, err := ioutil.ReadFile(pubKey)
+		pubkey, err := os.ReadFile(pubKey)
 		if err != nil {
 			glog.Exit(err)
 		}

--- a/client/multilog.go
+++ b/client/multilog.go
@@ -19,8 +19,8 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"time"
 
 	ct "github.com/google/certificate-transparency-go"
@@ -43,7 +43,7 @@ func TemporalLogConfigFromFile(filename string) (*configpb.TemporalLogConfig, er
 		return nil, errors.New("log config filename empty")
 	}
 
-	cfgBytes, err := ioutil.ReadFile(filename)
+	cfgBytes, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read log config: %v", err)
 	}

--- a/ctutil/sctcheck/sctcheck.go
+++ b/ctutil/sctcheck/sctcheck.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -79,7 +78,7 @@ func main() {
 			totalInvalid += invalid
 		} else {
 			// Treat the argument as a certificate file to load.
-			data, err := ioutil.ReadFile(arg)
+			data, err := os.ReadFile(arg)
 			if err != nil {
 				glog.Errorf("%s: failed to read data: %v", arg, err)
 				continue

--- a/fixchain/roundtrip_test.go
+++ b/fixchain/roundtrip_test.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -54,7 +54,7 @@ func (rt testRoundTripper) RoundTrip(request *http.Request) (*http.Response, err
 			Request:       request,
 		}, nil
 	case "https://ct.googleapis.com/pilot/ct/v1/add-chain":
-		body, err := ioutil.ReadAll(request.Body)
+		body, err := io.ReadAll(request.Body)
 		request.Body.Close()
 		if err != nil {
 			errStr := fmt.Sprintf("#%d: Could not read request body: %s", rt.testIndex, err.Error())
@@ -200,7 +200,7 @@ func (rt postTestRoundTripper) RoundTrip(request *http.Request) (*http.Response,
 	}
 
 	// Check Body
-	body, err := ioutil.ReadAll(request.Body)
+	body, err := io.ReadAll(request.Body)
 	request.Body.Close()
 	if err != nil {
 		errStr := fmt.Sprintf("#%d: Could not read request body: %s", rt.testIndex, err.Error())

--- a/fixchain/url_cache.go
+++ b/fixchain/url_cache.go
@@ -16,7 +16,7 @@ package fixchain
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"sync"
@@ -74,7 +74,7 @@ func (u *urlCache) getURL(url string) ([]byte, error) {
 		atomic.AddUint32(&u.badStatus, 1)
 		return nil, fmt.Errorf("can't deal with status %d", c.StatusCode)
 	}
-	r, err = ioutil.ReadAll(c.Body)
+	r, err = io.ReadAll(c.Body)
 	if err != nil {
 		atomic.AddUint32(&u.readFail, 1)
 		return nil, err

--- a/internal/witness/client/http/witness_client.go
+++ b/internal/witness/client/http/witness_client.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -57,7 +57,7 @@ func (w Witness) GetLatestSTH(ctx context.Context, logID string) ([]byte, error)
 	} else if resp.StatusCode != 200 {
 		return nil, fmt.Errorf("bad status response: %s", resp.Status)
 	}
-	return ioutil.ReadAll(resp.Body)
+	return io.ReadAll(resp.Body)
 }
 
 // Update attempts to clock the witness forward for the given logID.
@@ -84,7 +84,7 @@ func (w Witness) Update(ctx context.Context, logID string, sth []byte, proof [][
 		return nil, fmt.Errorf("failed to do http request: %v", err)
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read body: %v", err)
 	}

--- a/internal/witness/cmd/client/main.go
+++ b/internal/witness/cmd/client/main.go
@@ -22,9 +22,10 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"sync"
 	"time"
 
@@ -204,7 +205,7 @@ var getByScheme = map[string]func(*url.URL) ([]byte, error){
 	"http":  readHTTP,
 	"https": readHTTP,
 	"file": func(u *url.URL) ([]byte, error) {
-		return ioutil.ReadFile(u.Path)
+		return os.ReadFile(u.Path)
 	},
 }
 
@@ -215,7 +216,7 @@ func readHTTP(u *url.URL) ([]byte, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	return ioutil.ReadAll(resp.Body)
+	return io.ReadAll(resp.Body)
 }
 
 // readURL fetches and reads data from an HTTP-based or filesystem URL.

--- a/internal/witness/cmd/feeder/main.go
+++ b/internal/witness/cmd/feeder/main.go
@@ -23,7 +23,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -247,7 +247,7 @@ var getByScheme = map[string]func(*url.URL) ([]byte, error){
 	"http":  readHTTP,
 	"https": readHTTP,
 	"file": func(u *url.URL) ([]byte, error) {
-		return ioutil.ReadFile(u.Path)
+		return os.ReadFile(u.Path)
 	},
 }
 
@@ -258,7 +258,7 @@ func readHTTP(u *url.URL) ([]byte, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	return ioutil.ReadAll(resp.Body)
+	return io.ReadAll(resp.Body)
 }
 
 // readURL fetches and reads data from an HTTP-based or filesystem URL.

--- a/internal/witness/cmd/witness/config/config.go
+++ b/internal/witness/cmd/witness/config/config.go
@@ -19,9 +19,10 @@ import (
 	"encoding/base64"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
+	"os"
 
 	"github.com/golang/glog"
 	"github.com/google/certificate-transparency-go/internal/witness/cmd/witness/impl"
@@ -64,7 +65,7 @@ func main() {
 	if err != nil {
 		glog.Exitf("Failed to marshal log config into YAML: %v", err)
 	}
-	if err := ioutil.WriteFile(*configFile, data, 0644); err != nil {
+	if err := os.WriteFile(*configFile, data, 0644); err != nil {
 		glog.Exitf("Failed to write config to file: %v", err)
 	}
 }
@@ -73,7 +74,7 @@ var getByScheme = map[string]func(*url.URL) ([]byte, error){
 	"http":  readHTTP,
 	"https": readHTTP,
 	"file": func(u *url.URL) ([]byte, error) {
-		return ioutil.ReadFile(u.Path)
+		return os.ReadFile(u.Path)
 	},
 }
 
@@ -84,7 +85,7 @@ func readHTTP(u *url.URL) ([]byte, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	return ioutil.ReadAll(resp.Body)
+	return io.ReadAll(resp.Body)
 }
 
 // readURL fetches and reads data from an HTTP-based or filesystem URL.

--- a/internal/witness/cmd/witness/internal/http/server.go
+++ b/internal/witness/cmd/witness/internal/http/server.go
@@ -18,7 +18,7 @@ package http
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -50,7 +50,7 @@ func (s *Server) update(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		http.Error(w, fmt.Sprintf("cannot parse URL: %v", err.Error()), http.StatusBadRequest)
 	}
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("cannot read request body: %v", err.Error()), http.StatusBadRequest)
 		return

--- a/internal/witness/cmd/witness/internal/http/server_test.go
+++ b/internal/witness/cmd/witness/internal/http/server_test.go
@@ -21,7 +21,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -207,7 +207,7 @@ func TestGetLogs(t *testing.T) {
 				t.Errorf("status code got %d, want %d", got, want)
 			}
 			if len(test.wantBody) > 0 {
-				body, err := ioutil.ReadAll(resp.Body)
+				body, err := io.ReadAll(resp.Body)
 				if err != nil {
 					t.Fatalf("failed to read body: %v", err)
 				}

--- a/internal/witness/cmd/witness/main.go
+++ b/internal/witness/cmd/witness/main.go
@@ -20,7 +20,7 @@ package main
 import (
 	"context"
 	"flag"
-	"io/ioutil"
+	"os"
 
 	"github.com/golang/glog"
 	"github.com/google/certificate-transparency-go/internal/witness/cmd/witness/impl"
@@ -47,7 +47,7 @@ func main() {
 	if *configFile == "" {
 		glog.Exit("--config_file must not be empty")
 	}
-	fileData, err := ioutil.ReadFile(*configFile)
+	fileData, err := os.ReadFile(*configFile)
 	if err != nil {
 		glog.Exitf("Failed to read from config file: %v", err)
 	}

--- a/jsonclient/client.go
+++ b/jsonclient/client.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"math/rand"
 	"net/http"
@@ -191,7 +191,7 @@ func (c *JSONClient) GetAndParse(ctx context.Context, path string, params map[st
 	}
 
 	// Read everything now so http.Client can reuse the connection.
-	body, err := ioutil.ReadAll(httpRsp.Body)
+	body, err := io.ReadAll(httpRsp.Body)
 	httpRsp.Body.Close()
 	if err != nil {
 		return nil, nil, RspError{Err: fmt.Errorf("failed to read response body: %v", err), StatusCode: httpRsp.StatusCode, Body: body}
@@ -237,7 +237,7 @@ func (c *JSONClient) PostAndParse(ctx context.Context, path string, req, rsp int
 	// Read all of the body, if there is one, so that the http.Client can do Keep-Alive.
 	var body []byte
 	if httpRsp != nil {
-		body, err = ioutil.ReadAll(httpRsp.Body)
+		body, err = io.ReadAll(httpRsp.Body)
 		httpRsp.Body.Close()
 	}
 	if err != nil {

--- a/loglist/findlog/main.go
+++ b/loglist/findlog/main.go
@@ -22,8 +22,8 @@ import (
 	"encoding/base64"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/golang/glog"
@@ -50,7 +50,7 @@ func main() {
 
 	var pubKey crypto.PublicKey
 	if *logListPubKeyFile != "" {
-		data, err := ioutil.ReadFile(*logListPubKeyFile)
+		data, err := os.ReadFile(*logListPubKeyFile)
 		if err != nil {
 			glog.Exitf("Failed to read public key: %v", err)
 		}

--- a/preload/preloader/preloader.go
+++ b/preload/preloader/preloader.go
@@ -20,7 +20,6 @@ import (
 	"encoding/gob"
 	"flag"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"sync"
@@ -141,7 +140,7 @@ func main() {
 		defer sctFile.Close()
 		sctFileWriter = sctFile
 	} else {
-		sctFileWriter = ioutil.Discard
+		sctFileWriter = io.Discard
 	}
 
 	sctWriter := zlib.NewWriter(sctFileWriter)

--- a/scanner/scanlog/scanlog.go
+++ b/scanner/scanlog/scanlog.go
@@ -19,10 +19,10 @@ import (
 	"encoding/base64"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math/big"
 	"net/http"
+	"os"
 	"path"
 	"regexp"
 	"time"
@@ -82,7 +82,7 @@ func dumpData(entry *ct.RawLogEntry) {
 	if len(entry.Cert.Data) > 0 {
 		name := fmt.Sprintf("%s-%014d-%s.der", prefix, entry.Index, suffix)
 		filename := path.Join(*dumpDir, name)
-		if err := ioutil.WriteFile(filename, entry.Cert.Data, 0644); err != nil {
+		if err := os.WriteFile(filename, entry.Cert.Data, 0644); err != nil {
 			log.Printf("Failed to dump data for %s at index %d: %v", prefix, entry.Index, err)
 		}
 	}
@@ -90,7 +90,7 @@ func dumpData(entry *ct.RawLogEntry) {
 	for ii := 0; ii < len(entry.Chain); ii++ {
 		name := fmt.Sprintf("%s-%014d-%02d.der", prefix, entry.Index, ii)
 		filename := path.Join(*dumpDir, name)
-		if err := ioutil.WriteFile(filename, entry.Chain[ii].Data, 0644); err != nil {
+		if err := os.WriteFile(filename, entry.Chain[ii].Data, 0644); err != nil {
 			log.Printf("Failed to dump data for CA at index %d: %v", entry.Index, err)
 		}
 	}

--- a/serialization_test.go
+++ b/serialization_test.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/pem"
-	"io/ioutil"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -324,13 +324,13 @@ func TestUnmarshalSCT(t *testing.T) {
 func TestX509MerkleTreeLeafHash(t *testing.T) {
 	certFile := "./testdata/test-cert.pem"
 	sctFile := "./testdata/test-cert.proof"
-	certB, err := ioutil.ReadFile(certFile)
+	certB, err := os.ReadFile(certFile)
 	if err != nil {
 		t.Fatalf("Failed to read file %s: %v", certFile, err)
 	}
 	certDER, _ := pem.Decode(certB)
 
-	sctB, err := ioutil.ReadFile(sctFile)
+	sctB, err := os.ReadFile(sctFile)
 	if err != nil {
 		t.Fatalf("Failed to read file %s: %v", sctFile, err)
 	}

--- a/submission/hammer/main.go
+++ b/submission/hammer/main.go
@@ -21,9 +21,10 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
+	"os"
 	"sync"
 	"time"
 
@@ -45,11 +46,11 @@ var (
 
 func main() {
 	flag.Parse()
-	certData, err := ioutil.ReadFile("submission/hammer/testdata/precert.der")
+	certData, err := os.ReadFile("submission/hammer/testdata/precert.der")
 	if err != nil {
 		log.Fatal(err)
 	}
-	interimData, err := ioutil.ReadFile("submission/hammer/testdata/intermediate.der")
+	interimData, err := os.ReadFile("submission/hammer/testdata/intermediate.der")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -102,7 +103,7 @@ func main() {
 				var scts submission.SCTBatch
 				err = json.NewDecoder(resp.Body).Decode(&scts)
 				if err != nil {
-					responseData, err := ioutil.ReadAll(resp.Body)
+					responseData, err := io.ReadAll(resp.Body)
 					if err != nil {
 						log.Fatalf("Unable to parse response: %v", err)
 					}

--- a/submission/loglist_manager_test.go
+++ b/submission/loglist_manager_test.go
@@ -16,7 +16,6 @@ package submission
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -107,7 +106,7 @@ First:
 	}
 
 	sampleLogListUpdate := strings.Replace(testdata.SampleLogList, "ct.googleapis.com/racketeer/", "ct.googleapis.com/racketeer/v2/", 1)
-	if err := ioutil.WriteFile(f, []byte(sampleLogListUpdate), 0644); err != nil {
+	if err := os.WriteFile(f, []byte(sampleLogListUpdate), 0644); err != nil {
 		t.Fatalf("unable to update Log-list data file: %q", err)
 	}
 	select {

--- a/submission/loglist_refresher_test.go
+++ b/submission/loglist_refresher_test.go
@@ -17,7 +17,6 @@ package submission
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"regexp"
@@ -33,7 +32,7 @@ import (
 // createTempFile creates a file in the system's temp directory and writes data to it.
 // It returns the name of the file.
 func createTempFile(data string) (string, error) {
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	if err != nil {
 		return "", err
 	}
@@ -212,8 +211,8 @@ func TestNewLogListRefresherUpdate(t *testing.T) {
 			}
 
 			// Simulate Log list update.
-			if err := ioutil.WriteFile(f, []byte(tc.llNext), 0755); err != nil {
-				t.Fatalf("ioutil.WriteFile(%q, %q) = %q, want nil", f, tc.llNext, err)
+			if err := os.WriteFile(f, []byte(tc.llNext), 0755); err != nil {
+				t.Fatalf("os.WriteFile(%q, %q) = %q, want nil", f, tc.llNext, err)
 			}
 
 			beforeRefresh := time.Now()

--- a/submission/proxy_test.go
+++ b/submission/proxy_test.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -123,7 +122,7 @@ Init:
 	}
 
 	sampleLogListUpdate := strings.Replace(testdata.SampleLogList, "ct.googleapis.com/racketeer/", "ct.googleapis.com/racketeer/v2/", 1)
-	if err := ioutil.WriteFile(f, []byte(sampleLogListUpdate), 0644); err != nil {
+	if err := os.WriteFile(f, []byte(sampleLogListUpdate), 0644); err != nil {
 		t.Fatalf("unable to update Log-list data file: %q", err)
 	}
 	ctx, cancel = context.WithTimeout(context.Background(), time.Second)

--- a/trillian/ctfe/config.go
+++ b/trillian/ctfe/config.go
@@ -18,7 +18,7 @@ import (
 	"crypto"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/golang/glog"
@@ -45,7 +45,7 @@ type ValidatedLogConfig struct {
 // filename, which should contain text or binary-encoded protobuf configuration
 // data.
 func LogConfigFromFile(filename string) ([]*configpb.LogConfig, error) {
-	cfgBytes, err := ioutil.ReadFile(filename)
+	cfgBytes, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +81,7 @@ func ToMultiLogConfig(cfg []*configpb.LogConfig, beSpec string) *configpb.LogMul
 // filename, which should contain text or binary-encoded protobuf configuration data.
 // Does not do full validation of the config but checks that it is non empty.
 func MultiLogConfigFromFile(filename string) (*configpb.LogMultiConfig, error) {
-	cfgBytes, err := ioutil.ReadFile(filename)
+	cfgBytes, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/trillian/ctfe/config_test.go
+++ b/trillian/ctfe/config_test.go
@@ -19,7 +19,7 @@ import (
 	"encoding/base64"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -51,9 +51,9 @@ func mustMarshalAny(pb proto.Message) *anypb.Any {
 }
 
 func mustReadPublicKey(path string) *keyspb.PublicKey {
-	keyPEM, err := ioutil.ReadFile(path)
+	keyPEM, err := os.ReadFile(path)
 	if err != nil {
-		panic(fmt.Sprintf("ioutil.ReadFile(%q): %v", path, err))
+		panic(fmt.Sprintf("os.ReadFile(%q): %v", path, err))
 	}
 	block, _ := pem.Decode(keyPEM)
 	pubKey, err := x509.ParsePKIXPublicKey(block.Bytes)

--- a/trillian/ctfe/handlers.go
+++ b/trillian/ctfe/handlers.go
@@ -23,7 +23,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -375,7 +375,7 @@ func (li *logInfo) getSTH(ctx context.Context) (*ct.SignedTreeHead, error) {
 
 // ParseBodyAsJSONChain tries to extract cert-chain out of request.
 func ParseBodyAsJSONChain(r *http.Request) (ct.AddChainRequest, error) {
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		glog.V(1).Infof("Failed to read request body: %v", err)
 		return ct.AddChainRequest{}, err

--- a/trillian/ctfe/handlers_test.go
+++ b/trillian/ctfe/handlers_test.go
@@ -26,7 +26,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -1470,7 +1469,7 @@ func TestGetProofByHash(t *testing.T) {
 		if got, want := w.Header().Get("Cache-Control"), "public"; !strings.Contains(got, want) {
 			t.Errorf("proofByHash(%q): Cache-Control response header = %q, want %q", test.req, got, want)
 		}
-		jsonData, err := ioutil.ReadAll(w.Body)
+		jsonData, err := io.ReadAll(w.Body)
 		if err != nil {
 			t.Errorf("failed to read response body: %v", err)
 			continue
@@ -1826,7 +1825,7 @@ func TestGetSTHConsistency(t *testing.T) {
 		if got, want := w.Header().Get("Cache-Control"), "public"; !strings.Contains(got, want) {
 			t.Errorf("getSTHConsistency(%q): Cache-Control response header = %q, want %q", test.req, got, want)
 		}
-		jsonData, err := ioutil.ReadAll(w.Body)
+		jsonData, err := io.ReadAll(w.Body)
 		if err != nil {
 			t.Errorf("failed to read response body: %v", err)
 			continue

--- a/trillian/integration/ct_hammer/main.go
+++ b/trillian/integration/ct_hammer/main.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"os"
@@ -123,7 +122,7 @@ func copierGeneratorFactory(ctx context.Context) integration.GeneratorFactory {
 	uri := *srcLogURI
 	var opts jsonclient.Options
 	if *srcPubKey != "" {
-		pubkey, err := ioutil.ReadFile(*srcPubKey)
+		pubkey, err := os.ReadFile(*srcPubKey)
 		if err != nil {
 			glog.Exit(err)
 		}

--- a/trillian/integration/ct_integration.go
+++ b/trillian/integration/ct_integration.go
@@ -25,10 +25,11 @@ import (
 	"crypto/sha256"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"net"
 	"net/http"
+	"os"
 	"path/filepath"
 	"reflect"
 	"regexp"
@@ -792,7 +793,7 @@ func timeFromMS(ts uint64) time.Time {
 
 // GetChain retrieves a certificate from a file of the given name and directory.
 func GetChain(dir, path string) ([]ct.ASN1Cert, error) {
-	certdata, err := ioutil.ReadFile(filepath.Join(dir, path))
+	certdata, err := os.ReadFile(filepath.Join(dir, path))
 	if err != nil {
 		return nil, fmt.Errorf("failed to load certificate: %v", err)
 	}
@@ -849,7 +850,7 @@ func buildNewPrecertData(cert, issuer *x509.Certificate, signer crypto.Signer) (
 // MakeSigner creates a signer using the private key in the test directory.
 func MakeSigner(testDir string) (crypto.Signer, error) {
 	fileName := filepath.Join(testDir, "int-ca.privkey.pem")
-	keyPEM, err := ioutil.ReadFile(fileName)
+	keyPEM, err := os.ReadFile(fileName)
 	if err != nil {
 		return nil, fmt.Errorf("error reading file %q: %w", fileName, err)
 	}
@@ -912,7 +913,7 @@ func (ls *logStats) fromServer(ctx context.Context, servers string) (*logStats, 
 			return nil, fmt.Errorf("getting stats failed: %v", err)
 		}
 		defer httpRsp.Body.Close()
-		defer ioutil.ReadAll(httpRsp.Body)
+		defer io.ReadAll(httpRsp.Body)
 		if httpRsp.StatusCode != http.StatusOK {
 			return nil, fmt.Errorf("got HTTP Status %q", httpRsp.Status)
 		}

--- a/trillian/integration/ct_integration_test.go
+++ b/trillian/integration/ct_integration_test.go
@@ -19,8 +19,8 @@ import (
 	"encoding/pem"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -165,7 +165,7 @@ func TestInProcessCTIntegration(t *testing.T) {
 }
 
 func loadPublicKey(path string) ([]byte, error) {
-	pemKey, err := ioutil.ReadFile(path)
+	pemKey, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/trillian/integration/hammer_test.go
+++ b/trillian/integration/hammer_test.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"testing"
@@ -179,7 +178,7 @@ type fakeCTServer struct {
 }
 
 func (s *fakeCTServer) addChain(w http.ResponseWriter, req *http.Request) {
-	body, err := ioutil.ReadAll(req.Body)
+	body, err := io.ReadAll(req.Body)
 	if err != nil {
 		writeErr(w, http.StatusInternalServerError, err)
 		return

--- a/trillian/migrillian/core/config.go
+++ b/trillian/migrillian/core/config.go
@@ -17,7 +17,7 @@ package core
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/google/certificate-transparency-go/trillian/migrillian/configpb"
 	"google.golang.org/protobuf/encoding/prototext"
@@ -27,7 +27,7 @@ import (
 // LoadConfigFromFile reads MigrillianConfig from the given filename, which
 // should contain text-protobuf encoded configuration data.
 func LoadConfigFromFile(filename string) (*configpb.MigrillianConfig, error) {
-	cfgBytes, err := ioutil.ReadFile(filename)
+	cfgBytes, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/x509/name_constraints_test.go
+++ b/x509/name_constraints_test.go
@@ -12,7 +12,6 @@ import (
 	"encoding/hex"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"net"
 	"net/url"
@@ -2002,7 +2001,7 @@ func TestConstraintCases(t *testing.T) {
 }
 
 func writePEMsToTempFile(certs []*Certificate) *os.File {
-	file, err := ioutil.TempFile("", "name_constraints_test")
+	file, err := os.CreateTemp("", "name_constraints_test")
 	if err != nil {
 		panic("cannot create tempfile")
 	}

--- a/x509/root_darwin.go
+++ b/x509/root_darwin.go
@@ -13,7 +13,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/user"
@@ -185,7 +184,7 @@ func verifyCertWithSystem(cert *Certificate) bool {
 		Type: "CERTIFICATE", Bytes: cert.Raw,
 	})
 
-	f, err := ioutil.TempFile("", "cert")
+	f, err := os.CreateTemp("", "cert")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "can't create temporary file for cert: %v", err)
 		return false
@@ -224,7 +223,7 @@ func verifyCertWithSystem(cert *Certificate) bool {
 // settings. This code is only used for cgo-disabled builds.
 func getCertsWithTrustPolicy() (map[string]bool, error) {
 	set := map[string]bool{}
-	td, err := ioutil.TempDir("", "x509trustpolicy")
+	td, err := os.MkdirTemp("", "x509trustpolicy")
 	if err != nil {
 		return nil, err
 	}

--- a/x509/root_darwin_arm_gen.go
+++ b/x509/root_darwin_arm_gen.go
@@ -25,9 +25,10 @@ import (
 	"flag"
 	"fmt"
 	"go/format"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
+	"os"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -64,7 +65,7 @@ func main() {
 	if err != nil {
 		log.Fatal("source format error:", err)
 	}
-	if err := ioutil.WriteFile(*output, source, 0644); err != nil {
+	if err := os.WriteFile(*output, source, 0644); err != nil {
 		log.Fatal(err)
 	}
 }
@@ -133,7 +134,7 @@ func fetchCertIDs() ([]certID, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/x509/root_plan9.go
+++ b/x509/root_plan9.go
@@ -8,7 +8,6 @@
 package x509
 
 import (
-	"io/ioutil"
 	"os"
 )
 
@@ -25,7 +24,7 @@ func loadSystemRoots() (*CertPool, error) {
 	roots := NewCertPool()
 	var bestErr error
 	for _, file := range certFiles {
-		data, err := ioutil.ReadFile(file)
+		data, err := os.ReadFile(file)
 		if err == nil {
 			roots.AppendCertsFromPEM(data)
 			return roots, nil

--- a/x509/root_unix.go
+++ b/x509/root_unix.go
@@ -8,7 +8,6 @@
 package x509
 
 import (
-	"io/ioutil"
 	"os"
 )
 
@@ -46,7 +45,7 @@ func loadSystemRoots() (*CertPool, error) {
 
 	var firstErr error
 	for _, file := range files {
-		data, err := ioutil.ReadFile(file)
+		data, err := os.ReadFile(file)
 		if err == nil {
 			roots.AppendCertsFromPEM(data)
 			break
@@ -62,7 +61,7 @@ func loadSystemRoots() (*CertPool, error) {
 	}
 
 	for _, directory := range dirs {
-		fis, err := ioutil.ReadDir(directory)
+		fis, err := os.ReadDir(directory)
 		if err != nil {
 			if firstErr == nil && !os.IsNotExist(err) {
 				firstErr = err
@@ -71,7 +70,7 @@ func loadSystemRoots() (*CertPool, error) {
 		}
 		rootsAdded := false
 		for _, fi := range fis {
-			data, err := ioutil.ReadFile(directory + "/" + fi.Name())
+			data, err := os.ReadFile(directory + "/" + fi.Name())
 			if err == nil && roots.AppendCertsFromPEM(data) {
 				rootsAdded = true
 			}

--- a/x509/x509_test.go
+++ b/x509/x509_test.go
@@ -18,10 +18,10 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"net"
 	"net/url"
+	"os"
 	"os/exec"
 	"reflect"
 	"runtime"
@@ -2864,7 +2864,7 @@ func TestParseCertificateFail(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			data, err := ioutil.ReadFile(test.in)
+			data, err := os.ReadFile(test.in)
 			if err != nil {
 				t.Fatalf("failed to read test data: %v", err)
 			}

--- a/x509util/crlcheck/crlcheck.go
+++ b/x509util/crlcheck/crlcheck.go
@@ -19,7 +19,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"time"
@@ -172,7 +172,7 @@ func processCert(data []byte, caCerts []*x509.Certificate) error {
 		if err != nil || rsp.StatusCode != http.StatusOK {
 			return fmt.Errorf("failed to get CRL from %q: %v", crldp, err)
 		}
-		body, err := ioutil.ReadAll(rsp.Body)
+		body, err := io.ReadAll(rsp.Body)
 		if err != nil {
 			return fmt.Errorf("failed to read CRL from %q: %v", crldp, err)
 		}

--- a/x509util/pem_cert_pool.go
+++ b/x509util/pem_cert_pool.go
@@ -19,7 +19,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/golang/glog"
 	"github.com/google/certificate-transparency-go/x509"
@@ -93,7 +93,7 @@ func (p *PEMCertPool) AppendCertsFromPEM(pemCerts []byte) (ok bool) {
 
 // AppendCertsFromPEMFile adds certs from a file that contains concatenated PEM data.
 func (p *PEMCertPool) AppendCertsFromPEMFile(pemFile string) error {
-	pemData, err := ioutil.ReadFile(pemFile)
+	pemData, err := os.ReadFile(pemFile)
 	if err != nil {
 		return fmt.Errorf("failed to load PEM certs file: %v", err)
 	}


### PR DESCRIPTION
Migrate all uses of the deprecated `ioutil` package to the corresponding methods in `io` or `os`.

### Checklist

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
