### PR TITLE
Add missing license header

### DIFF
--- a/trillian/migrillian/core/controller_test.go
+++ b/trillian/migrillian/core/controller_test.go
@@ -1,3 +1,17 @@
+// Copyright 2018 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package core
 
 import (


### PR DESCRIPTION
Adds missing license header to `trillian/migrillian/core/controller_test.go`.

Used same date as the corresponding `.../controller.go` file.

### Checklist


- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
