### PR TITLE
client/ctclient: Fix doubled https in --log_name

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,6 +8,7 @@
 #
 # Please keep the list sorted.
 
+Alex Cohn <alex@alexcohn.com>
 Comodo CA Limited
 Ed Maste <emaste@freebsd.org>
 Fiaz Hossain <fiaz.hossain@salesforce.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -24,6 +24,7 @@
 
 Adam Eijdenberg <eijdenberg@google.com> <adam.eijdenberg@gmail.com>
 Al Cutter <al@google.com>
+Alex Cohn <alex@alexcohn.com>
 Ben Laurie <benl@google.com> <ben@links.org>
 Chris Kennelly <ckennelly@google.com> <ckennelly@ckennelly.com>
 David Drysdale <drysdale@google.com>

--- a/client/ctclient/cmd/root.go
+++ b/client/ctclient/cmd/root.go
@@ -137,7 +137,7 @@ func connect(ctx context.Context) *client.LogClient {
 			}
 			klog.Exitf("Multiple logs with name like %q found in loglist: %s", logName, strings.Join(logNames, ","))
 		}
-		uri = "https://" + logs[0].URL
+		uri = logs[0].URL
 		if opts.PublicKey == "" {
 			opts.PublicKeyDER = logs[0].Key
 		}


### PR DESCRIPTION
The URL format in Google's v1 and v3 log lists is different - v1 doesn't include the https:// protocol, but v3 does. The fix in aff1cefb14e0eb8d6bb32948ffa1c3c4bb0dd1d0 to use v3 log lists didn't account for this change.

Fixes #989

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.

I'm not sure if either of these apply; this is a simple bugfix that should have been done as part of aff1cefb14e0eb8d6bb32948ffa1c3c4bb0dd1d0. It doesn't need additional documentation imo.
