### PR TITLE
[Scanner] Retry on errors fetching updated STHs

### DIFF
--- a/scanner/fetcher.go
+++ b/scanner/fetcher.go
@@ -238,7 +238,7 @@ func (f *Fetcher) updateSTH(ctx context.Context) error {
 	return f.sthBackoff.Retry(ctx, func() error {
 		sth, err := f.client.GetSTH(ctx)
 		if err != nil {
-			return err
+			return backoff.RetriableErrorf("GetSTH: %v", err)
 		}
 		klog.V(2).Infof("%s: Got STH with %d certs", f.uri, sth.TreeSize)
 


### PR DESCRIPTION
This causes the scanner to retry when the log client fails to fetch an updated STH when running in continuous mode.

For #1019 

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
