### PR TITLE
x509: allow empty integer in lax mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@
 
  * Remove v2 log list package files.
 
- ### Misc
+### Misc
 
  * Updated golangci-lint to v1.50.1 (developers should update to this version).
  * Bump Go version from 1.17 to 1.19.
+ * asn1: Allow empty integers in lax mode.
 
 ## v1.1.4
 

--- a/asn1/asn1.go
+++ b/asn1/asn1.go
@@ -106,13 +106,13 @@ func parseBool(bytes []byte, fieldName string) (ret bool, err error) {
 // checkInteger returns nil if the given bytes are a valid DER-encoded
 // INTEGER and an error otherwise.
 func checkInteger(bytes []byte, lax bool, fieldName string) error {
+	if lax {
+		return nil
+	}
 	if len(bytes) == 0 {
 		return StructuralError{"empty integer", fieldName}
 	}
 	if len(bytes) == 1 {
-		return nil
-	}
-	if lax {
 		return nil
 	}
 	if (bytes[0] == 0 && bytes[1]&0x80 == 0) || (bytes[0] == 0xff && bytes[1]&0x80 == 0x80) {

--- a/asn1/asn1.go
+++ b/asn1/asn1.go
@@ -21,6 +21,7 @@
 //     ISO8859-1.
 //   - checkInteger() allows integers that are not minimally encoded (and
 //     so are not correct DER).
+//   - checkInteger() treats zero-length integers as equal to zero.
 //   - parseObjectIdentifier() allows zero-length OIDs.
 //   - Better diagnostics on which particular field causes errors.
 package asn1

--- a/asn1/asn1_test.go
+++ b/asn1/asn1_test.go
@@ -59,7 +59,7 @@ var int64TestData = []int64Test{
 	{[]byte{0xff}, true, true, -1},
 	{[]byte{0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, true, true, -9223372036854775808},
 	{[]byte{0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, false, false, 0},
-	{[]byte{}, false, false, 0},
+	{[]byte{}, false, true, 0},
 	{[]byte{0x00, 0x7f}, false, true, 127},
 	{[]byte{0xff, 0xf0}, false, true, -16},
 }
@@ -68,7 +68,7 @@ func TestParseInt64(t *testing.T) {
 	for i, test := range int64TestData {
 		ret, err := parseInt64(test.in, false, "fieldname")
 		if (err == nil) != test.ok {
-			t.Errorf("#%d: Incorrect error result (did fail? %v, expected: %v)", i, err == nil, test.ok)
+			t.Errorf("#%d: Incorrect error result (success? %t, expected: %t)", i, err == nil, test.ok)
 		}
 		if test.ok && ret != test.out {
 			t.Errorf("#%d: Bad result: %v (expected %v)", i, ret, test.out)
@@ -76,7 +76,7 @@ func TestParseInt64(t *testing.T) {
 
 		ret, err = parseInt64(test.in, true, "fieldname")
 		if (err == nil) != test.okLax {
-			t.Errorf("#%d: Incorrect lax error result (did fail? %v, expected: %v)", i, err == nil, test.okLax)
+			t.Errorf("#%d: Incorrect lax error result (success? %t, expected: %t)", i, err == nil, test.okLax)
 		}
 		if test.okLax && ret != test.out {
 			t.Errorf("#%d: Bad lax result: %v (expected %v)", i, ret, test.out)
@@ -101,7 +101,7 @@ var int32TestData = []int32Test{
 	{[]byte{0xff}, true, true, -1},
 	{[]byte{0x80, 0x00, 0x00, 0x00}, true, true, -2147483648},
 	{[]byte{0x80, 0x00, 0x00, 0x00, 0x00}, false, false, 0},
-	{[]byte{}, false, false, 0},
+	{[]byte{}, false, true, 0},
 	{[]byte{0x00, 0x7f}, false, true, 127},
 	{[]byte{0xff, 0xf0}, false, true, -16},
 }
@@ -110,7 +110,7 @@ func TestParseInt32(t *testing.T) {
 	for i, test := range int32TestData {
 		ret, err := parseInt32(test.in, false, "fieldname")
 		if (err == nil) != test.ok {
-			t.Errorf("#%d: Incorrect error result (did fail? %v, expected: %v)", i, err == nil, test.ok)
+			t.Errorf("#%d: Incorrect error result (did fail? %t, expected: %t)", i, err == nil, test.ok)
 		}
 		if test.ok && int32(ret) != test.out {
 			t.Errorf("#%d: Bad result: %v (expected %v)", i, ret, test.out)
@@ -118,7 +118,7 @@ func TestParseInt32(t *testing.T) {
 
 		ret, err = parseInt32(test.in, true, "fieldname")
 		if (err == nil) != test.okLax {
-			t.Errorf("#%d: Incorrect lax error result (did fail? %v, expected: %v)", i, err == nil, test.okLax)
+			t.Errorf("#%d: Incorrect lax error result (success? %t, expected: %t)", i, err == nil, test.okLax)
 		}
 		if test.okLax && int32(ret) != test.out {
 			t.Errorf("#%d: Bad lax result: %v (expected %v)", i, ret, test.out)
@@ -138,7 +138,7 @@ var bigIntTests = []struct {
 	{[]byte{0x00, 0xff}, true, true, "255"},
 	{[]byte{0xff, 0x00}, true, true, "-256"},
 	{[]byte{0x01, 0x00}, true, true, "256"},
-	{[]byte{}, false, false, ""},
+	{[]byte{}, false, true, "0"},
 	{[]byte{0x00, 0x7f}, false, true, "127"},
 	{[]byte{0xff, 0xf0}, false, true, "-16"},
 }
@@ -167,7 +167,7 @@ func TestParseBigInt(t *testing.T) {
 
 		ret, err = parseBigInt(test.in, true, "fieldname")
 		if (err == nil) != test.okLax {
-			t.Errorf("#%d: Incorrect lax error result (did fail? %v, expected: %v)", i, err == nil, test.okLax)
+			t.Errorf("#%d: Incorrect lax error result (success? %t, expected: %t)", i, err == nil, test.okLax)
 		}
 		if test.okLax {
 			if ret.String() != test.base10 {

--- a/x509/pkcs1.go
+++ b/x509/pkcs1.go
@@ -47,7 +47,7 @@ type pkcs1PublicKey struct {
 // This kind of key is commonly encoded in PEM blocks of type "RSA PRIVATE KEY".
 func ParsePKCS1PrivateKey(der []byte) (*rsa.PrivateKey, error) {
 	var priv pkcs1PrivateKey
-	rest, err := asn1.Unmarshal(der, &priv)
+	rest, err := asn1.UnmarshalWithParams(der, &priv, "lax")
 	if len(rest) > 0 {
 		return nil, asn1.SyntaxError{Msg: "trailing data"}
 	}
@@ -138,7 +138,7 @@ func MarshalPKCS1PrivateKey(key *rsa.PrivateKey) []byte {
 // This kind of key is commonly encoded in PEM blocks of type "RSA PUBLIC KEY".
 func ParsePKCS1PublicKey(der []byte) (*rsa.PublicKey, error) {
 	var pub pkcs1PublicKey
-	rest, err := asn1.Unmarshal(der, &pub)
+	rest, err := asn1.UnmarshalWithParams(der, &pub, "lax")
 	if err != nil {
 		if _, err := asn1.Unmarshal(der, &publicKeyInfo{}); err == nil {
 			return nil, errors.New("x509: failed to parse public key (use ParsePKIXPublicKey instead for this key format)")

--- a/x509/pkcs8.go
+++ b/x509/pkcs8.go
@@ -35,7 +35,7 @@ type pkcs8 struct {
 // This kind of key is commonly encoded in PEM blocks of type "PRIVATE KEY".
 func ParsePKCS8PrivateKey(der []byte) (key interface{}, err error) {
 	var privKey pkcs8
-	if _, err := asn1.Unmarshal(der, &privKey); err != nil {
+	if _, err := asn1.UnmarshalWithParams(der, &privKey, "lax"); err != nil {
 		if _, err := asn1.Unmarshal(der, &ecPrivateKey{}); err == nil {
 			return nil, errors.New("x509: failed to parse private key (use ParseECPrivateKey instead for this key format)")
 		}
@@ -55,7 +55,7 @@ func ParsePKCS8PrivateKey(der []byte) (key interface{}, err error) {
 	case privKey.Algo.Algorithm.Equal(OIDPublicKeyECDSA):
 		bytes := privKey.Algo.Parameters.FullBytes
 		namedCurveOID := new(asn1.ObjectIdentifier)
-		if _, err := asn1.Unmarshal(bytes, namedCurveOID); err != nil {
+		if _, err := asn1.UnmarshalWithParams(bytes, namedCurveOID, "lax"); err != nil {
 			namedCurveOID = nil
 		}
 		key, err = parseECPrivateKey(namedCurveOID, privKey.PrivateKey)
@@ -69,7 +69,7 @@ func ParsePKCS8PrivateKey(der []byte) (key interface{}, err error) {
 			return nil, errors.New("x509: invalid Ed25519 private key parameters")
 		}
 		var curvePrivateKey []byte
-		if _, err := asn1.Unmarshal(privKey.PrivateKey, &curvePrivateKey); err != nil {
+		if _, err := asn1.UnmarshalWithParams(privKey.PrivateKey, &curvePrivateKey, "lax"); err != nil {
 			return nil, fmt.Errorf("x509: invalid Ed25519 private key: %v", err)
 		}
 		if l := len(curvePrivateKey); l != ed25519.SeedSize {


### PR DESCRIPTION
This allows empty integers when the "lax" tag is passed, treating them as zero. This came up for Let's Encrypt when parsing a dump of private key files, many of which were mis-encoded (the Version field of some RSA private keys was zero-length, among other problems).

This also turns on lax-mode parsing for ParsePKCS1PrivateKey and ParsePKCS8PrivateKey.

### Checklist

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
- [x] I have updated [documentation](docs/) accordingly.
