### PR TITLE
Add Go 1.20 Compatibility

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -35,12 +35,3 @@ linters:
 issues:
   # Don't turn off any checks by default. We can do this explicitly if needed.
   exclude-use-default: false
-  # List of regexps of issue texts to exclude.
-  #
-  # But independently of this option we use default exclude patterns,
-  # it can be disabled by `exclude-use-default: false`.
-  # To list all excluded by default patterns execute `golangci-lint run --help`
-  #
-  # Default: https://golangci-lint.run/usage/false-positives/#default-exclusions
-  exclude:
-    - "rand.Seed has been deprecated since Go 1.20 and an alternative has been available since Go 1.0"

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -35,3 +35,12 @@ linters:
 issues:
   # Don't turn off any checks by default. We can do this explicitly if needed.
   exclude-use-default: false
+  # List of regexps of issue texts to exclude.
+  #
+  # But independently of this option we use default exclude patterns,
+  # it can be disabled by `exclude-use-default: false`.
+  # To list all excluded by default patterns execute `golangci-lint run --help`
+  #
+  # Default: https://golangci-lint.run/usage/false-positives/#default-exclusions
+  exclude:
+    - "rand.Seed has been deprecated since Go 1.20 and an alternative has been available since Go 1.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
  ### Misc
 
- * Updated golangci-lint to v1.50.1 (developers should update to this version).
+ * Updated golangci-lint to v1.51.1 (developers should update to this version).
  * Bump Go version from 1.17 to 1.19.
 
 ## v1.1.4

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ pull requests for review.
 
 ```bash
 # Install golangci-lint
-go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.1
 
 # Run code generation, build, test and linters
 ./scripts/presubmit.sh

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -79,7 +79,7 @@ steps:
 
       # Cache all the modules we'll need too
       go mod download
-      go test -i ./...
+      go test ./...
 
       # Wait for trillian logserver to be up
       until nc -z deployment_trillian-log-server_1 8090; do echo .; sleep 5; done

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -76,6 +76,9 @@ steps:
         go.etcd.io/etcd/v3 go.etcd.io/etcd/etcdctl/v3 \
         github.com/fullstorydev/grpcurl/cmd/grpcurl
 
+      # Generate all protoc and mockgen files
+      go generate -run="protoc" ./...
+      go generate -run="mockgen" ./...
 
       # Cache all the modules we'll need too
       go mod download
@@ -90,6 +93,7 @@ steps:
   id: 'default_test'
   env:
     - 'GOFLAGS='
+    - 'PRESUBMIT_OPTS=--no-generate'
     - 'TRILLIAN_LOG_SERVERS=deployment_trillian-log-server_1:8090'
     - 'TRILLIAN_LOG_SERVER_1=deployment_trillian-log-server_1:8090'
   waitFor: ['ci-ready']

--- a/cloudbuild_master.yaml
+++ b/cloudbuild_master.yaml
@@ -79,7 +79,7 @@ steps:
 
       # Cache all the modules we'll need too
       go mod download
-      go test -i ./...
+      go test ./...
 
       # Wait for trillian logserver to be up
       until nc -z deployment_trillian-log-server_1 8090; do echo .; sleep 5; done

--- a/cloudbuild_master.yaml
+++ b/cloudbuild_master.yaml
@@ -76,6 +76,9 @@ steps:
         go.etcd.io/etcd/v3 go.etcd.io/etcd/etcdctl/v3 \
         github.com/fullstorydev/grpcurl/cmd/grpcurl
 
+      # Generate all protoc and mockgen files
+      go generate -run="protoc" ./...
+      go generate -run="mockgen" ./...
 
       # Cache all the modules we'll need too
       go mod download
@@ -90,6 +93,7 @@ steps:
   id: 'default_test'
   env:
     - 'GOFLAGS='
+    - 'PRESUBMIT_OPTS=--no-generate'
     - 'TRILLIAN_LOG_SERVERS=deployment_trillian-log-server_1:8090'
     - 'TRILLIAN_LOG_SERVER_1=deployment_trillian-log-server_1:8090'
   waitFor: ['ci-ready']

--- a/cloudbuild_tag.yaml
+++ b/cloudbuild_tag.yaml
@@ -79,7 +79,7 @@ steps:
 
       # Cache all the modules we'll need too
       go mod download
-      go test -i ./...
+      go test ./...
 
       # Wait for trillian logserver to be up
       until nc -z deployment_trillian-log-server_1 8090; do echo .; sleep 5; done

--- a/cloudbuild_tag.yaml
+++ b/cloudbuild_tag.yaml
@@ -76,6 +76,9 @@ steps:
         go.etcd.io/etcd/v3 go.etcd.io/etcd/etcdctl/v3 \
         github.com/fullstorydev/grpcurl/cmd/grpcurl
 
+      # Generate all protoc and mockgen files
+      go generate -run="protoc" ./...
+      go generate -run="mockgen" ./...
 
       # Cache all the modules we'll need too
       go mod download
@@ -90,6 +93,7 @@ steps:
   id: 'default_test'
   env:
     - 'GOFLAGS='
+    - 'PRESUBMIT_OPTS=--no-generate'
     - 'TRILLIAN_LOG_SERVERS=deployment_trillian-log-server_1:8090'
     - 'TRILLIAN_LOG_SERVER_1=deployment_trillian-log-server_1:8090'
   waitFor: ['ci-ready']

--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -11,7 +11,7 @@ ENV GO111MODULE=on
 RUN apt-get update && apt-get -y install build-essential curl docker-compose lsof netcat unzip wget xxd
 
 RUN cd /usr/bin && curl -L -O https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && mv jq-linux64 /usr/bin/jq && chmod +x /usr/bin/jq
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.50.1
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.51.1
 RUN mkdir protoc && \
     (cd protoc && \
     PROTOC_VERSION=3.20.1 && \

--- a/schedule/schedule_test.go
+++ b/schedule/schedule_test.go
@@ -48,6 +48,7 @@ func TestEvery(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
+			test := test
 			t.Parallel()
 			ctx, cancel := context.WithTimeout(context.Background(), test.timeout)
 			defer cancel()

--- a/trillian/integration/ct_hammer/main.go
+++ b/trillian/integration/ct_hammer/main.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"math/rand"
 	"net/http"
 	"os"
 	"strings"
@@ -64,7 +63,6 @@ var (
 	parallelFetch   = flag.Int("parallel_fetch", 2, "Number of concurrent GetEntries fetches")
 
 	metricsEndpoint     = flag.String("metrics_endpoint", "", "Endpoint for serving metrics; if left empty, metrics will not be exposed")
-	seed                = flag.Int64("seed", -1, "Seed for random number generation")
 	logConfig           = flag.String("log_config", "", "File holding log config in JSON")
 	mmd                 = flag.Duration("mmd", 2*time.Minute, "Default MMD for logs")
 	operations          = flag.Uint64("operations", ^uint64(0), "Number of operations to perform")
@@ -177,11 +175,6 @@ func main() {
 	if *logConfig == "" {
 		klog.Exit("Test aborted as no log config provided (via --log_config)")
 	}
-	if *seed == -1 {
-		*seed = time.Now().UTC().UnixNano() & 0xFFFFFFFF
-	}
-	fmt.Printf("Today's test has been brought to you by the letters C and T and the number %#x\n", *seed)
-	rand.Seed(*seed)
 
 	cfg, err := ctfe.LogConfigFromFile(*logConfig)
 	if err != nil {

--- a/trillian/integration/ct_integration_test.go
+++ b/trillian/integration/ct_integration_test.go
@@ -19,7 +19,6 @@ import (
 	"encoding/pem"
 	"flag"
 	"fmt"
-	"math/rand"
 	"os"
 	"strings"
 	"testing"
@@ -38,7 +37,6 @@ var (
 	httpServers    = flag.String("ct_http_servers", "localhost:8092", "Comma-separated list of (assumed interchangeable) servers, each as address:port")
 	metricsServers = flag.String("ct_metrics_servers", "localhost:8093", "Comma-separated list of (assumed interchangeable) metrics servers, each as address:port")
 	testDir        = flag.String("testdata_dir", "testdata", "Name of directory with test data")
-	seed           = flag.Int64("seed", -1, "Seed for random number generation")
 	logConfig      = flag.String("log_config", "", "File holding log config in JSON")
 	mmd            = flag.Duration("mmd", 30*time.Second, "MMD for tested logs")
 	skipStats      = flag.Bool("skip_stats", false, "Skip checks of expected log statistics")
@@ -49,11 +47,6 @@ func commonSetup(t *testing.T) []*configpb.LogConfig {
 	if *logConfig == "" {
 		t.Skip("Integration test skipped as no log config provided")
 	}
-	if *seed == -1 {
-		*seed = time.Now().UTC().UnixNano() & 0xFFFFFFFF
-	}
-	fmt.Printf("Today's test has been brought to you by the letters C and T and the number %#x\n", *seed)
-	rand.Seed(*seed)
 
 	cfgs, err := ctfe.LogConfigFromFile(*logConfig)
 	if err != nil {


### PR DESCRIPTION
<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->
The cloud build starts using [Go 1.20](https://go.dev/doc/go1.20). The changes below are necessary to support Go 1.20.

- Fix deprecated go test -i flag
- Bump golangci-lint from v1.50.1 to v1.51.1
- Fix loopclosure: loop variable test captured by func literal
- Remove deprecated global random number generator `rand.Seed` in trillian/integration

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
