### PR TITLE
Remove random seed from integration/ct_hammer

### DIFF
--- a/trillian/integration/ct_hammer/main.go
+++ b/trillian/integration/ct_hammer/main.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"math/rand"
 	"net/http"
 	"os"
 	"strings"
@@ -64,7 +63,6 @@ var (
 	parallelFetch   = flag.Int("parallel_fetch", 2, "Number of concurrent GetEntries fetches")
 
 	metricsEndpoint     = flag.String("metrics_endpoint", "", "Endpoint for serving metrics; if left empty, metrics will not be exposed")
-	seed                = flag.Int64("seed", -1, "Seed for random number generation")
 	logConfig           = flag.String("log_config", "", "File holding log config in JSON")
 	mmd                 = flag.Duration("mmd", 2*time.Minute, "Default MMD for logs")
 	operations          = flag.Uint64("operations", ^uint64(0), "Number of operations to perform")
@@ -177,11 +175,6 @@ func main() {
 	if *logConfig == "" {
 		klog.Exit("Test aborted as no log config provided (via --log_config)")
 	}
-	if *seed == -1 {
-		*seed = time.Now().UTC().UnixNano() & 0xFFFFFFFF
-	}
-	fmt.Printf("Today's test has been brought to you by the letters C and T and the number %#x\n", *seed)
-	rand.Seed(*seed)
 
 	cfg, err := ctfe.LogConfigFromFile(*logConfig)
 	if err != nil {

--- a/trillian/integration/ct_integration_test.go
+++ b/trillian/integration/ct_integration_test.go
@@ -38,7 +38,6 @@ var (
 	httpServers    = flag.String("ct_http_servers", "localhost:8092", "Comma-separated list of (assumed interchangeable) servers, each as address:port")
 	metricsServers = flag.String("ct_metrics_servers", "localhost:8093", "Comma-separated list of (assumed interchangeable) metrics servers, each as address:port")
 	testDir        = flag.String("testdata_dir", "testdata", "Name of directory with test data")
-	seed           = flag.Int64("seed", -1, "Seed for random number generation")
 	logConfig      = flag.String("log_config", "", "File holding log config in JSON")
 	mmd            = flag.Duration("mmd", 30*time.Second, "MMD for tested logs")
 	skipStats      = flag.Bool("skip_stats", false, "Skip checks of expected log statistics")
@@ -49,11 +48,6 @@ func commonSetup(t *testing.T) []*configpb.LogConfig {
 	if *logConfig == "" {
 		t.Skip("Integration test skipped as no log config provided")
 	}
-	if *seed == -1 {
-		*seed = time.Now().UTC().UnixNano() & 0xFFFFFFFF
-	}
-	fmt.Printf("Today's test has been brought to you by the letters C and T and the number %#x\n", *seed)
-	rand.Seed(*seed)
 
 	cfgs, err := ctfe.LogConfigFromFile(*logConfig)
 	if err != nil {


### PR DESCRIPTION
`rand.Seed` is deprecated as of `go1.20`, but I also suspect that setting this seed didn't do what it was intended to; deeper down, `crypto/rand` is used to source entropy (mainly the cert generator), but this will be unaffected by the seed in `math/rand`.

Helps toward #1035 .

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
