### PR TITLE
change wrong path

### DIFF
--- a/trillian/integration/demo-script.sh
+++ b/trillian/integration/demo-script.sh
@@ -27,8 +27,8 @@ echo 'Reset MySQL database'
 yes | ${GOPATH}/src/github.com/google/trillian/scripts/resetdb.sh
 
 echo 'Building Trillian log code'
-go build github.com/google/trillian/server/trillian_log_server/
-go build github.com/google/trillian/server/trillian_log_signer/
+go build github.com/google/trillian/cmd/trillian_log_server/
+go build github.com/google/trillian/cmd/trillian_log_signer/
 
 echo 'Start a Trillian Log server (do in separate terminal)'
 ./trillian_log_server --rpc_endpoint=localhost:6962 --http_endpoint=localhost:6963 --logtostderr &


### PR DESCRIPTION
from go build github.com/google/trillian/server/trillian_log_server/ to go build github.com/google/trillian/cmd/trillian_log_server/

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
