### PR TITLE
If a public key has been configured for a log, check that it is consistent with the private key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## HEAD
 
+### Public/Private Key Consistency
+
+ * #1044: If a public key has been configured for a log, check that it is consistent with the private key.
+
 ### Cleanup
 
  * Remove v2 log list package files.

--- a/trillian/ctfe/instance.go
+++ b/trillian/ctfe/instance.go
@@ -17,6 +17,9 @@ package ctfe
 import (
 	"context"
 	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/rsa"
 	"errors"
 	"fmt"
 	"net/http"
@@ -125,6 +128,26 @@ func setUpLogInfo(ctx context.Context, opts InstanceOptions) (*logInfo, error) {
 		var err error
 		if signer, err = keys.NewSigner(ctx, vCfg.PrivKey); err != nil {
 			return nil, fmt.Errorf("failed to load private key: %v", err)
+		}
+
+		// If a public key has been configured for a log, check that it is consistent with the private key.
+		if vCfg.PubKey != nil {
+			switch pub := vCfg.PubKey.(type) {
+			case *ecdsa.PublicKey:
+				if !pub.Equal(signer.Public()) {
+					return nil, errors.New("public key is not consistent with private key")
+				}
+			case ed25519.PublicKey:
+				if !pub.Equal(signer.Public()) {
+					return nil, errors.New("public key is not consistent with private key")
+				}
+			case *rsa.PublicKey:
+				if !pub.Equal(signer.Public()) {
+					return nil, errors.New("public key is not consistent with private key")
+				}
+			default:
+				return nil, errors.New("failed to verify consistency of public key with private key")
+			}
 		}
 	}
 

--- a/trillian/docs/ManualDeployment.md
+++ b/trillian/docs/ManualDeployment.md
@@ -299,8 +299,9 @@ Each Log instance needs configuration for:
        }
      }
      ```
- - `public_key`: The corresponding public key for the log instance.  (This is
-   not actually used by the CTFE, but is worth including for reference and for
+ - `public_key`: The corresponding public key for the log instance.  When
+   both the public and private keys are specified, they will be checked for
+   consistency.  (The public key is also worth including for reference and for
    use by test tools.)
 
 **Cross-check**: The config file should be accepted at start-up by the


### PR DESCRIPTION
Sectigo's Sabre log was recently migrated from SuperDuper to Trillian.  Due to a configuration mistake, the CTFE server signed STHs and SCTs using the wrong private key for a period of approximately 20 hours, until the problem was detected and corrected.  Before and during this [incident](https://groups.google.com/a/chromium.org/g/ct-policy/c/9U3t2k5vugM), the correct public key was specified in the `public_key` field in the CTFE configuration, but that field currently [is not actually used by the CTFE](https://github.com/google/certificate-transparency-go/blob/master/trillian/docs/ManualDeployment.md#ctfe-configuration:~:text=is%20not%20actually%20used%20by%20the%20CTFE).

This PR adds a check for the consistency of the `public_key` and `private_key`, when both of these fields are specified in the CTFE configuration.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [x] I have updated [documentation](docs/) accordingly.
