### PR TITLE
Escape forward slashes in certificate Subject names when used as user quota id strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 
  * Updated golangci-lint to v1.51.1 (developers should update to this version).
  * Bump Go version from 1.17 to 1.19.
+ * #1059: Escape forward slashes in certificate Subject names when used as user quota id strings.
 
 ## v1.1.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@
 
 ### Chrome CT Policy Update
  * #906: Update chromepolicy.go to follow the updated Chrome CT policy.
- 
+
+### Misc
+ * #1059: Escape forward slashes in certificate Subject names when used as user quota id strings.
+
 ## v1.1.6
 
 ## Dependency update
@@ -29,11 +32,10 @@
 
  * Remove v2 log list package files.
 
- ### Misc
+### Misc
 
  * Updated golangci-lint to v1.51.1 (developers should update to this version).
  * Bump Go version from 1.17 to 1.19.
- * #1059: Escape forward slashes in certificate Subject names when used as user quota id strings.
 
 ## v1.1.4
 

--- a/trillian/ctfe/cert_quota.go
+++ b/trillian/ctfe/cert_quota.go
@@ -18,6 +18,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"strings"
 
 	"github.com/google/certificate-transparency-go/x509"
 )
@@ -38,5 +39,5 @@ const CertificateQuotaUserPrefix = "@intermediate"
 // See tests for examples.
 func QuotaUserForCert(c *x509.Certificate) string {
 	spkiHash := sha256.Sum256(c.RawSubjectPublicKeyInfo)
-	return fmt.Sprintf("%s %s %s", CertificateQuotaUserPrefix, c.Subject.String(), hex.EncodeToString(spkiHash[0:5]))
+	return fmt.Sprintf("%s %s %s", CertificateQuotaUserPrefix, strings.ReplaceAll(c.Subject.String(), "/", "%2F"), hex.EncodeToString(spkiHash[0:5]))
 }


### PR DESCRIPTION
add-chain requests to Sectigo's Dodo log are failing for leaf certificates issued by certain Actalis CAs, with errors of this form:
`AddChain handler error: backend QueueLeaves request failed: rpc error: code = ResourceExhausted desc = quota exhausted: invalid name: "quotas/users/@intermediate CN=Actalis Authentication Root CA,O=Actalis S.p.A./03358520967,L=Milan,C=IT 25d4913cf5/write/config"`
Note the forward slash character in the "O" field ("Actalis S.p.A./03358520967").

Example certs: https://crt.sh/?id=9077408990, https://crt.sh/?id=9077429351

IINM, these errors are occurring because the string form of the issuer certificate's [Subject](https://github.com/google/certificate-transparency-go/blob/d2e643e1a2f08235fcd8e1911a9d55c1b5b94cbc/trillian/ctfe/cert_quota.go#L41) name is matched against a [regex](https://github.com/google/trillian/blob/master/quota/etcd/storage/quota_storage.go#L60) that allows any character _except_ the forward slash character.

To resolve this issue, this PR simply escapes (to "%2F") any forward slash character in the Subject name.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
