### PR TITLE
Add command for starting ctfe to ManualDeploy doc

### DIFF
--- a/trillian/docs/ManualDeployment.md
+++ b/trillian/docs/ManualDeployment.md
@@ -342,7 +342,9 @@ script should (mostly) make sense.
 
 **Cross-check**: Opening `http://localhost:<port>/<prefix>/ct/v1/get-sth` in a
 browser should show JSON that indicates an empty tree.
+
 Alternatively, the `ctclient` command-line tool shows the same information:
+e.g.
 ```bash
 go run github.com/google/certificate-transparency-go/client/ctclient@master get-sth --log_uri http://localhost:6966/aramis
 2018-10-12 11:28:08.544 +0100 BST (timestamp 1539340088544): Got STH for V1 log (size=11718) at http://localhost:6966/aramis, hash 6fb36fcca60d61aa85e04ff0c34a87782f12d08568118602eec0208d85c3a40d
@@ -352,11 +354,12 @@ Value=3045022100df855f0fd097a45070e2eb244c7cb63effda942f2d30308e3b84a72e1d16118b
 
 **Cross-check**: Once the CTFE is configured and running, opening
 `http://localhost:<port>/<prefix>/ct/v1/get-roots` shows the configured roots.
+
 Alternatively, the `ctclient` command-line tool shows the same information in a
 more friendly way:
-
+e.g.
 ```bash
-go run github.com/google/certificate-transparency-go/client/ctclient@master getroots --log_uri http://localhost:6966/aramis
+go run github.com/google/certificate-transparency-go/client/ctclient@master get-roots --log_uri http://localhost:6966/aramis
 Certificate:
     Data:
         Version: 3 (0x2)

--- a/trillian/docs/ManualDeployment.md
+++ b/trillian/docs/ManualDeployment.md
@@ -285,24 +285,6 @@ for feeding to `ct-server` can thus be produced with:
 % cat /etc/ssl/certs/* > ca-roots.pem
 ```
 
-**Cross-check**: Once the CTFE is configured and running
-([below](#ctfe-start-up)), opening
-`http://localhost:<port>/<prefix>/ct/v1/get-roots` shows the configured roots.
-Alternatively, the `ctclient` command-line tool shows the same information in a
-more friendly way:
-
-```bash
-% go install github.com/google/certificate-transparency-go/client/ctclient
-% ctclient --log_uri http://localhost:6966/aramis getroots
-Certificate:
-    Data:
-        Version: 3 (0x2)
-        Serial Number: 67554046 (0x406cafe)
-    Signature Algorithm: ECDSA-SHA256
-...
-```
-
-
 ### CTFE Configuration
 
 The information from the previous steps now needs to be assembled into a
@@ -344,6 +326,14 @@ can be started.
    it should match the `--rpc_endpoint` for the [log server](#trillian-services).
  - The `--http_endpoint` option indicates the port that the CTFE should respond
    to HTTP(S) requests on.
+   
+ e.g.
+ ```bash
+ CTFE_CONFIG=/path/to/your/ctfe_config_file
+ TRILLIAN_LOG_SERVER_RPC_ENDPOINT=localhost:8080
+ go run github.com/google/certificate-transparency-go/trillian/ctfe/ct_server --log_config ${CTFE_CONFIG} --http_endpoint=localhost:6966 --log_rpc_server ${TRILLIAN_LOG_SERVER_RPC_ENDPOINT} --logtostderr
+     
+ ```
 
 At this point, a complete (but minimal) CT Log setup is available. The manual
 set up steps up to this point match the
@@ -359,6 +349,22 @@ go run github.com/google/certificate-transparency-go/client/ctclient@master get-
 Signature: Hash=SHA256 Sign=ECDSA
 Value=3045022100df855f0fd097a45070e2eb244c7cb63effda942f2d30308e3b84a72e1d16118b0220038e55f142501402cf03790b3997081f82ffe47f2d3f3b667e1c484aecf40a33
 ```
+
+**Cross-check**: Once the CTFE is configured and running, opening
+`http://localhost:<port>/<prefix>/ct/v1/get-roots` shows the configured roots.
+Alternatively, the `ctclient` command-line tool shows the same information in a
+more friendly way:
+
+```bash
+go run github.com/google/certificate-transparency-go/client/ctclient@master getroots --log_uri http://localhost:6966/aramis
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 67554046 (0x406cafe)
+    Signature Algorithm: ECDSA-SHA256
+...
+```
+
 
 <img src="images/Deployment3CTFE.png" width="650">
 


### PR DESCRIPTION
Adds an explicit example of the command to start the ctfe server.

Also moves a cross-check which relies on the ctfe server running below where the ctfe command is given.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [X] I have updated [documentation](docs/) accordingly.
