### PR TITLE
Migrate CTFE Ingress manifest to support GKE version 1.23

### DIFF
--- a/trillian/examples/deployment/kubernetes/ctfe-ingress.yaml
+++ b/trillian/examples/deployment/kubernetes/ctfe-ingress.yaml
@@ -1,10 +1,12 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: trillian-ctfe-ingress
   annotations:
     kubernetes.io/ingress.global-static-ip-name: trillian-ctfe-global-static-ip
 spec:
-  backend:
-    serviceName: trillian-ctfe-service
-    servicePort: 6962
+  defaultBackend:
+    service:
+      name: trillian-ctfe-service
+      port: 
+        number: 6962


### PR DESCRIPTION
<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->
The Cloud Build pipeline started to fail due to CTFE Ingress manifest using deprecated APIs. This PR follows instructions in the deprecated API migration guide.
https://cloud.google.com/kubernetes-engine/docs/deprecations/apis-1-22#ingress-v122

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
