### PR TITLE
Add build tags for zOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## HEAD
 
+### Add support for IBM Z operating system z/OS
+ * Add build tags for zos
+
 ### Chrome CT Policy Update
  * #906: Update chromepolicy.go to follow the updated Chrome CT policy.
  

--- a/x509/root_unix.go
+++ b/x509/root_unix.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build dragonfly || freebsd || linux || netbsd || openbsd || solaris
-// +build dragonfly freebsd linux netbsd openbsd solaris
+//go:build dragonfly || freebsd || linux || netbsd || openbsd || solaris || zos
+// +build dragonfly freebsd linux netbsd openbsd solaris zos
 
 package x509
 

--- a/x509/root_unix_test.go
+++ b/x509/root_unix_test.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build dragonfly || freebsd || linux || netbsd || openbsd || solaris
-// +build dragonfly freebsd linux netbsd openbsd solaris
+//go:build dragonfly || freebsd || linux || netbsd || openbsd || solaris || zos
+// +build dragonfly freebsd linux netbsd openbsd solaris zos
 
 package x509
 

--- a/x509/root_zos.go
+++ b/x509/root_zos.go
@@ -1,0 +1,14 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build zos
+// +build zos
+
+package x509
+
+// Possible certificate files; stop after finding one.
+var certFiles = []string{
+	"/etc/cacert.pem",                // IBM zOS default
+	"/$HOME/zopen/boot/cacert.pem",   // IBM zOS zopen - https://github.com/ZOSOpenTools/meta/
+}


### PR DESCRIPTION
Hello,

This PR adds the 'zos' build tag to a few files, and points to the currently relevant default cert files.

Will look to update this PR with test results or whatever else is necessary for thoroughness (for Z audience's reference later).

### Checklist

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
