### PR TITLE
Add support for WASI port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## HEAD
 
+### Add support for WASI port
+* Add build tags for wasip1 GOOS
+
 ### Add support for IBM Z operating system z/OS
 * Add build tags for zos
 

--- a/x509/root_wasip1.go
+++ b/x509/root_wasip1.go
@@ -1,0 +1,19 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build wasip1
+// +build wasip1
+
+package x509
+
+// Possible certificate files; stop after finding one.
+var certFiles = []string{}
+
+func loadSystemRoots() (*CertPool, error) {
+	return NewCertPool(), nil
+}
+
+func (c *Certificate) systemVerify(opts *VerifyOptions) (chains [][]*Certificate, err error) {
+	return nil, nil
+}


### PR DESCRIPTION
Fix building when the new `wasip1` port is being used.
This is a new target that will be introduced by go 1.21.

For more details https://github.com/golang/go/issues/58141

### Checklist

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
