### PR TITLE
Remove Dependabot ignore configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,19 +5,3 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: google.golang.org/grpc
-    versions:
-    - 1.35.0
-    - 1.36.0
-    - 1.36.1
-    - 1.37.0
-  - dependency-name: github.com/prometheus/client_golang
-    versions:
-    - 1.10.0
-  - dependency-name: google.golang.org/protobuf
-    versions:
-    - 1.28.0
-  - dependency-name: github.com/golang/mock
-    versions:
-    - 1.5.0


### PR DESCRIPTION
<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->
The Dependabot ignore configuration is no longer required as the defined dependencies versions are outdated.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
