### PR TITLE
Search whole chain looking for issuer match

### DIFF
--- a/ctutil/sctcheck/sctcheck.go
+++ b/ctutil/sctcheck/sctcheck.go
@@ -114,9 +114,14 @@ func checkChain(ctx context.Context, lf logInfoFactory, chain []*x509.Certificat
 	}
 
 	var issuer *x509.Certificate
-	for _, c := range chain[1:] {
+	for i := 1; i < len(chain); i++ {
+		c := chain[i]
 		if bytes.Equal(c.SubjectKeyId, leaf.SubjectKeyId) {
 			issuer = c
+			if i > 1 {
+				klog.Warningf("Certificate chain out of order; issuer cert found at index %d", i)
+			}
+			break
 		}
 	}
 

--- a/ctutil/sctcheck/sctcheck.go
+++ b/ctutil/sctcheck/sctcheck.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"errors"
@@ -113,15 +114,19 @@ func checkChain(ctx context.Context, lf logInfoFactory, chain []*x509.Certificat
 	}
 
 	var issuer *x509.Certificate
-	if len(chain) < 2 {
+	for _, c := range chain[1:] {
+		if bytes.Equal(c.SubjectKeyId, leaf.SubjectKeyId) {
+			issuer = c
+		}
+	}
+
+	if issuer == nil {
 		klog.Info("No issuer in chain; attempting online retrieval")
 		var err error
 		issuer, err = x509util.GetIssuer(leaf, hc)
 		if err != nil {
 			klog.Errorf("Failed to get issuer online: %v", err)
 		}
-	} else {
-		issuer = chain[1]
 	}
 
 	// Build a Merkle leaf that corresponds to the embedded SCTs.  We can use the same


### PR DESCRIPTION
This is a more thorough alternative to #1111 to solve #1096 as I understand the problem.

Where the chain is out of order, look through the whole chain to find a matching issuer cert. If we don't find one, then use the fallback logic that was already there for no issuer chain provided.