### PR TITLE
Build the ctfe/ct_server binary without depending on glibc

### DIFF
--- a/trillian/examples/deployment/docker/ctfe/Dockerfile
+++ b/trillian/examples/deployment/docker/ctfe/Dockerfile
@@ -10,7 +10,7 @@ COPY go.sum .
 RUN go mod download
 COPY . .
 
-RUN go build ./trillian/ctfe/ct_server
+RUN CGO_ENABLED=0 go build ./trillian/ctfe/ct_server
 
 FROM gcr.io/distroless/base@sha256:73deaaf6a207c1a33850257ba74e0f196bc418636cada9943a03d7abea980d6d
 


### PR DESCRIPTION
<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->
Fixes #1118.

Here is the distroless Dockerfile example for Go.
https://github.com/GoogleContainerTools/distroless/blob/main/examples/go/Dockerfile

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
