### PR TITLE
Export is_mirror = 0.0 for non mirror instead of nothing

### DIFF
--- a/trillian/ctfe/handlers.go
+++ b/trillian/ctfe/handlers.go
@@ -316,6 +316,8 @@ func newLogInfo(
 
 	if cfg.IsMirror {
 		isMirrorLog.Set(1.0, label)
+	} else {
+		isMirrorLog.Set(0.0, label)
 	}
 	maxMergeDelay.Set(float64(cfg.MaxMergeDelaySec), label)
 	expMergeDelay.Set(float64(cfg.ExpectedMergeDelaySec), label)


### PR DESCRIPTION
This makes it easier to differentiate between missing data, and non mirrors.