### PR TITLE
Update the minimal image to gcr.io/distroless/base-debian12

### DIFF
--- a/trillian/examples/deployment/docker/ctfe/Dockerfile
+++ b/trillian/examples/deployment/docker/ctfe/Dockerfile
@@ -10,9 +10,9 @@ COPY go.sum .
 RUN go mod download
 COPY . .
 
-RUN CGO_ENABLED=0 go build ./trillian/ctfe/ct_server
+RUN go build ./trillian/ctfe/ct_server
 
-FROM gcr.io/distroless/base@sha256:b31a6e02605827e77b7ebb82a0ac9669ec51091edd62c2c076175e05556f4ab9
+FROM gcr.io/distroless/base-debian12@sha256:1dfdb5ed7d9a66dcfc90135b25a46c25a85cf719b619b40c249a2445b9d055f5
 
 COPY --from=build /build/ct_server /
 


### PR DESCRIPTION
<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->
This PR reverts the change in https://github.com/google/certificate-transparency-go/pull/1119/ and update the minimal image to use debian12 for glibc.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
