### PR TITLE
Move golangci-lint from Cloud Build to GitHub Action

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,22 @@
+name: golangci-lint
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        with:
+          go-version: "1.20"
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
+        with:
+          version: v1.55.1

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -92,7 +92,7 @@ steps:
   id: 'default_test'
   env:
     - 'GOFLAGS='
-    - 'PRESUBMIT_OPTS=--no-generate'
+    - 'PRESUBMIT_OPTS=--no-linters --no-generate'
     - 'TRILLIAN_LOG_SERVERS=deployment_trillian-log-server_1:8090'
     - 'TRILLIAN_LOG_SERVER_1=deployment_trillian-log-server_1:8090'
   waitFor: ['ci-ready']

--- a/cloudbuild_master.yaml
+++ b/cloudbuild_master.yaml
@@ -92,7 +92,7 @@ steps:
   id: 'default_test'
   env:
     - 'GOFLAGS='
-    - 'PRESUBMIT_OPTS=--no-generate'
+    - 'PRESUBMIT_OPTS=--no-linters --no-generate'
     - 'TRILLIAN_LOG_SERVERS=deployment_trillian-log-server_1:8090'
     - 'TRILLIAN_LOG_SERVER_1=deployment_trillian-log-server_1:8090'
   waitFor: ['ci-ready']

--- a/cloudbuild_tag.yaml
+++ b/cloudbuild_tag.yaml
@@ -92,7 +92,7 @@ steps:
   id: 'default_test'
   env:
     - 'GOFLAGS='
-    - 'PRESUBMIT_OPTS=--no-generate'
+    - 'PRESUBMIT_OPTS=--no-linters --no-generate'
     - 'TRILLIAN_LOG_SERVERS=deployment_trillian-log-server_1:8090'
     - 'TRILLIAN_LOG_SERVER_1=deployment_trillian-log-server_1:8090'
   waitFor: ['ci-ready']


### PR DESCRIPTION
<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->
The Cloud Build duration will be slightly shorten by moving the golangci-lint to GitHub Action workflow.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
