### PR TITLE
Run with go1.20.12 because 1.20.11 has a vulnerability

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -19,5 +19,5 @@ jobs:
       - id: govulncheck
         uses: golang/govulncheck-action@7da72f730e37eeaad891fcff0a532d27ed737cd4 # v1.0.1
         with:
-          go-version-input: 1.20.11
+          go-version-input: 1.20.12
           go-package: ./...


### PR DESCRIPTION
https://pkg.go.dev/vuln/GO-2023-2382
