### PR TITLE
Use the appropriate HTTP response code for backend timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Add build tags for AIX operating system
 
+### Misc
+
+* Return HTTP 504 instead of HTTP 408 upon timeout or cancellation of a backend connection context by @robstradling in https://github.com/google/certificate-transparency-go/pull/1313
+
 ## v1.1.7
 
 * Recommended Go version for development: 1.20

--- a/trillian/ctfe/handlers.go
+++ b/trillian/ctfe/handlers.go
@@ -1101,7 +1101,7 @@ func (li *logInfo) toHTTPStatus(err error) int {
 	case codes.OK:
 		return http.StatusOK
 	case codes.Canceled, codes.DeadlineExceeded:
-		return http.StatusRequestTimeout
+		return http.StatusGatewayTimeout
 	case codes.InvalidArgument, codes.OutOfRange, codes.AlreadyExists:
 		return http.StatusBadRequest
 	case codes.NotFound:


### PR DESCRIPTION
Upon timeout or cancellation of a backend connection context, CTFE currently returns HTTP 408 to the client.  This seems wrong, because 408 is intended to mean that the client did not send its request quickly enough.

[HTTP 504](https://datatracker.ietf.org/doc/html/rfc7231#section-6.6.5) (Gateway Timeout) seems a more appropriate error code, given that the timeout or cancellation occurred because an "upstream server" (i.e., the Trillian backend) did not respond quickly enough:

>  The 504 (Gateway Timeout) status code indicates that the server,
>   while acting as a gateway or proxy, did not receive a timely response
>   from an upstream server it needed to access in order to complete the
>   request.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
