### PR TITLE
Return 429 Too Many Requests for gRPC error code `ResourceExhausted` from Trillian

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Adds the ability for a CT client to disable root compatibile checking: https://github.com/google/certificate-transparency-go/pull/1258
 
+### Fixes
+
+* Return 429 Too Many Requests for gRPC error code `ResourceExhausted` from Trillian.
+
 ## v1.1.8
 
 * Recommended Go version for development: 1.21

--- a/trillian/ctfe/handlers.go
+++ b/trillian/ctfe/handlers.go
@@ -1118,8 +1118,10 @@ func (li *logInfo) toHTTPStatus(err error) int {
 		return http.StatusBadRequest
 	case codes.NotFound:
 		return http.StatusNotFound
-	case codes.PermissionDenied, codes.ResourceExhausted:
+	case codes.PermissionDenied:
 		return http.StatusForbidden
+	case codes.ResourceExhausted:
+		return http.StatusTooManyRequests
 	case codes.Unauthenticated:
 		return http.StatusUnauthorized
 	case codes.FailedPrecondition:


### PR DESCRIPTION
<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->
The existing HTTP status code `StatusForbidden` does not reflect the actual gRPC error code `ResourceExhausted` from Trillian. `429 Too Many Requests` is a better HTTP status code to fit into the translation.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
