### PR TITLE
Safeguard against redirects on PUT request

### DIFF
--- a/internal/witness/client/http/witness_client.go
+++ b/internal/witness/client/http/witness_client.go
@@ -83,6 +83,9 @@ func (w Witness) Update(ctx context.Context, logID string, sth []byte, proof [][
 	if err != nil {
 		return nil, fmt.Errorf("failed to do http request: %v", err)
 	}
+	if resp.Request.Method != "PUT" {
+		return nil, fmt.Errorf("PUT request to %q was converted to %s request to %q", u.String(), resp.Request.Method, resp.Request.URL)
+	}
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {


### PR DESCRIPTION
A redirect on a PUT request will make the http client perform a GET request to the signposted URL. This will (probably) return a 200, which the code will then interpret as a successful PUT. This check ensures that the method the response relates to is the same as the one we invoked.
