### PR TITLE
Add new types `PrecertChainEntryHash` and `CertificateChainHash` for TLS marshal/unmarshal in storage saving

### DIFF
--- a/types.go
+++ b/types.go
@@ -248,6 +248,23 @@ type CertificateChain struct {
 	Entries []ASN1Cert `tls:"minlen:0,maxlen:16777215"`
 }
 
+// PrecertChainEntryHash is an extended PrecertChainEntry with the
+// NonLeafCertificateChainHash field added to store the hash of the
+// CertificateChain field of PrecertChainEntry.
+type PrecertChainEntryHash struct {
+	PreCertificate              ASN1Cert   `tls:"minlen:1,maxlen:16777215"`
+	CertificateChain            []ASN1Cert `tls:"minlen:0,maxlen:16777215"`
+	NonLeafCertificateChainHash []byte     `tls:"minlen:0,maxlen:32"`
+}
+
+// CertificateChainHash is an extended CertificateChain with the
+// NonLeafCertificateChainHash field added to store the hash of the
+// Entries field of CertificateChain.
+type CertificateChainHash struct {
+	Entries                     []ASN1Cert `tls:"minlen:0,maxlen:16777215"`
+	NonLeafCertificateChainHash []byte     `tls:"minlen:0,maxlen:32"`
+}
+
 // JSONDataEntry holds arbitrary data.
 type JSONDataEntry struct {
 	Data []byte `tls:"minlen:0,maxlen:1677215"`


### PR DESCRIPTION
<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

The new CTFE extra data storage saving types contribute to https://github.com/google/certificate-transparency-go/issues/691.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
