### PR TITLE
Fix incorrect deployment doc and server config

### DIFF
--- a/trillian/examples/deployment/docker/ctfe/README.md
+++ b/trillian/examples/deployment/docker/ctfe/README.md
@@ -39,15 +39,14 @@ First bring up the trillian instance and the database:
 # Terminal 1
 cd ${GIT_HOME}/certificate-transparency-go/trillian/examples/deployment/docker/ctfe/
 docker compose up
-docker exec -i ctfe-db mariadb -pzaphod -Dtest < ${GIT_HOME}/certificate-transparency-go/trillian/ctfe/storage/mysql/schema.sql
 ```
 
 This brings up everything except the CTFE. Now to provision the logs.
 
 ```bash
 # Terminal 2
-cd ${GIT_HOME}/trillian/
-docker exec -i ctfe-db mariadb -pzaphod -Dtest < ./storage/mysql/schema/storage.sql
+docker exec -i ctfe-db mariadb -pzaphod -Dtest < ${GIT_HOME}/trillian/storage/mysql/schema/storage.sql
+docker exec -i ctfe-db mariadb -pzaphod -Dtest < ${GIT_HOME}/certificate-transparency-go/trillian/ctfe/storage/mysql/schema.sql
 ```
 
 The CTFE requires some configuration files. First prepare a directory containing

--- a/trillian/examples/deployment/docker/ctfe/ct_server.cfg
+++ b/trillian/examples/deployment/docker/ctfe/ct_server.cfg
@@ -12,6 +12,6 @@ config {
 	}
 	max_merge_delay_sec: 86400
 	expected_merge_delay_sec: 120
-	ctfe_storage_connection_string: "mysql://test:zaphod@tcp(localhost:3306)/test"
+	ctfe_storage_connection_string: "mysql://test:zaphod@tcp(db:3306)/test"
 	extra_data_issuance_chain_storage_backend: ISSUANCE_CHAIN_STORAGE_BACKEND_CTFE
 }


### PR DESCRIPTION
<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->
The steps in deployment doc and server config do not work as expected after the extra data issuance chain changes. This pull request ensures all steps are tested and verified.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
