### PR TITLE
Group dependabot updates as much as possible

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,34 +3,69 @@ updates:
 - package-ecosystem: gomod
   directory: /
   schedule:
-    interval: daily
+    interval: weekly
+  groups:
+    all-deps:
+      applies-to: version-updates
+      patterns:
+        - "*"
 
 - package-ecosystem: github-actions
   directory: /
   schedule:
-    interval: daily
+    interval: weekly
+  groups:
+    all-deps:
+      applies-to: version-updates
+      patterns:
+        - "*"
 
 - package-ecosystem: docker
   directory: /integration
   schedule:
-    interval: daily
+    interval: weekly
+  groups:
+    all-deps:
+      applies-to: version-updates
+      patterns:
+        - "*"
 
 - package-ecosystem: docker
   directory: /internal/witness/cmd/feeder
   schedule:
-    interval: daily
+    interval: weekly
+  groups:
+    all-deps:
+      applies-to: version-updates
+      patterns:
+        - "*"
 
 - package-ecosystem: docker
   directory: /internal/witness/cmd/witness
   schedule:
-    interval: daily
+    interval: weekly
+  groups:
+    all-deps:
+      applies-to: version-updates
+      patterns:
+        - "*"
 
 - package-ecosystem: docker
   directory: /trillian/examples/deployment/docker/ctfe
   schedule:
-    interval: daily
+    interval: weekly
+  groups:
+    all-deps:
+      applies-to: version-updates
+      patterns:
+        - "*"
 
 - package-ecosystem: docker
   directory: /trillian/examples/deployment/docker/envsubst
   schedule:
-    interval: daily
+    interval: weekly
+  groups:
+    all-deps:
+      applies-to: version-updates
+      patterns:
+        - "*"

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -19,5 +19,5 @@ jobs:
       - id: govulncheck
         uses: golang/govulncheck-action@3a32958c2706f7048305d5a2e53633d7e37e97d0 # v1.0.2
         with:
-          go-version-input: 1.21.10
+          go-version-input: 1.21.11
           go-package: ./...


### PR DESCRIPTION
Also bump version of go used for vulnerability scanning to unblocked
merges.
