### PR TITLE
Refactor issuance chain service

### DIFF
--- a/trillian/ctfe/handlers_test.go
+++ b/trillian/ctfe/handlers_test.go
@@ -165,7 +165,7 @@ func setupTest(t *testing.T, pemRoots []string, signer crypto.Signer) handlerTes
 	cfg := &configpb.LogConfig{LogId: 0x42, Prefix: "test", IsMirror: false}
 	vCfg := &ValidatedLogConfig{Config: cfg}
 	iOpts := InstanceOptions{Validated: vCfg, Client: info.client, Deadline: time.Millisecond * 500, MetricFactory: monitoring.InertMetricFactory{}, RequestLog: new(DefaultRequestLog)}
-	info.li = newLogInfo(iOpts, vOpts, signer, fakeTimeSource, newIssuanceChainService(nil, nil))
+	info.li = newLogInfo(iOpts, vOpts, signer, fakeTimeSource, &directIssuanceChainService{})
 
 	for _, pemRoot := range pemRoots {
 		if !info.roots.AppendCertsFromPEM([]byte(pemRoot)) {

--- a/trillian/ctfe/instance.go
+++ b/trillian/ctfe/instance.go
@@ -185,13 +185,17 @@ func setUpLogInfo(ctx context.Context, opts InstanceOptions) (*logInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	// issuanceChainCache is nil if the cache related flags are not defined.
+	if issuanceChainStorage == nil {
+		return newLogInfo(opts, validationOpts, signer, new(util.SystemTimeSource), &directIssuanceChainService{}), nil
+	}
+
+	// We are storing chains outside of Trillian, so set up cache and service.
 	issuanceChainCache, err := cache.NewIssuanceChainCache(ctx, opts.CacheType, opts.CacheOption)
 	if err != nil {
 		return nil, err
 	}
 
-	issuanceChainService := newIssuanceChainService(issuanceChainStorage, issuanceChainCache)
+	issuanceChainService := newIndirectIssuanceChainService(issuanceChainStorage, issuanceChainCache)
 
 	logInfo := newLogInfo(opts, validationOpts, signer, new(util.SystemTimeSource), issuanceChainService)
 	return logInfo, nil

--- a/trillian/ctfe/services_test.go
+++ b/trillian/ctfe/services_test.go
@@ -36,7 +36,7 @@ func TestIssuanceChainServiceAddAndGet(t *testing.T) {
 	ctx := context.Background()
 	storage := &fakeIssuanceChainStorage{}
 	cache := &fakeIssuanceChainCache{}
-	issuanceChainService := newIssuanceChainService(storage, cache)
+	issuanceChainService := newIndirectIssuanceChainService(storage, cache)
 
 	for _, test := range tests {
 		hash, err := issuanceChainService.add(ctx, test.chain)
@@ -44,7 +44,7 @@ func TestIssuanceChainServiceAddAndGet(t *testing.T) {
 			t.Errorf("IssuanceChainService.Add(): %v", err)
 		}
 
-		got, err := issuanceChainService.GetByHash(ctx, hash)
+		got, err := issuanceChainService.getByHash(ctx, hash)
 		if err != nil {
 			t.Errorf("IssuanceChainService.GetByHash(): %v", err)
 		}


### PR DESCRIPTION
Primary goal is to have 2 separate implementations of the different services, instead of having both implementations inside the same class with conditional switching. This is realized by introducing a _direct_ chain service that performs the legacy implementation of storing chains directly inside the extra data in Trillian. The logic for the new feature is now in an _indirect_ chain service that requires the storage and cache that chains are stored in.
