### PR TITLE
Add TLS support for CTLog server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Add TLS support for Trillian: By using `--trillian_tls_ca_cert_file` flag, users can provide a CA certificate, that is used to establish a secure communication with Trillian log server. In https://github.com/google/certificate-transparency-go/pull/1525
 
+* Add TLS support for ct_server: By using `--tls_certificate` and `--tls_key` flags, users can provide a service certificate and key, that enables the server to handle HTTPS requests. In https://github.com/google/certificate-transparency-go/pull/1523
+
 ## v1.2.1
 
 ### Fixes

--- a/trillian/ctfe/ct_server/main.go
+++ b/trillian/ctfe/ct_server/main.go
@@ -21,6 +21,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/rsa"
+	"crypto/tls"
 	"flag"
 	"fmt"
 	"net/http"
@@ -57,6 +58,8 @@ import (
 // Global flags that affect all log instances.
 var (
 	httpEndpoint       = flag.String("http_endpoint", "localhost:6962", "Endpoint for HTTP (host:port)")
+	tlsCert            = flag.String("tls_certificate", "", "Path to server TLS certificate")
+	tlsKey             = flag.String("tls_key", "", "Path to server TLS private key")
 	metricsEndpoint    = flag.String("metrics_endpoint", "", "Endpoint for serving metrics; if left empty, metrics will be visible on --http_endpoint")
 	rpcBackend         = flag.String("log_rpc_server", "", "Backend specification; comma-separated list or etcd service name (if --etcd_servers specified). If unset backends are specified in config (as a LogMultiConfig proto)")
 	rpcDeadline        = flag.Duration("rpc_deadline", time.Second*10, "Deadline for backend RPC requests")
@@ -306,7 +309,20 @@ func main() {
 	}
 
 	// Bring up the HTTP server and serve until we get a signal not to.
-	srv := http.Server{Addr: *httpEndpoint, Handler: handler}
+	srv := http.Server{}
+	if *tlsCert != "" && *tlsKey != "" {
+		cert, err := tls.LoadX509KeyPair(*tlsCert, *tlsKey)
+		if err != nil {
+			klog.Errorf("failed to load TLS certificate/key: %v", err)
+		}
+		tlsConfig := &tls.Config{
+			Certificates: []tls.Certificate{cert},
+			MinVersion:   tls.VersionTLS12,
+		}
+		srv = http.Server{Addr: *httpEndpoint, Handler: handler, TLSConfig: tlsConfig}
+	} else {
+		srv = http.Server{Addr: *httpEndpoint, Handler: handler}
+	}
 	shutdownWG := new(sync.WaitGroup)
 	go awaitSignal(func() {
 		shutdownWG.Add(1)


### PR DESCRIPTION
## Summary
This pull request introduces support for enabling TLS security for CTLog. By adding two new command-line flags`--tls_certificate` and `--tls_key` which represents the path to server TLS certificate and private key respectively.
And also implementing the necessary logic to handle TLS, this update enhances the security of CTLog.

## Release Note
- Feature: Added support for TLS security for CTLog server.
New Flags: `--tls_certificate` and `--tls_key` to specify the file path for service certificate and private key.
Behavior: If  `--tls_certificate` and `--tls_key` flags  are not both provided, the system will default to insecure connections.
Security: This update significantly enhances the security of data in transit by enabling TLS.


Resolves Issue: https://github.com/google/certificate-transparency-go/issues/1522
<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [x] I have updated [documentation](docs/) accordingly.
