### PR TITLE
Add TLS support for Trillian server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD
 
+* Add TLS support for Trillian: By using `--trillian_tls_ca_cert_file` flag, users can provide a CA certificate, that is used to establish a secure communication with Trillian log server. In https://github.com/google/certificate-transparency-go/pull/1525
+
 ## v1.2.1
 
 ### Fixes


### PR DESCRIPTION
## Summary
This pull request introduces the option to specify a CA certificate for establishing secure connections with the Trillian server. 
By using `--trillian_tls_ca_cert_file` flag, users can provide a CA certificate, that is used to establish a secure communication with Trillian server.

## Release Note
- Feature: Added support for TLS security for Trillian server.
New Flag: `--trillian_tls_ca_cert_file` to specify the file path to the CA certificate.
Behavior: If   `--trillian_tls_ca_cert_file` flag is not provided, the system will default to insecure connections.
Security: This update significantly enhances the security of data in transit by enabling TLS.


Resolves Issue: https://github.com/google/certificate-transparency-go/issues/1524
<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [x] I have updated [documentation](docs/) accordingly.
