### PR TITLE
Bump version of go used by the vuln checker

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -19,5 +19,5 @@ jobs:
       - id: govulncheck
         uses: golang/govulncheck-action@dd0578b371c987f96d1185abb54344b44352bd58 # v1.0.3
         with:
-          go-version-input: 1.21.11
+          go-version-input: 1.21.12
           go-package: ./...


### PR DESCRIPTION
TODO: look if we can avoid nailing down a patch version in here, because these PRs are frequent and don't provide much value. The version of go it uses should be pulled from whatever version we're using in the build chain if this is to have any real value.
