### PR TITLE
Use the version in the go.mod file for vuln checks

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -19,5 +19,5 @@ jobs:
       - id: govulncheck
         uses: golang/govulncheck-action@dd0578b371c987f96d1185abb54344b44352bd58 # v1.0.3
         with:
-          go-version-input: 1.21.12
+          go-version-file: go.mod
           go-package: ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/certificate-transparency-go
 
-go 1.21.0
+go 1.21.12
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2


### PR DESCRIPTION
This actually secures the build tooling used for this repo, instead of
having an arbitrary side check which notifies us of issues in the core
Go libraries.
