### PR TITLE
fix TLS configuration for ct_server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Add TLS support for ct_server: By using `--tls_certificate` and `--tls_key` flags, users can provide a service certificate and key, that enables the server to handle HTTPS requests. In https://github.com/google/certificate-transparency-go/pull/1523
 
+### Fixes
+
+* Fix ct_server TLS configuration: When TLS on ct_server is enable, use ListenAndServeTLS instead of ListenAndServe.
+
 ## v1.2.1
 
 ### Fixes

--- a/trillian/ctfe/ct_server/main.go
+++ b/trillian/ctfe/ct_server/main.go
@@ -337,7 +337,11 @@ func main() {
 		klog.Info("HTTP server shutdown")
 	})
 
-	err = srv.ListenAndServe()
+	if *tlsCert != "" && *tlsKey != "" {
+		err = srv.ListenAndServeTLS("", "")
+	} else {
+		err = srv.ListenAndServe()
+	}
 	if err != http.ErrServerClosed {
 		klog.Warningf("Server exited: %v", err)
 	}


### PR DESCRIPTION
<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

A minor fix following PR: https://github.com/google/certificate-transparency-go/pull/1523
Use ListenAndServeTLS instead of ListenAndServe when TLS is enabled on `ct_server`.

Issue: https://github.com/google/certificate-transparency-go/issues/1541

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [x] I have updated [documentation](docs/) accordingly.

