### PR TITLE
Add Trillian TLS support for ct_server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## HEAD
 
-* Add TLS support for Trillian: By using `--trillian_tls_ca_cert_file` flag, users can provide a CA certificate, that is used to establish a secure communication with Trillian log server. In https://github.com/google/certificate-transparency-go/pull/1525
+* Add TLS support for Trillian: By using `--trillian_tls_ca_cert_file` flag, users can provide a CA certificate, that is used to establish a secure communication with Trillian log server. In https://github.com/google/certificate-transparency-go/pull/1551
 
 * Add TLS support for ct_server: By using `--tls_certificate` and `--tls_key` flags, users can provide a service certificate and key, that enables the server to handle HTTPS requests. In https://github.com/google/certificate-transparency-go/pull/1523
 

--- a/trillian/ctfe/ct_server/main.go
+++ b/trillian/ctfe/ct_server/main.go
@@ -81,7 +81,7 @@ var (
 	cacheType             = flag.String("cache_type", "noop", "Supported cache type: noop, lru (Default: noop)")
 	cacheSize             = flag.Int("cache_size", -1, "Size parameter set to 0 makes cache of unlimited size")
 	cacheTTL              = flag.Duration("cache_ttl", -1*time.Second, "Providing 0 TTL turns expiring off")
-	trillianTlsCACertFile = flag.String("trillian_tls_ca_cert_file", "", "CA certificate file to use for secure connections with Trillian server")
+	trillianTLSCACertFile = flag.String("trillian_tls_ca_cert_file", "", "CA certificate file to use for secure connections with Trillian server")
 )
 
 const unknownRemoteUser = "UNKNOWN_REMOTE"
@@ -138,8 +138,8 @@ func main() {
 	}
 
 	dialOpts := []grpc.DialOption{}
-	if *trillianTlsCACertFile != "" {
-		creds, err := credentials.NewClientTLSFromFile(*trillianTlsCACertFile, "")
+	if *trillianTLSCACertFile != "" {
+		creds, err := credentials.NewClientTLSFromFile(*trillianTLSCACertFile, "")
 		if err != nil {
 			klog.Exitf("Failed to create TLS credentials from Trillian CA certificate: %v", err)
 		}

--- a/trillian/migrillian/main.go
+++ b/trillian/migrillian/main.go
@@ -18,20 +18,16 @@ package main
 
 import (
 	"context"
-	"crypto/tls"
-	"crypto/x509"
 	"errors"
 	"flag"
 	"fmt"
 	"net/http"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"k8s.io/klog/v2"
 
@@ -61,7 +57,6 @@ var (
 
 	maxIdleConnsPerHost = flag.Int("max_idle_conns_per_host", 10, "Max idle HTTP connections per host (0 = DefaultMaxIdleConnsPerHost)")
 	maxIdleConns        = flag.Int("max_idle_conns", 100, "Max number of idle HTTP connections across all hosts (0 = unlimited)")
-	tlsCACertFile       = flag.String("trillian_tls_ca_cert_file", "", "CA certificate file to use for secure connections with Trillian server")
 )
 
 func main() {
@@ -82,11 +77,7 @@ func main() {
 	}
 
 	klog.Infof("Dialling Trillian backend: %v", *backend)
-	creds, err := newTrillianTransportCredentialsFromFlags(*backend)
-	if err != nil {
-		klog.Exitf("Failed to get credentials: %v", err)
-	}
-	conn, err := grpc.Dial(*backend, grpc.WithTransportCredentials(creds), grpc.WithBlock())
+	conn, err := grpc.Dial(*backend, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
 	if err != nil {
 		klog.Exitf("Could not dial Trillian server: %v: %v", *backend, err)
 	}
@@ -124,32 +115,6 @@ func main() {
 	go util.AwaitSignal(cctx, cancel)
 
 	core.RunMigration(cctx, ctrls)
-}
-
-// newTrillianTransportCredentialsFromFlags returns "creds" of type credentials.TransportCredentials to be
-// passed as credentials arguments to grpc.WithTransportCredentials. It configures TLS credentials
-// if a CA certificate file is specified, otherwise it uses insecure credentials.
-func newTrillianTransportCredentialsFromFlags(backend string) (credentials.TransportCredentials, error) {
-	var creds credentials.TransportCredentials
-
-	if len(*tlsCACertFile) > 0 {
-		tlsCaCert, err := os.ReadFile(filepath.Clean(*tlsCACertFile))
-		if err != nil {
-			return nil, err
-		}
-		certPool := x509.NewCertPool()
-		if !certPool.AppendCertsFromPEM(tlsCaCert) {
-			return nil, fmt.Errorf("failed to append CA certificate to pool")
-		}
-		creds = credentials.NewTLS(&tls.Config{
-			ServerName: backend,
-			RootCAs:    certPool,
-			MinVersion: tls.VersionTLS12,
-		})
-	} else {
-		creds = insecure.NewCredentials()
-	}
-	return creds, nil
 }
 
 // getController creates a single log migration Controller.


### PR DESCRIPTION
<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

**Add Trillian TLS support for ct_server:** 
In a previous PR: https://github.com/google/certificate-transparency-go/pull/1525, this change was intended but was done on the wrong file `trillian/migrillian/main.go` instead of `trillian/ctfe/ct_server/main.go`

This issue was identified while testing a real scenario. It should be fixed by this PR. 

related isssue: https://github.com/google/certificate-transparency-go/issues/1524
### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [x] I have updated [documentation](docs/) accordingly.
