### PR TITLE
Explicitly include version tag

### DIFF
--- a/internal/witness/cmd/feeder/Dockerfile
+++ b/internal/witness/cmd/feeder/Dockerfile
@@ -18,7 +18,7 @@ COPY . .
 RUN go build -o /build/bin/feeder ./internal/witness/cmd/feeder
 
 # Build release image
-FROM alpine@sha256:1e42bbe2508154c9126d48c2b8a75420c3544343bf86fd041fb7527e017a4b4a
+FROM alpine:3.20@sha256:1e42bbe2508154c9126d48c2b8a75420c3544343bf86fd041fb7527e017a4b4a
 
 COPY --from=builder /build/bin/feeder /bin/feeder
 ENTRYPOINT ["/bin/feeder"]


### PR DESCRIPTION
This is redundant for correctness because of the sha256, but it makes it easier for humans reviewing dependabot changes to see that things are going forwards.
