### PR TITLE
Add TiledLogs to log list JSON

### DIFF
--- a/loglist3/loglist3.go
+++ b/loglist3/loglist3.go
@@ -74,7 +74,8 @@ type Operator struct {
 	TiledLogs []*TiledLog `json:"tiled_logs"`
 }
 
-// Log describes a single CT log.
+// Log describes a single RFC 6962 CT log. It is nearly the same as the TiledLog struct,
+// but has a single URL field instead of SubmissionURL and MonitoringURL fields.
 type Log struct {
 	// Description is a human-readable string that describes the log.
 	Description string `json:"description,omitempty"`
@@ -102,7 +103,8 @@ type Log struct {
 	Type string `json:"log_type,omitempty"`
 }
 
-// TiledLog describes a static-ct-api log
+// TiledLog describes a Static CT API log. It is nearly the same as the Log struct,
+// but has both SubmissionURL and MonitoringURL fields instead of a single URL field.
 type TiledLog struct {
 	// Description is a human-readable string that describes the log.
 	Description string `json:"description,omitempty"`

--- a/loglist3/loglist3.go
+++ b/loglist3/loglist3.go
@@ -68,8 +68,10 @@ type Operator struct {
 	// Email lists the email addresses that can be used to contact this log
 	// operator.
 	Email []string `json:"email"`
-	// Logs is a list of CT logs run by this operator.
+	// Logs is a list of RFC 6962 CT logs run by this operator.
 	Logs []*Log `json:"logs"`
+	// TiledLogs is a list of Static CT API CT logs run by this operator.
+	TiledLogs []*TiledLog `json:"tiled_logs"`
 }
 
 // Log describes a single CT log.
@@ -82,6 +84,36 @@ type Log struct {
 	Key []byte `json:"key"`
 	// URL is the address of the HTTPS API.
 	URL string `json:"url"`
+	// DNS is the address of the DNS API.
+	DNS string `json:"dns,omitempty"`
+	// MMD is the Maximum Merge Delay, in seconds. All submitted
+	// certificates must be incorporated into the log within this time.
+	MMD int32 `json:"mmd"`
+	// PreviousOperators is a list of previous operators and the timestamp
+	// of when they stopped running the log.
+	PreviousOperators []*PreviousOperator `json:"previous_operators,omitempty"`
+	// State is the current state of the log, from the perspective of the
+	// log list distributor.
+	State *LogStates `json:"state,omitempty"`
+	// TemporalInterval, if set, indicates that this log only accepts
+	// certificates with a NotAfter date in this time range.
+	TemporalInterval *TemporalInterval `json:"temporal_interval,omitempty"`
+	// Type indicates the purpose of this log, e.g. "test" or "prod".
+	Type string `json:"log_type,omitempty"`
+}
+
+// TiledLog describes a static-ct-api log
+type TiledLog struct {
+	// Description is a human-readable string that describes the log.
+	Description string `json:"description,omitempty"`
+	// LogID is the SHA-256 hash of the log's public key.
+	LogID []byte `json:"log_id"`
+	// Key is the public key with which signatures can be verified.
+	Key []byte `json:"key"`
+	// SubmissionURL
+	SubmissionURL string `json:"submission_url"`
+	// MonitoringURL
+	MonitoringURL string `json:"monitoring_url"`
 	// DNS is the address of the DNS API.
 	DNS string `json:"dns,omitempty"`
 	// MMD is the Maximum Merge Delay, in seconds. All submitted

--- a/loglist3/loglist3_test.go
+++ b/loglist3/loglist3_test.go
@@ -117,6 +117,7 @@ var sampleLogList = LogList{
 					},
 				},
 			},
+			TiledLogs: make([]*TiledLog, 0),
 		},
 		{
 			Name:  "Bob's CT Log Shop",
@@ -146,6 +147,7 @@ var sampleLogList = LogList{
 					},
 				},
 			},
+			TiledLogs: make([]*TiledLog, 0),
 		},
 	},
 }
@@ -165,9 +167,11 @@ func TestJSONMarshal(t *testing.T) {
 				`{"description":"Google 'Icarus' log","log_id":"KTxRllTIOWW6qlD8WAfUt2+/WHopctykwwz05UVH9Hg=","key":"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAETtK8v7MICve56qTHHDhhBOuV4IlUaESxZryCfk9QbG9co/CqPvTsgPDbCpp6oFtyAHwlDhnvr7JijXRD9Cb2FA==","url":"https://ct.googleapis.com/icarus/","dns":"icarus.ct.googleapis.com","mmd":86400,"state":{"usable":{"timestamp":"2018-02-27T00:00:00Z"}}},` +
 				`{"description":"Google 'Racketeer' log","log_id":"7kEv4llINIlh4vPgjGgugT7A/3cLbXUXF2OvMBT/l2g=","key":"Hy2TPTZ2yq9ASMmMZiB9SZEUx5WNH5G0Ft5Tm9vKMcPXA+ic/Ap3gg6fXzBJR8zLkt5lQjvKMdbHYMGv7yrsZg==","url":"https://ct.googleapis.com/racketeer/","dns":"racketeer.ct.googleapis.com","mmd":86400},` +
 				`{"description":"Google 'Rocketeer' log","log_id":"7ku9t3XOYLrhQmkfq+GeZqMPfl+wctiDAMR7iXqo/cs=","key":"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIFsYyDzBi7MxCAC/oJBXK7dHjG+1aLCOkHjpoHPqTyghLpzA9BYbqvnV16mAw04vUjyYASVGJCUoI3ctBcJAeg==","url":"https://ct.googleapis.com/rocketeer/","dns":"rocketeer.ct.googleapis.com","mmd":86400},` +
-				`{"description":"Google 'Argon2020' log","log_id": "sh4FzIuizYogTodm+Su5iiUgZ2va+nDnsklTLe+LkF4=","key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE6Tx2p1yKY4015NyIYvdrk36es0uAc1zA4PQ+TGRY+3ZjUTIYY9Wyu+3q/147JG4vNVKLtDWarZwVqGkg6lAYzA==","url":"https://ct.googleapis.com/logs/argon2020/","dns":"argon2020.ct.googleapis.com","mmd":86400,"state":{"qualified":{"timestamp":"2018-02-27T00:00:00Z"}},"temporal_interval":{"start_inclusive":"2020-01-01T00:00:00Z","end_exclusive":"2021-01-01T00:00:00Z"}}]},` +
+				`{"description":"Google 'Argon2020' log","log_id": "sh4FzIuizYogTodm+Su5iiUgZ2va+nDnsklTLe+LkF4=","key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE6Tx2p1yKY4015NyIYvdrk36es0uAc1zA4PQ+TGRY+3ZjUTIYY9Wyu+3q/147JG4vNVKLtDWarZwVqGkg6lAYzA==","url":"https://ct.googleapis.com/logs/argon2020/","dns":"argon2020.ct.googleapis.com","mmd":86400,"state":{"qualified":{"timestamp":"2018-02-27T00:00:00Z"}},"temporal_interval":{"start_inclusive":"2020-01-01T00:00:00Z","end_exclusive":"2021-01-01T00:00:00Z"}}],` +
+				`"tiled_logs":[]},` +
 				`{"name":"Bob's CT Log Shop","email":["bob@example.com"],"logs":[` +
-				`{"description":"Bob's Dubious Log","log_id":"zbUXm3/BwEb+6jETaj+PAC5hgvr4iW/syLL1tatgSQA=","key":"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAECyPLhWKYYUgEc+tUXfPQB4wtGS2MNvXrjwFCCnyYJifBtd2Sk7Cu+Js9DNhMTh35FftHaHu6ZrclnNBKwmbbSA==","url":"https://log.bob.io","dns":"dubious-bob.ct.googleapis.com","mmd":86400,"previous_operators":[ {"name":"Alice's Shady Log","end_time":"2014-11-06T12:00:00Z"}],"state":{"retired":{"timestamp":"2016-04-15T00:00:00Z"}},"temporal_interval":{"start_inclusive":"2014-11-07T12:00:00Z","end_exclusive":"2015-03-07T12:00:00Z"}}]}]}`,
+				`{"description":"Bob's Dubious Log","log_id":"zbUXm3/BwEb+6jETaj+PAC5hgvr4iW/syLL1tatgSQA=","key":"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAECyPLhWKYYUgEc+tUXfPQB4wtGS2MNvXrjwFCCnyYJifBtd2Sk7Cu+Js9DNhMTh35FftHaHu6ZrclnNBKwmbbSA==","url":"https://log.bob.io","dns":"dubious-bob.ct.googleapis.com","mmd":86400,"previous_operators":[ {"name":"Alice's Shady Log","end_time":"2014-11-06T12:00:00Z"}],"state":{"retired":{"timestamp":"2016-04-15T00:00:00Z"}},"temporal_interval":{"start_inclusive":"2014-11-07T12:00:00Z","end_exclusive":"2015-03-07T12:00:00Z"}}],` +
+				`"tiled_logs":[]}]}`,
 		},
 	}
 


### PR DESCRIPTION
This adds the new TiledLog field to the loglist3 JSON.

It does it in what I think is a minimal backwards-compatible fashion, but which results in duplicating most of the Log struct. As this is a fairly "low level" representation of the log JSON, I think that's an appropriate choice.

There's some other options this could take, so I'd like to hear from the maintainers about how they'd like to proceed here.

We could add the new SubmissionURL and Monitoring URL fields to the existing log struct, and one or the other URLs will be set. Users of this code will have to know how to handle an empty URL, which they probably don't do today.

We could pull all the shared fields into a new "BaseLog" struct, which is embedded in both the TiledLog and Log structs. I think this is a decent option, but is a breaking change.

In any of these situations, I'd like to also update the FindLogBy* methods (or add a new version of each) to support both log types, at least for the shared submission paths which are common between both. That'll require some common representation - perhaps an interface with methods that correctly handle the differences. Supporting reading from a tiled log would be great for this package but is definitely beyond the scope of what I intend to accomplish right now.


