### PR TITLE
Update ctclient to support SCT extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD
 
+* Update ctclient tool to support SCT extensions field by @liweitianux in https://github.com/google/certificate-transparency-go/pull/1645
+
 ## v1.3.1
 
 * Add AllLogListSignatureURL by @AlexLaroche in https://github.com/google/certificate-transparency-go/pull/1634

--- a/client/ctclient/cmd/get_entries.go
+++ b/client/ctclient/cmd/get_entries.go
@@ -80,6 +80,9 @@ func showRawLogEntry(rle *ct.RawLogEntry) {
 	ts := rle.Leaf.TimestampedEntry
 	when := ct.TimestampToTime(ts.Timestamp)
 	fmt.Printf("Index=%d Timestamp=%d (%v) ", rle.Index, ts.Timestamp, when)
+	if len(ts.Extensions) > 0 {
+		fmt.Printf("Extensions=%x ", ts.Extensions)
+	}
 
 	switch ts.EntryType {
 	case ct.X509LogEntryType:

--- a/client/logclient.go
+++ b/client/logclient.go
@@ -160,6 +160,7 @@ func (c *LogClient) VerifySCTSignature(sct ct.SignedCertificateTimestamp, ctype 
 	if err != nil {
 		return fmt.Errorf("failed to build MerkleTreeLeaf: %v", err)
 	}
+	leaf.TimestampedEntry.Extensions = sct.Extensions
 	entry := ct.LogEntry{Leaf: *leaf}
 	return c.Verifier.VerifySCTSignature(sct, entry)
 }


### PR DESCRIPTION
According to [RFC 6962 (Section 3.4)](https://www.rfc-editor.org/rfc/rfc6962#section-3.4), the `extensions` field defined for SCT is also included in `MerkleTreeLeaf.TimestampedEntry`.  So, the functions that build the `MerkleTreeLeaf` struct are required to accept the `extensions` parameter to fill this field.

Although RFC 6962 itself specified no extensions, the [Static CT API v1.0.0](https://github.com/C2SP/C2SP/blob/static-ct-api/v1.0.0-rc.1/static-ct-api.md) defined the `leaf_index(0)` SCT extension.  With a CT deployment based on [Sunlight](https://sunlight.dev/) and [Sunglasses](https://pkg.go.dev/src.agwa.name/sunglasses), the `ctclient get-inclusion-proof` was failing because of the wrong leaf hash.  With this patch, both `ctclient upload` and `ctclient get-inclusion-proof` work as expected.

Example 1:

```
% ./ctclient upload --log_uri http://xx.xx.xx.xx/ --cert_chain certchain.pem 
Uploaded chain of 2 certs to V1 log at http://xx.xx.xx.xx, timestamp: 1736993985743 (2025-01-16 10:19:45.743 +0800 CST)
LogID: e1cd6efe39e5c0c3e74662da1b7ee34341ad35b1b88cd1d423009183bd2af233
LeafHash: 95dfd9d2ce74b02ffa0bd223f46699b5cc16f1daefc38a9e7296faf02a215ba0
Extensions: 0000050000000003
Signature: Signature: Hash=SHA256 Sign=ECDSA Value=3045022100ae6c61d79279be24cd74b8ea2865af8e450c4233ba3ace5ec03c2024cbda722e022056be7cae85ef3704ff258d45b289adbd15de3904c74429f7e7a28fdc6c684403

% ./ctclient get-inclusion-proof --log_uri http://xx.xx.xx.xx/ --cert_chain certchain.pem --timestamp 1736993985743 --extensions 0000050000000003
W0116 10:48:43.940273  769215 get_inclusion_proof.go:115] WARNING: Timestamp (2025-01-16 10:19:45.743 +0800 CST) is with MMD window (24h0m0s), log may not have incorporated this entry yet.
Inclusion proof for index 3 in tree of size 4:
  0318588c51b46f47cfc616866430c80b6d0f5e48a9443f9487742bce4657ffec
  9f18abe16348ff92e5a0a4dde5b7a4e26a2cad5eb25aa88fef0cc74b2fa1869c
Verified that hash 95dfd9d2ce74b02ffa0bd223f46699b5cc16f1daefc38a9e7296faf02a215ba0 + proof = root hash 374d16c2911995e6ccb82de5faf338fbdfc6ae46110bc92f7dbbdd347b028cd9

% ./ctclient get-inclusion-proof --log_uri http://xx.xx.xx.xx/ --leaf_hash 95dfd9d2ce74b02ffa0bd223f46699b5cc16f1daefc38a9e7296faf02a215ba0 --timestamp 1736993985743
Inclusion proof for index 3 in tree of size 4:
  0318588c51b46f47cfc616866430c80b6d0f5e48a9443f9487742bce4657ffec
  9f18abe16348ff92e5a0a4dde5b7a4e26a2cad5eb25aa88fef0cc74b2fa1869c
Verified that hash 95dfd9d2ce74b02ffa0bd223f46699b5cc16f1daefc38a9e7296faf02a215ba0 + proof = root hash 374d16c2911995e6ccb82de5faf338fbdfc6ae46110bc92f7dbbdd347b028cd9
```

Example 2:

```
% ./ctclient get-entries --log_uri=http://xx.xx.xx.xx/ --text=false --first=0 --last=0 | tee /tmp/cert.pem 
Index=0 Timestamp=1736905054743 (2025-01-15 09:37:34.743 +0800 CST) Extensions=0000050000000000 X.509 certificate:
-----BEGIN CERTIFICATE-----
<snipped>
-----END CERTIFICATE-----

% ./ctclient get-inclusion-proof --log_uri=http://xx.xx.xx.xx/ --cert_chain=/tmp/cert.pem
Inclusion proof for index 0 in tree of size 5:
  e8b8c9f9f817b1883b10d142c6e36301c38425579008de9c2014d97473913ff2
  c5c949e33b5bd60a5d2b04cf55be9cfdcd0ddc770e2f7a48e388092896357106
  f0ea43a03eb06795727a7ebf4a2d3c560076001df2632671681ec3b141d63e1f
Verified that hash 2bd991db6c1a1d3c4a5f210efadb857d5ec0927a9ebb9887b7eecd65eca72758 + proof = root hash df2555e82accd739d1568aed994d9e0bc36b4912a0a8cb4637943f5593fb8b09
```

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [x] I have updated [documentation](docs/) accordingly.
