### PR TITLE
bump go version to 1.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Bump golangci-lint from 1.55.1 to 1.61.0 (developers should update to this version).
 * Update ctclient tool to support SCT extensions field by @liweitianux in https://github.com/google/certificate-transparency-go/pull/1645
+* Bump go to 1.23
 
 ## v1.3.1
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This repository holds Go code related to
 [Certificate Transparency](https://www.certificate-transparency.org/) (CT).  The
-repository requires Go version 1.22.
+repository requires Go version 1.23.
 
  - [Repository Structure](#repository-structure)
  - [Trillian CT Personality](#trillian-ct-personality)

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/google/certificate-transparency-go
 
-go 1.22.0
+go 1.23.0
 
-toolchain go1.22.10
+toolchain go1.23.4
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2


### PR DESCRIPTION
bump go version to 1.23

### Checklist

- [X] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [X] I have updated [documentation](docs/) accordingly.
