### PR TITLE
Bearer token and scheme prefix support for ct_hammer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Bump golangci-lint from 1.55.1 to 1.61.0 (developers should update to this version).
 * Update ctclient tool to support SCT extensions field by @liweitianux in https://github.com/google/certificate-transparency-go/pull/1645
 * Bump go to 1.23
+* [ct_hammer] support HTTPS and Bearer token for Authentication.
 
 ## v1.3.1
 

--- a/trillian/integration/ct_hammer/main.go
+++ b/trillian/integration/ct_hammer/main.go
@@ -271,7 +271,10 @@ func main() {
 	var wg sync.WaitGroup
 	for _, c := range cfg {
 		wg.Add(1)
-		auth := fmt.Sprintf("Bearer %s", *bearerToken)
+		var auth string
+		if *bearerToken != "" {
+			auth = fmt.Sprintf("Bearer %s", *bearerToken)
+		}
 		pool, err := integration.NewRandomPool(*httpServers, c.PublicKey, c.Prefix, auth)
 		if err != nil {
 			klog.Exitf("Failed to create client pool: %v", err)

--- a/trillian/integration/ct_hammer/main.go
+++ b/trillian/integration/ct_hammer/main.go
@@ -47,6 +47,7 @@ import (
 var (
 	banner      = flag.Bool("banner", true, "Display intro")
 	httpServers = flag.String("ct_http_servers", "localhost:8092", "Comma-separated list of (assumed interchangeable) servers, each as address:port")
+	bearerToken = flag.String("bearer_token", "", "The bearer token for authentication with servers. Not set if empty. For GCP this is the result of `gcloud auth print-identity-token`")
 
 	// Options for synthetic cert generation.
 	testDir      = flag.String("testdata_dir", "testdata", "Name of directory with test data")
@@ -270,7 +271,8 @@ func main() {
 	var wg sync.WaitGroup
 	for _, c := range cfg {
 		wg.Add(1)
-		pool, err := integration.NewRandomPool(*httpServers, c.PublicKey, c.Prefix)
+		auth := fmt.Sprintf("Bearer %s", *bearerToken)
+		pool, err := integration.NewRandomPool(*httpServers, c.PublicKey, c.Prefix, auth)
 		if err != nil {
 			klog.Exitf("Failed to create client pool: %v", err)
 		}

--- a/trillian/integration/ct_integration.go
+++ b/trillian/integration/ct_integration.go
@@ -110,7 +110,10 @@ func NewRandomPool(servers string, pubKey *keyspb.PublicKey, prefix string, auth
 
 	var pool RandomPool
 	for _, s := range strings.Split(servers, ",") {
-		c, err := client.New(fmt.Sprintf("http://%s/%s", s, prefix), hc, opts)
+		if !strings.HasPrefix(s, "http://") && !strings.HasPrefix(s, "https://") {
+			s = "http://" + s
+		}
+		c, err := client.New(fmt.Sprintf("%s/%s", s, prefix), hc, opts)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create LogClient instance: %v", err)
 		}

--- a/trillian/integration/ct_integration.go
+++ b/trillian/integration/ct_integration.go
@@ -99,10 +99,11 @@ func (p RandomPool) Next() *client.LogClient {
 }
 
 // NewRandomPool creates a pool which returns a random client from list of servers.
-func NewRandomPool(servers string, pubKey *keyspb.PublicKey, prefix string) (ClientPool, error) {
+func NewRandomPool(servers string, pubKey *keyspb.PublicKey, prefix string, auth string) (ClientPool, error) {
 	opts := jsonclient.Options{
-		PublicKeyDER: pubKey.GetDer(),
-		UserAgent:    "ct-go-integrationtest/1.0",
+		PublicKeyDER:  pubKey.GetDer(),
+		UserAgent:     "ct-go-integrationtest/1.0",
+		Authorization: auth,
 	}
 
 	hc := &http.Client{Transport: DefaultTransport}
@@ -256,7 +257,7 @@ func (t *testInfo) checkPreCertEntry(ctx context.Context, precertIndex int64, tb
 // nolint: gocyclo
 func RunCTIntegrationForLog(cfg *configpb.LogConfig, servers, metricsServers, testdir string, mmd time.Duration, stats *logStats) error {
 	ctx := context.Background()
-	pool, err := NewRandomPool(servers, cfg.PublicKey, cfg.Prefix)
+	pool, err := NewRandomPool(servers, cfg.PublicKey, cfg.Prefix, "")
 	if err != nil {
 		return fmt.Errorf("failed to create pool: %v", err)
 	}
@@ -621,7 +622,7 @@ func RunCTLifecycleForLog(cfg *configpb.LogConfig, servers, metricsServers, admi
 	}
 
 	ctx := context.Background()
-	pool, err := NewRandomPool(servers, cfg.PublicKey, cfg.Prefix)
+	pool, err := NewRandomPool(servers, cfg.PublicKey, cfg.Prefix, "")
 	if err != nil {
 		return fmt.Errorf("failed to create pool: %v", err)
 	}


### PR DESCRIPTION
This PR adds bearer token support to the CT hammer and allows for log URLS to contain an "http://" or "https://" prefix.

- [X] I have updated the [CHANGELOG](CHANGELOG.md).

