### PR TITLE
Support bearer token authentication for the preloader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Update ctclient tool to support SCT extensions field by @liweitianux in https://github.com/google/certificate-transparency-go/pull/1645
 * Bump go to 1.23
 * [ct_hammer] support HTTPS and Bearer token for Authentication.
+* [preloader] support Bearer token Authentication for non temporal logs.
 
 ## v1.3.1
 


### PR DESCRIPTION
The preloader can run in two modes:
 1. Source Log --> Target Log
 2. Source Log --> Multiple target logs, where each log covers a different temporal interval.

This PR adds Bearer token support to 1., since this is the only one we need for now. Adding it to 2. would require either changing the signature of public method, or including the bearer token in the proto config, which doesn't seem the right place for such a short lived parameter. Let's add it for 2. when/if we need it.

### Checklist

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
