### PR TITLE
Suppress unnecessary duplicate key errors in the IssuanceChainStorage PostgreSQL implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 * [ct_hammer] support HTTPS and Bearer token for Authentication.
 * [preloader] support Bearer token Authentication for non temporal logs.
 
+### CTFE Storage Saving: Extra Data Issuance Chain Deduplication
+
+* Suppress unnecessary duplicate key errors in the IssuanceChainStorage PostgreSQL implementation by @robstradling in https://github.com/google/certificate-transparency-go/pull/1678
+
 ## v1.3.1
 
 * Add AllLogListSignatureURL by @AlexLaroche in https://github.com/google/certificate-transparency-go/pull/1634


### PR DESCRIPTION
When enabled, the CTFE IssuanceChainStorage feature attempts to INSERT a row into the IssuanceChain table for every single add-chain and add-pre-chain request.  Often a duplicate key exception will be raised, in which case CTFE will ignore it; however, each time such an exception is raised on the database server, an error of the following form is added to the PostgreSQL log file:

```code
2025-03-14 19:09:48.407 UTC [79887] ctlog@ctlog ERROR: duplicate key value violates unique constraint "issuancechain_pkey"
2025-03-14 19:09:48.407 UTC [79887] ctlog@ctlog DETAIL: Key (identityhash)=(\x75fd98459142f4ad8a38a620c728d994057d980ab64a44190badccd265dd4d4a) already exists.
2025-03-14 19:09:48.407 UTC [79887] ctlog@ctlog STATEMENT: INSERT INTO IssuanceChain(IdentityHash, ChainValue) VALUES ($1, $2)
```

Since these "errors" are expected to occur and do not represent an actual problem, it's not useful or desirable to log them.

This PR stops adds `ON CONFLICT DO NOTHING` to the INSERT statement, so that no exception is raised and these errors will not appear in the PostgreSQL log file.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
