### PR TITLE
Only store IssuanceChain if not cached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### CTFE Storage Saving: Extra Data Issuance Chain Deduplication
 
 * Suppress unnecessary duplicate key errors in the IssuanceChainStorage PostgreSQL implementation by @robstradling in https://github.com/google/certificate-transparency-go/pull/1678
+* Only store IssuanceChain if not cached by @robstradling in https://github.com/google/certificate-transparency-go/pull/1679
 
 ## v1.3.1
 

--- a/trillian/ctfe/services.go
+++ b/trillian/ctfe/services.go
@@ -197,6 +197,11 @@ func (s *indirectIssuanceChainService) getByHash(ctx context.Context, hash []byt
 func (s *indirectIssuanceChainService) add(ctx context.Context, chain []byte) ([]byte, error) {
 	hash := issuanceChainHash(chain)
 
+	// If present in cache, then the chain is already stored.
+	if _, err := s.cache.Get(ctx, hash); err == nil {
+		return hash, nil
+	}
+
 	if err := s.storage.Add(ctx, hash, chain); err != nil {
 		return nil, err
 	}

--- a/trillian/ctfe/services.go
+++ b/trillian/ctfe/services.go
@@ -198,7 +198,7 @@ func (s *indirectIssuanceChainService) add(ctx context.Context, chain []byte) ([
 	hash := issuanceChainHash(chain)
 
 	// If present in cache, then the chain is already stored.
-	if _, err := s.cache.Get(ctx, hash); err == nil {
+	if cachedChain, err := s.cache.Get(ctx, hash); err == nil && cachedChain != nil {
 		return hash, nil
 	}
 


### PR DESCRIPTION
If an IssuanceChain is already present in CTFE's LRU cache, then we know it must also already be stored on the database.  Since a cache lookup is less expensive than a database write (that we know will fail with a duplicate key exception), it makes sense to check the cache and then only perform the database write if the IssuanceChain is not present in the cache.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
