### PR TITLE
Move dependabot to monthly cadence

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
 - package-ecosystem: gomod
   directory: /
   schedule:
-    interval: weekly
+    interval: monthly
   groups:
     all-deps:
       applies-to: version-updates
@@ -13,7 +13,7 @@ updates:
 - package-ecosystem: github-actions
   directory: /
   schedule:
-    interval: weekly
+    interval: monthly
   groups:
     all-deps:
       applies-to: version-updates
@@ -28,7 +28,7 @@ updates:
     - /trillian/examples/deployment/docker/ctfe
     - /trillian/examples/deployment/docker/envsubst
   schedule:
-    interval: weekly
+    interval: monthly
   groups:
     docker-deps:
       applies-to: version-updates


### PR DESCRIPTION
Weekly is requiring a lot of human time to review and support non-standard upgrades (e.g. protobuf changes that require regen files). Moving to monthly to give us some more breathing space.
