### PR TITLE
jsonclient: surface HTTP Do and Read errors

### DIFF
--- a/jsonclient/client_test.go
+++ b/jsonclient/client_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -516,15 +517,15 @@ func TestCancelledContext(t *testing.T) {
 
 	var result TestStruct
 	_, _, err = logClient.GetAndParse(ctx, "/struct/path", nil, &result)
-	if err != context.Canceled {
+	if !errors.Is(err, context.Canceled) {
 		t.Errorf("GetAndParse() = (_,_,%v), want %q", err, context.Canceled)
 	}
 	_, _, err = logClient.PostAndParse(ctx, "/struct/path", nil, &result)
-	if err != context.Canceled {
+	if !errors.Is(err, context.Canceled) {
 		t.Errorf("PostAndParse() = (_,_,%v), want %q", err, context.Canceled)
 	}
 	_, _, err = logClient.PostAndParseWithRetry(ctx, "/struct/path", nil, &result)
-	if err != context.Canceled {
+	if !errors.Is(err, context.Canceled) {
 		t.Errorf("PostAndParseWithRetry() = (_,_,%v), want %q", err, context.Canceled)
 	}
 }

--- a/trillian/integration/ct_integration.go
+++ b/trillian/integration/ct_integration.go
@@ -48,7 +48,6 @@ import (
 	"github.com/transparency-dev/merkle"
 	"github.com/transparency-dev/merkle/proof"
 	"github.com/transparency-dev/merkle/rfc6962"
-	"golang.org/x/net/context/ctxhttp"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
@@ -905,13 +904,13 @@ func (ls *logStats) fromServer(ctx context.Context, servers string) (*logStats, 
 
 	got := newLogStats(int64(ls.logID))
 	for _, s := range strings.Split(servers, ",") {
-		httpReq, err := http.NewRequest(http.MethodGet, "http://"+s+"/metrics", nil)
+		httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+s+"/metrics", nil)
 		if err != nil {
 			return nil, fmt.Errorf("failed to build GET request: %v", err)
 		}
 		c := new(http.Client)
 
-		httpRsp, err := ctxhttp.Do(ctx, c, httpReq)
+		httpRsp, err := c.Do(httpReq)
 		if err != nil {
 			return nil, fmt.Errorf("getting stats failed: %v", err)
 		}


### PR DESCRIPTION
Right now they are shadowed by the Close error.

Note this from the net/http Client.Do docs, which allows simplifying the
logic by far:

> On error, any Response can be ignored. A non-nil Response with a
> non-nil error only occurs when CheckRedirect fails, and even then the
> returned [Response.Body] is already closed.
