### PR TITLE
Remove klog from some client-facing packages

### DIFF
--- a/jsonclient/client.go
+++ b/jsonclient/client.go
@@ -34,7 +34,6 @@ import (
 
 	ct "github.com/google/certificate-transparency-go"
 	"github.com/google/certificate-transparency-go/x509"
-	"k8s.io/klog/v2"
 )
 
 const maxJitter = 250 * time.Millisecond
@@ -182,7 +181,6 @@ func (c *JSONClient) GetAndParse(ctx context.Context, path string, params map[st
 		vals.Add(k, v)
 	}
 	fullURI := fmt.Sprintf("%s%s?%s", c.uri, path, vals.Encode())
-	klog.V(2).Infof("GET %s", fullURI)
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, fullURI, nil)
 	if err != nil {
 		return nil, nil, err
@@ -231,7 +229,6 @@ func (c *JSONClient) PostAndParse(ctx context.Context, path string, req, rsp int
 		return nil, nil, err
 	}
 	fullURI := fmt.Sprintf("%s%s", c.uri, path)
-	klog.V(2).Infof("POST %s", fullURI)
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, fullURI, bytes.NewReader(postBody))
 	if err != nil {
 		return nil, nil, err

--- a/loglist3/logfilter.go
+++ b/loglist3/logfilter.go
@@ -17,7 +17,6 @@ package loglist3
 import (
 	"github.com/google/certificate-transparency-go/x509"
 	"github.com/google/certificate-transparency-go/x509util"
-	"k8s.io/klog/v2"
 )
 
 // LogRoots maps Log-URLs (stated at LogList) to the pools of their accepted
@@ -68,7 +67,8 @@ func (ll *LogList) RootCompatible(certRoot *x509.Certificate, roots LogRoots) Lo
 
 	// Check whether root is a CA-cert.
 	if certRoot != nil && !certRoot.IsCA {
-		klog.Warningf("Compatible method expects fully rooted chain, while last cert of the chain provided is not root")
+		// Compatible method expects fully rooted chain, while last cert of the chain provided is not root.
+		// Proceed anyway.
 		return compatible
 	}
 

--- a/x509util/pem_cert_pool.go
+++ b/x509util/pem_cert_pool.go
@@ -22,7 +22,6 @@ import (
 	"os"
 
 	"github.com/google/certificate-transparency-go/x509"
-	"k8s.io/klog/v2"
 )
 
 // String for certificate blocks in BEGIN / END PEM headers
@@ -80,7 +79,6 @@ func (p *PEMCertPool) AppendCertsFromPEM(pemCerts []byte) (ok bool) {
 
 		cert, err := x509.ParseCertificate(block.Bytes)
 		if x509.IsFatal(err) {
-			klog.Warningf("error parsing PEM certificate: %v", err)
 			return false
 		}
 


### PR DESCRIPTION
This reduces the set of transitive dependencies that clients need to pull in.

Fixes #1691