### PR TITLE
[CTFE] Configurable mechanism to rate-limit non-fresh submissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@
 * Suppress unnecessary duplicate key errors in the IssuanceChainStorage PostgreSQL implementation by @robstradling in https://github.com/google/certificate-transparency-go/pull/1678
 * Only store IssuanceChain if not cached by @robstradling in https://github.com/google/certificate-transparency-go/pull/1679
 
+### CTFE Rate Limiting Of Non-Fresh Submissions
+
+To protect a log from being flooded with requests for "old" certificates, optional rate limiting for "non-fresh submissions" can be configured by providing the following flags:
+
+- `non_fresh_submission_age`
+- `non_fresh_submission_burst`
+- `non_fresh_submission_limit`
+
+This can help to ensure that the log maintains its ability to (1) accept "fresh" submissions and (2) distribute all log entries to monitors.
+
+* [CTFE] Configurable mechanism to rate-limit non-fresh submissions by @robstradling in https://github.com/google/certificate-transparency-go/pull/1698
+
 ## v1.3.1
 
 * Add AllLogListSignatureURL by @AlexLaroche in https://github.com/google/certificate-transparency-go/pull/1634

--- a/trillian/ctfe/ct_server/main.go
+++ b/trillian/ctfe/ct_server/main.go
@@ -27,6 +27,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -48,6 +49,7 @@ import (
 	"github.com/tomasen/realip"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/naming/endpoints"
+	"golang.org/x/time/rate"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/resolver"
@@ -58,31 +60,34 @@ import (
 
 // Global flags that affect all log instances.
 var (
-	httpEndpoint          = flag.String("http_endpoint", "localhost:6962", "Endpoint for HTTP (host:port)")
-	httpIdleTimeout       = flag.Duration("http_idle_timeout", -1*time.Second, "Timeout after which idle connections will be closed by server")
-	tlsCert               = flag.String("tls_certificate", "", "Path to server TLS certificate")
-	tlsKey                = flag.String("tls_key", "", "Path to server TLS private key")
-	metricsEndpoint       = flag.String("metrics_endpoint", "", "Endpoint for serving metrics; if left empty, metrics will be visible on --http_endpoint")
-	rpcBackend            = flag.String("log_rpc_server", "", "Backend specification; comma-separated list or etcd service name (if --etcd_servers specified). If unset backends are specified in config (as a LogMultiConfig proto)")
-	rpcDeadline           = flag.Duration("rpc_deadline", time.Second*10, "Deadline for backend RPC requests")
-	getSTHInterval        = flag.Duration("get_sth_interval", time.Second*180, "Interval between internal get-sth operations (0 to disable)")
-	logConfig             = flag.String("log_config", "", "File holding log config in text proto format")
-	maxGetEntries         = flag.Int64("max_get_entries", 0, "Max number of entries we allow in a get-entries request (0=>use default 1000)")
-	etcdServers           = flag.String("etcd_servers", "", "A comma-separated list of etcd servers")
-	etcdHTTPService       = flag.String("etcd_http_service", "trillian-ctfe-http", "Service name to announce our HTTP endpoint under")
-	etcdMetricsService    = flag.String("etcd_metrics_service", "trillian-ctfe-metrics-http", "Service name to announce our HTTP metrics endpoint under")
-	maskInternalErrors    = flag.Bool("mask_internal_errors", false, "Don't return error strings with Internal Server Error HTTP responses")
-	tracing               = flag.Bool("tracing", false, "If true opencensus Stackdriver tracing will be enabled. See https://opencensus.io/.")
-	tracingProjectID      = flag.String("tracing_project_id", "", "project ID to pass to stackdriver. Can be empty for GCP, consult docs for other platforms.")
-	tracingPercent        = flag.Int("tracing_percent", 0, "Percent of requests to be traced. Zero is a special case to use the DefaultSampler")
-	quotaRemote           = flag.Bool("quota_remote", true, "Enable requesting of quota for IP address sending incoming requests")
-	quotaIntermediate     = flag.Bool("quota_intermediate", true, "Enable requesting of quota for intermediate certificates in submitted chains")
-	handlerPrefix         = flag.String("handler_prefix", "", "If set e.g. to '/logs' will prefix all handlers that don't define a custom prefix")
-	pkcs11ModulePath      = flag.String("pkcs11_module_path", "", "Path to the PKCS#11 module to use for keys that use the PKCS#11 interface")
-	cacheType             = flag.String("cache_type", "noop", "Supported cache type: noop, lru (Default: noop)")
-	cacheSize             = flag.Int("cache_size", -1, "Size parameter set to 0 makes cache of unlimited size")
-	cacheTTL              = flag.Duration("cache_ttl", -1*time.Second, "Providing 0 TTL turns expiring off")
-	trillianTLSCACertFile = flag.String("trillian_tls_ca_cert_file", "", "CA certificate file to use for secure connections with Trillian server")
+	httpEndpoint            = flag.String("http_endpoint", "localhost:6962", "Endpoint for HTTP (host:port)")
+	httpIdleTimeout         = flag.Duration("http_idle_timeout", -1*time.Second, "Timeout after which idle connections will be closed by server")
+	tlsCert                 = flag.String("tls_certificate", "", "Path to server TLS certificate")
+	tlsKey                  = flag.String("tls_key", "", "Path to server TLS private key")
+	metricsEndpoint         = flag.String("metrics_endpoint", "", "Endpoint for serving metrics; if left empty, metrics will be visible on --http_endpoint")
+	rpcBackend              = flag.String("log_rpc_server", "", "Backend specification; comma-separated list or etcd service name (if --etcd_servers specified). If unset backends are specified in config (as a LogMultiConfig proto)")
+	rpcDeadline             = flag.Duration("rpc_deadline", time.Second*10, "Deadline for backend RPC requests")
+	getSTHInterval          = flag.Duration("get_sth_interval", time.Second*180, "Interval between internal get-sth operations (0 to disable)")
+	logConfig               = flag.String("log_config", "", "File holding log config in text proto format")
+	maxGetEntries           = flag.Int64("max_get_entries", 0, "Max number of entries we allow in a get-entries request (0=>use default 1000)")
+	etcdServers             = flag.String("etcd_servers", "", "A comma-separated list of etcd servers")
+	etcdHTTPService         = flag.String("etcd_http_service", "trillian-ctfe-http", "Service name to announce our HTTP endpoint under")
+	etcdMetricsService      = flag.String("etcd_metrics_service", "trillian-ctfe-metrics-http", "Service name to announce our HTTP metrics endpoint under")
+	maskInternalErrors      = flag.Bool("mask_internal_errors", false, "Don't return error strings with Internal Server Error HTTP responses")
+	tracing                 = flag.Bool("tracing", false, "If true opencensus Stackdriver tracing will be enabled. See https://opencensus.io/.")
+	tracingProjectID        = flag.String("tracing_project_id", "", "project ID to pass to stackdriver. Can be empty for GCP, consult docs for other platforms.")
+	tracingPercent          = flag.Int("tracing_percent", 0, "Percent of requests to be traced. Zero is a special case to use the DefaultSampler")
+	quotaRemote             = flag.Bool("quota_remote", true, "Enable requesting of quota for IP address sending incoming requests")
+	quotaIntermediate       = flag.Bool("quota_intermediate", true, "Enable requesting of quota for intermediate certificates in submitted chains")
+	nonFreshSubmissionAge   = flag.Duration("non_fresh_submission_age", time.Hour*24, "Maximum age of a fresh submission")
+	nonFreshSubmissionBurst = flag.Int("non_fresh_submission_burst", 1, "Maximum burst size when rate-limiting non-fresh submissions")
+	nonFreshSubmissionLimit = flag.String("non_fresh_submission_limit", "", "Maximum rate at which non-fresh submissions will be accepted (e.g., \"30/1s\"; or \"\" to disable)")
+	handlerPrefix           = flag.String("handler_prefix", "", "If set e.g. to '/logs' will prefix all handlers that don't define a custom prefix")
+	pkcs11ModulePath        = flag.String("pkcs11_module_path", "", "Path to the PKCS#11 module to use for keys that use the PKCS#11 interface")
+	cacheType               = flag.String("cache_type", "noop", "Supported cache type: noop, lru (Default: noop)")
+	cacheSize               = flag.Int("cache_size", -1, "Size parameter set to 0 makes cache of unlimited size")
+	cacheTTL                = flag.Duration("cache_ttl", -1*time.Second, "Providing 0 TTL turns expiring off")
+	trillianTLSCACertFile   = flag.String("trillian_tls_ca_cert_file", "", "CA certificate file to use for secure connections with Trillian server")
 )
 
 const unknownRemoteUser = "UNKNOWN_REMOTE"
@@ -412,6 +417,20 @@ func setupAndRegister(ctx context.Context, client trillian.TrillianLogClient, de
 		klog.Info("Enabling quota for intermediate certificates")
 		opts.CertificateQuotaUser = ctfe.QuotaUserForCert
 	}
+	if *nonFreshSubmissionLimit != "" {
+		if s := strings.SplitN(*nonFreshSubmissionLimit, "/", 2); len(s) != 2 {
+			return nil, fmt.Errorf("could not parse non-fresh submission rate limit [%s]", *nonFreshSubmissionLimit)
+		} else if s0, err := strconv.Atoi(s[0]); err != nil {
+			return nil, fmt.Errorf("could not parse non-fresh submission rate limit quantity ['%s' of '%s']", s[0], *nonFreshSubmissionLimit)
+		} else if s1, err := time.ParseDuration(s[1]); err != nil {
+			return nil, fmt.Errorf("could not parse non-fresh submission rate limit duration ['%s' of '%s']", s[1], *nonFreshSubmissionLimit)
+		} else {
+			opts.FreshSubmissionMaxAge = *nonFreshSubmissionAge
+			opts.NonFreshSubmissionLimiter = rate.NewLimiter(rate.Every(s1/time.Duration(s0)), *nonFreshSubmissionBurst)
+			klog.Infof("Enabling rate limiting at %f req/sec for non-fresh submissions", opts.NonFreshSubmissionLimiter.Limit())
+		}
+	}
+
 	// Full handler pattern will be of the form "/logs/yyz/ct/v1/add-chain", where "/logs" is the
 	// HandlerPrefix and "yyz" is the c.Prefix for this particular log. Use the default
 	// HandlerPrefix unless the log config overrides it. The custom prefix in

--- a/trillian/ctfe/instance.go
+++ b/trillian/ctfe/instance.go
@@ -37,6 +37,7 @@ import (
 	"github.com/google/trillian"
 	"github.com/google/trillian/crypto/keys"
 	"github.com/google/trillian/monitoring"
+	"golang.org/x/time/rate"
 	"k8s.io/klog/v2"
 )
 
@@ -67,6 +68,15 @@ type InstanceOptions struct {
 	// limited. If unset, no quota will be requested for intermediate
 	// certificates.
 	CertificateQuotaUser func(*x509.Certificate) string
+	// FreshSubmissionMaxAge is the maximum age of a fresh submission.
+	// Freshness is determined by comparing the NotBefore timestamp of
+	// the first certificate in the submitted chain against the current time.
+	FreshSubmissionMaxAge time.Duration
+	// NonFreshSubmissionLimiter limits the rate at which this log instance
+	// will accept non-fresh submissions.
+	// This is used to prevent the log from being flooded with requests for
+	// "old" certificates.
+	NonFreshSubmissionLimiter *rate.Limiter
 	// STHStorage provides STHs of a source log for the mirror. Only mirror
 	// instances will use it, i.e. when IsMirror == true in the config. If it is
 	// empty then the DefaultMirrorSTHStorage will be used.


### PR DESCRIPTION
Recently we've seen a lot of CT log growth due to one or more third parties bulk-submitting lots of "old" certificates that are presumably already present in multiple other logs.  This DDoS vector has caused availability issues for some logs, affecting both the POST and GET endpoints.  We need to be able to ensure that "old" submissions do not overwhelm a log's ability to (1) accept "fresh" submissions and (2) distribute them to monitors.

Over on the transparency-dev Slack, Matthew McPherrin suggested:
> On the submission side, we could more aggressively ratelimit submission of "old" certificates (NotBefore that's more than 24 or so hours ago) to keep overload from preloading down

And Joe DeBlasio replied:
> IMO this would be a totally reasonable rate limiting strategy

This PR implements this rate limiting strategy for CTFE.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
