### PR TITLE
jsonclient: reduce backoff multiplier on success

### DIFF
--- a/jsonclient/client.go
+++ b/jsonclient/client.go
@@ -301,6 +301,7 @@ func (c *JSONClient) PostAndParseWithRetry(ctx context.Context, path string, req
 		} else {
 			switch httpRsp.StatusCode {
 			case http.StatusOK:
+				c.backoff.decreaseMultiplier()
 				return httpRsp, body, nil
 			case http.StatusRequestTimeout:
 				// Request timeout, retry immediately


### PR DESCRIPTION
Fixes #1696 