### PR TITLE
[CTFE] Short cache max-age when get-entries returns fewer entries than requested

### DIFF
--- a/trillian/ctfe/handlers.go
+++ b/trillian/ctfe/handlers.go
@@ -56,6 +56,8 @@ const (
 	cacheControlHeader = "Cache-Control"
 	// Value for Cache-Control header when response contains immutable data, i.e. entries or proofs. Allows the response to be cached for 1 day.
 	cacheControlImmutable = "public, max-age=86400"
+	// Value for Cache-Control header when response contains immutable but partial data, i.e. fewer entries than requested. Allows the response to be cached for 1 minute.
+	cacheControlPartial = "public, max-age=60"
 	// HTTP content type header
 	contentTypeHeader string = "Content-Type"
 	// MIME content type for JSON
@@ -802,7 +804,11 @@ func getEntries(ctx context.Context, li *logInfo, w http.ResponseWriter, r *http
 		return http.StatusInternalServerError, fmt.Errorf("failed to process leaves returned from backend: %s", err)
 	}
 
-	w.Header().Set(cacheControlHeader, cacheControlImmutable)
+	if len(rsp.Leaves) < int(count) {
+		w.Header().Set(cacheControlHeader, cacheControlPartial)
+	} else {
+		w.Header().Set(cacheControlHeader, cacheControlImmutable)
+	}
 	w.Header().Set(contentTypeHeader, contentTypeJSON)
 	jsonData, err := json.Marshal(&jsonRsp)
 	if err != nil {


### PR DESCRIPTION
The CTFE get-entries handler currently returns `Cache-Control: public, max-age=86400` even when the response contains fewer entries than requested.  This long cache max-age is problematic when `start` < `tree_size` < `end`, because the response would be expected to change after a new entry is added to the log.

To mitigate this problem whilst retaining some caching benefit, this PR implements `max-age=60` for get-entries responses that return fewer entries than requested.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
