### PR TITLE
Fix incorrect leaf hash calculation for precertificates in upload command

### DIFF
--- a/client/ctclient/cmd/upload.go
+++ b/client/ctclient/cmd/upload.go
@@ -73,7 +73,15 @@ func runUpload(ctx context.Context) {
 		exitWithDetails(err)
 	}
 	// Calculate the leaf hash.
-	leafEntry := ct.CreateX509MerkleTreeLeaf(chain[0], sct.Timestamp)
+	var leafEntry *ct.MerkleTreeLeaf
+	if isPrecert {
+		leafEntry, err = ct.MerkleTreeLeafFromRawChain(chain, ct.PrecertLogEntryType, sct.Timestamp)
+		if err != nil {
+			klog.Exitf("Failed to build pre-certificate leaf entry: %v", err)
+		}
+	} else {
+		leafEntry = ct.CreateX509MerkleTreeLeaf(chain[0], sct.Timestamp)
+	}
 	leafEntry.TimestampedEntry.Extensions = sct.Extensions
 	leafHash, err := ct.LeafHashForLeaf(leafEntry)
 	if err != nil {


### PR DESCRIPTION
The upload command was using` CreateX509MerkleTreeLeaf`for all certificates, including precertificates. This creates leaves with `X509LogEntryType`, but precertificates must use `PrecertLogEntryType` with a `PreCert` structure containing the issuer key hash.

This mismatch caused 'Leaf not found' errors when attempting to get inclusion proofs for re-uploaded precertificates (MMD 24h), as the calculated leaf hash didn't match the hash stored in the log.

The fix uses `MerkleTreeLeafFromRawChain` with the correct entry type, matching the approach used in `get_inclusion_proof.go`.


Before: 
```
$ go run . upload --cert_chain chain.pem --log_uri https://ct.cloudflare.com/logs/nimbus2025/
Uploading pre-certificate to log
Uploaded chain of 2 certs to V1 log at https://ct.cloudflare.com/logs/nimbus2025, timestamp: 1749322941367 (2025-06-07 21:02:21.367 +0200 CEST)
LogID: ccfb0f6a85710965fe959b53cee9b27c22e9855c0d978db6a97e54c0fe4c0db0
LeafHash: 0ea29977a0cfc3a766e4e506d69f71a2f5f3c04820914b06076e1a65b2e2d477
Extensions: (nil)
Signature: Signature: Hash=SHA256 Sign=ECDSA Value=3044022003774b34fb1ea9e3da40c9d2767dffc48f745cb012401e648e386a9797581c85022019c5316281760ccd167a7e169ce25e575a20f94b7df84fd721e9dba155a3ee77
I0614 07:14:27.476667    7828 root.go:85] HTTP details: status=404, body:
Not Found
backend GetInclusionProofByHash request failed: rpc error: code = NotFound desc = No leaves for hash: 0ea29977a0cfc3a766e4e506d69f71a2f5f3c04820914b06076e1a65b2e2d477
F0614 07:14:27.476725    7828 root.go:87] got HTTP Status "404 Not Found"
exit status 1


$ go run . upload --cert_chain chain.pem --log_uri https://ct.googleapis.com/logs/eu1/xenon2025h2/
Uploading pre-certificate to log
Uploaded chain of 2 certs to V1 log at https://ct.googleapis.com/logs/eu1/xenon2025h2, timestamp: 1748439948956 (2025-05-28 15:45:48.956 +0200 CEST)
LogID: dddcca3495d7e11605e79532fac79ff83d1c50dfdb003a1412760a2cacbbc82a
LeafHash: 8a9160ef749484ed1431e114db7797629b6675e9b5104d96fbe7538b497082a6
Extensions: (nil)
Signature: Signature: Hash=SHA256 Sign=ECDSA Value=304402205392e731f647e9429b1874b6da802eae50e58e38fcf77cd9130fb2a78c9715390220322b11f55992decc3369ec2c9c69b51581eddb5729cbbd9627dd776851518daf
I0614 07:14:42.618666    7874 root.go:85] HTTP details: status=404, body:
Not Found
backend GetInclusionProofByHash request failed: rpc error: code = NotFound desc = No leaf found for hash: 8a9160ef749484ed1431e114db7797629b6675e9b5104d96fbe7538b497082a6 in tree size 1061038211
F0614 07:14:42.618695    7874 root.go:87] got HTTP Status "404 Not Found"
exit status 1


$ go run . upload --cert_chain chain.pem --log_uri https://compact-log.ct.merklemap.com/
Uploading pre-certificate to log
Uploaded chain of 2 certs to V1 log at https://compact-log.ct.merklemap.com, timestamp: 1749771665805 (2025-06-13 01:41:05.805 +0200 CEST)
LogID: 8c9ca4af2cd53d0cdd48efd9ec38d65a67dbbd665c215a02baf79b594963b86d
LeafHash: 9ed2f766265529a2228f36b8a678938df8297bfbf251ea780c294186800b5319
Extensions: (nil)
Signature: Signature: Hash=SHA256 Sign=ECDSA Value=88b85a81afa748580be0c88b37c9fd2cd813d5495f8954d642f2e3e44452b9cf5a06a6f19a595773ca58b23d791ed644c81fb9af80b2a8ff34111adeee42dc81
I0614 07:14:35.934299    7850 root.go:85] HTTP details: status=404, body:
{"error":"Leaf not found"}
F0614 07:14:35.934320    7850 root.go:87] got HTTP Status "404 Not Found"
exit status 1
```


Now:

```
$ go run . upload --cert_chain chain.pem --log_uri https://compact-log.ct.merklemap.com/
Uploading pre-certificate to log
Uploaded chain of 2 certs to V1 log at https://compact-log.ct.merklemap.com, timestamp: 1749771665805 (2025-06-13 01:41:05.805 +0200 CEST)
LogID: 8c9ca4af2cd53d0cdd48efd9ec38d65a67dbbd665c215a02baf79b594963b86d
LeafHash: b6b8570b04c826b68120b82c15198909bc63827ef9921927136c89794aa554e0
Extensions: (nil)
Signature: Signature: Hash=SHA256 Sign=ECDSA Value=88b85a81afa748580be0c88b37c9fd2cd813d5495f8954d642f2e3e44452b9cf5a06a6f19a595773ca58b23d791ed644c81fb9af80b2a8ff34111adeee42dc81
Inclusion proof for index 120355 in tree of size 193686366:
  df68d97f8d24c79f8c065c1a6f81dd80352b43f06c393d1ec7040daa9d673c8f
  4e618d092ded72f1a5f6470f5e223b333cc7623d47b3de94f18e30cdfd32a9c1
  5d5437d19e7eee8459fccb1a8a504a8fba7806a9c7c929f1ac1f6448983d56de
  016f6ccecf288e0717add009a2571c71c78fb08c1f9f7bda23605ecef33529d3
  18c8988cfb3d556a891de5559db59e2689e88c3c04d65fa056dcc9834412d765
  40d7b5a67a3399684c9c930cffff4bef1a0cde9210b61ba38ed144882fad80e5
  d9b44be21dbc015fd16163ad37f5881a1a34ee6f29a634eb078f857ed8844eaa
  6bd5f54dc07e81ed6cf14cc22d9f71694b47c133e215a8909287f23cf7faa7dd
  30047a055393248834140bf334ec8bc491c10195e5070055df3d028912f9c5f1
  d5b45354d069d15db0e37ac0644ec1c66e3afaec68600689d90dcb4a7a51a3fb
  206ff95877201ab4eec98af2fbec2fd593b9cf05e95e0ad788f1ba0b72e4894c
  f8989a5d0a411674e64638b77561727b7053f701f35e1f99dd66a2d75a4c92dd
  cf8283b8a9f64a97946b03d2ee67f143f4d3dc6db46288f5dac4b3346148099a
  a4780ba090d00e3070d0d7e23197d8d951d80392746ca4f06533bed875f9f0e9
  b2654c513c44e0363e45cc019391f8547fcfeffd4db393da4874bc00148c97b8
  884e6648ccd4d37cf84c99bb1da01e3979111edc310a0ec7f6f056f1a6168cef
  d892a3b444e24f087f00a48062dda2f617aaffa924f75b2b71d56b1dc15a2ac3
  80978bb39f8b4767cbc51e2cd77441717814f845f346f23de7694ba01dd169bc
  85bed379d2c8226ed0a9d97583627bd8b8ad4f1f802bd97b872b176dbb556936
  d450855234aa16a56e4d87d2a198f1962521f2580b05e1a7fa0ec7a7765e8795
  50f2609112b5b4f51c6362da2d061be366494f6ece1752b95c7291e5709a6205
  057f394f82fe39675b8aa071d8d98b92a6fdcf056fdcab4b19a3b42c9d13e103
  103945be04d76bd35c4ba87f093ff5d152f3f79d01647d047af8b6aea205f32c
  902fb2bb6467ea81bb37e9726c5079245d0b0a89518a4229ed4e1b5e124434d1
  2a2d665b873ee6e44f5614db96f6b0acaf42a399e81aa4d5eea3cad0c54c60db
  8c01210ddc7f35b7029bf2e19f70f22416c60256a2db9c97837bff0ebff99804
  cf902e4444e0d1a1102e9fc7d1bf24bf12bfb3c4ee6cdd64ddd1e097ca9c9e89
  6e2eba8cd8686e82244d91492c0d5b038521968d031380f57c9c49516fe44c51
Verified that hash b6b8570b04c826b68120b82c15198909bc63827ef9921927136c89794aa554e0 + proof = root hash 0a6d652a619dc8ad65857ce196e45b23765b8778c48ce1bd0a2b50d4d0ed7a66
```
### Checklist

- [x] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
