### PR TITLE
Add additional docs to clarify key generation and format for config file

### DIFF
--- a/trillian/docs/ManualDeployment.md
+++ b/trillian/docs/ManualDeployment.md
@@ -258,6 +258,13 @@ ASN1 OID: prime256v1
 NIST CURVE: P-256
 ```
 
+**Cross-check**: Convert the private and public key into DER format encoded as a hex string that can be set in the configuration file:
+```bash
+% openssl pkcs8 -in privkey.pem -topk8 -nocrypt -outform der -out privkey.der
+% xxd -p privkey.der | tr -d '\n' | sed 's/../\\x&/g' > privkey.hex
+```
+Copy the contents of privkey.hex (single line) into the private_key stanza in the configuration file. Repeat the process for the public key.
+
 **Cross-check**: Once the CTFE is configured and running
 ([below](#ctfe-start-up)), the `ctclient` command-line tool allows signature
 checking against the public key with the `--pub_key` option:


### PR DESCRIPTION
<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

This is a documentation enhancement to help folks understand how to convert the log public/private keys into the correct format in the ctfe config file. It took a lot of trial and error for me to figure out how to do this and I finally dug up this comment in an older open issue: https://github.com/google/certificate-transparency-go/issues/780.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
