### PR TITLE
fix: prevent integer overflow in get-entries range check and limit HTTP response body reads

### DIFF
--- a/jsonclient/client.go
+++ b/jsonclient/client.go
@@ -36,7 +36,12 @@ import (
 	"github.com/google/certificate-transparency-go/x509"
 )
 
-const maxJitter = 250 * time.Millisecond
+const (
+	maxJitter = 250 * time.Millisecond
+	// maxResponseBodyBytes limits HTTP response body reads to prevent OOM when
+	// communicating with a CT log server returning an unexpectedly large response.
+	maxResponseBodyBytes = 32 * 1024 * 1024 // 32 MiB
+)
 
 type backoffer interface {
 	// set adjusts/increases the current backoff interval (typically on retryable failure);
@@ -196,7 +201,7 @@ func (c *JSONClient) GetAndParse(ctx context.Context, path string, params map[st
 	if err != nil {
 		return nil, nil, err
 	}
-	body, err := io.ReadAll(httpRsp.Body)
+	body, err := io.ReadAll(io.LimitReader(httpRsp.Body, maxResponseBodyBytes))
 	if err != nil {
 		return nil, nil, RspError{Err: fmt.Errorf("failed to read response body: %w", err), StatusCode: httpRsp.StatusCode, Body: body}
 	}
@@ -245,7 +250,7 @@ func (c *JSONClient) PostAndParse(ctx context.Context, path string, req, rsp int
 	if err != nil {
 		return nil, nil, err
 	}
-	body, err := io.ReadAll(httpRsp.Body)
+	body, err := io.ReadAll(io.LimitReader(httpRsp.Body, maxResponseBodyBytes))
 	if err != nil {
 		_ = httpRsp.Body.Close()
 		return nil, nil, err

--- a/trillian/ctfe/handlers.go
+++ b/trillian/ctfe/handlers.go
@@ -27,6 +27,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"math"
 	"sync"
 	"time"
 
@@ -1099,6 +1100,12 @@ func parseGetEntriesRange(r *http.Request, maxRange, logID int64) (int64, int64,
 	}
 	if start > end {
 		return 0, 0, fmt.Errorf("start (%d) and end (%d) is not a valid range", start, end)
+	}
+	// Guard against integer overflow: end-start+1 wraps to a negative number when
+	// end == math.MaxInt64, silently bypassing the maxRange cap below. Reject such
+	// values before computing the count.
+	if end == math.MaxInt64 {
+		return 0, 0, fmt.Errorf("end parameter value %d is too large", end)
 	}
 
 	count := end - start + 1

--- a/x509util/files.go
+++ b/x509util/files.go
@@ -26,6 +26,13 @@ import (
 	"github.com/google/certificate-transparency-go/x509"
 )
 
+// maxHTTPResponseBytes is the maximum number of bytes read from an HTTP
+// response when retrieving issuer certificates or CRLs from URLs embedded in
+// certificates. Responses larger than this limit are truncated and an error is
+// returned, preventing a malicious server from exhausting memory by returning
+// an unbounded body.
+const maxHTTPResponseBytes = 10 * 1024 * 1024 // 10 MiB
+
 // ReadPossiblePEMFile loads data from a file which may be in DER format
 // or may be in PEM format (with the given blockname).
 func ReadPossiblePEMFile(filename, blockname string) ([][]byte, error) {
@@ -49,7 +56,8 @@ func ReadPossiblePEMURL(target, blockname string) ([][]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to http.Get(%q): %v", target, err)
 	}
-	data, err := io.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	data, err := io.ReadAll(io.LimitReader(rsp.Body, maxHTTPResponseBytes))
 	if err != nil {
 		return nil, fmt.Errorf("failed to io.ReadAll(%q): %v", target, err)
 	}
@@ -88,7 +96,8 @@ func ReadFileOrURL(target string, client *http.Client) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to http.Get(%q): %v", target, err)
 	}
-	return io.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	return io.ReadAll(io.LimitReader(rsp.Body, maxHTTPResponseBytes))
 }
 
 // GetIssuer attempts to retrieve the issuer for a certificate, by examining
@@ -104,7 +113,7 @@ func GetIssuer(cert *x509.Certificate, client *http.Client) (*x509.Certificate, 
 		return nil, fmt.Errorf("failed to get issuer from %q: %v", issuerURL, err)
 	}
 	defer rsp.Body.Close()
-	body, err := io.ReadAll(rsp.Body)
+	body, err := io.ReadAll(io.LimitReader(rsp.Body, maxHTTPResponseBytes))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read issuer from %q: %v", issuerURL, err)
 	}


### PR DESCRIPTION
## Summary

Three security fixes:

### 1. Integer overflow bypasses `MaxGetEntriesAllowed` cap (`trillian/ctfe/handlers.go`)

`parseGetEntriesRange` computes `count = end - start + 1` before comparing against `MaxGetEntriesAllowed` (default 1000). When `end == math.MaxInt64`, the `+1` overflows to `math.MinInt64`, which is less than 1000, silently bypassing the cap:

```
GET /ct/v1/get-entries?start=0&end=9223372036854775807
→ count = math.MinInt64  →  MinInt64 > 1000 is false  →  cap bypassed
→ Trillian receives GetLeavesByRangeRequest{Count: -9223372036854775808}
```

An unauthenticated client can hammer the Trillian gRPC backend without hitting the intended rate limit.

**Fix:** Reject `end == math.MaxInt64` before computing the range.

### 2. Unbounded `io.ReadAll` on CT log HTTP responses (`jsonclient/client.go`)

`GetAndParse` and `PostAndParse` read HTTP response bodies with no size limit. A compromised CT log server returning a gigabyte-scale body causes OOM. This affects the submission proxy's `RefreshRoots` path, the scanner, and all library consumers.

**Fix:** Wrap `io.ReadAll` with `io.LimitReader` capped at 32 MiB.

### 3. Unbounded HTTP response reads in `x509util` (previous commit on this branch)

`ReadPossiblePEMURL`, `ReadFileOrURL`, and `GetIssuer` read HTTP responses for certificate AIA/CRL URLs without size limits.

**Fix:** Apply `io.LimitReader` (10 MiB) and add missing `defer resp.Body.Close()` in `ReadPossiblePEMURL`.