### PR TITLE
Fix Uint24 unmarshal offset

### DIFF
--- a/tls/tls.go
+++ b/tls/tls.go
@@ -336,7 +336,7 @@ func parseField(v reflect.Value, data []byte, initOffset int, info *fieldInfo) (
 		if len(rest) < 3 {
 			return offset, syntaxError{info.fieldName(), "truncated uint24"}
 		}
-		v.SetUint(uint64(data[0])<<16 | uint64(data[1])<<8 | uint64(data[2]))
+		v.SetUint(uint64(rest[0])<<16 | uint64(rest[1])<<8 | uint64(rest[2]))
 		offset += 3
 		return offset, nil
 	case uint32Type:

--- a/tls/tls_test.go
+++ b/tls/tls_test.go
@@ -29,6 +29,11 @@ type testStruct struct {
 	Enum   Enum `tls:"size:2"`
 }
 
+type testUint24AfterPrefix struct {
+	Prefix byte
+	Value  Uint24
+}
+
 type testVariant struct {
 	Which Enum    `tls:"size:1"`
 	Val16 *uint16 `tls:"selector:Which,val:0"`
@@ -234,6 +239,20 @@ func TestUnmarshalMarshalWithParamsRoundTrip(t *testing.T) {
 		} else if !bytes.Equal(data, inData) {
 			t.Errorf("Marshal(%+v)=%s,nil; want %s", inVal, hex.EncodeToString(data), test.data)
 		}
+	}
+}
+
+func TestUnmarshalUint24AfterPrefix(t *testing.T) {
+	var got testUint24AfterPrefix
+	rest, err := Unmarshal([]byte{0x41, 0x00, 0x00, 0x01}, &got)
+	if err != nil {
+		t.Fatalf("Unmarshal() returned error: %v", err)
+	}
+	if len(rest) != 0 {
+		t.Fatalf("Unmarshal() left %d trailing bytes", len(rest))
+	}
+	if got.Prefix != 0x41 || got.Value != 1 {
+		t.Fatalf("Unmarshal() = %+v, want Prefix 0x41 and Value 1", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- decode `tls.Uint24` fields from the current parse offset instead of the start of the input buffer
- add a regression where a `Uint24` appears after a prefix byte

Closes #1800.

## Tests
- `go test ./tls`
