### PR TITLE
Limit add-chain/add-pre-chain request body size to prevent memory exh…

### DIFF
--- a/trillian/ctfe/handlers.go
+++ b/trillian/ctfe/handlers.go
@@ -53,6 +53,7 @@ var (
 )
 
 const (
+	maxAddChainBodyBytes int64 = 512000 // limits add-chain/add-pre-chain body size to prevent memory exhaustion
 	// HTTP Cache-Control header
 	cacheControlHeader = "Cache-Control"
 	// Value for Cache-Control header when response contains immutable data, i.e. entries or proofs. Allows the response to be cached for 1 day.
@@ -464,6 +465,7 @@ func addChainInternal(ctx context.Context, li *logInfo, w http.ResponseWriter, r
 	}
 
 	// Check the contents of the request and convert to slice of certificates.
+	r.Body = http.MaxBytesReader(w, r.Body, maxAddChainBodyBytes)
 	addChainReq, err := ParseBodyAsJSONChain(r)
 	if err != nil {
 		var maxBytesErr *http.MaxBytesError


### PR DESCRIPTION
## Summary
This PR fixes an unbounded memory allocation vulnerability in the add-chain 
and add-pre-chain HTTP handlers. `ParseBodyAsJSONChain` reads the entire 
request body via `io.ReadAll(r.Body)` without any size limit, allowing a 
malicious client to send an oversized request and exhaust server memory.

## Fix
Applies `http.MaxBytesReader` to `r.Body` before it reaches 
`ParseBodyAsJSONChain`, limiting the body to 512000 bytes (matching the 
existing `maxAddChainBodyBytes` constant already used in 
`submission/proxy_server.go`). The error-handling code in `addChainInternal` 
already expected an `http.MaxBytesError`, but nothing triggered it on the 
direct CTFE path — only the proxy path was protected.

## Testing
- `go build ./trillian/ctfe/...` passes
- `go test ./trillian/ctfe/...` passes (all existing tests pass)

## Related
Reported via Google OSS VRP, Issue Tracker #542934724.