### PR TITLE
Remove CloudBuild interactions with GKE CI

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -184,31 +184,6 @@ steps:
   - -t
   - envsubst
   waitFor: ['ci_complete']
-- id: envsubst_kubernetes_configs
-  name: envsubst
-  args:
-  - trillian/examples/deployment/kubernetes/ctfe-deployment.yaml
-  - trillian/examples/deployment/kubernetes/ctfe-service.yaml
-  - trillian/examples/deployment/kubernetes/ctfe-ingress.yaml
-  env:
-  - PROJECT_ID=${PROJECT_ID}
-  - IMAGE_TAG=${COMMIT_SHA}
-  waitFor:
-  - build_envsubst
-- id: update_kubernetes_configs_dryrun
-  name: gcr.io/cloud-builders/kubectl
-  args:
-  - apply
-  - --dry-run=server
-  - -f=trillian/examples/deployment/kubernetes/ctfe-deployment.yaml
-  - -f=trillian/examples/deployment/kubernetes/ctfe-service.yaml
-  - -f=trillian/examples/deployment/kubernetes/ctfe-ingress.yaml
-  env:
-  - CLOUDSDK_COMPUTE_ZONE=${_MASTER_ZONE}
-  - CLOUDSDK_CONTAINER_CLUSTER=${_CLUSTER_NAME}
-  waitFor:
-  - envsubst_kubernetes_configs
-  - build_ctfe
 
 images:
 - gcr.io/${PROJECT_ID}/ctfe:${COMMIT_SHA}

--- a/cloudbuild_master.yaml
+++ b/cloudbuild_master.yaml
@@ -201,30 +201,6 @@ steps:
   - -t
   - envsubst
   waitFor: ["-"]
-- id: envsubst_kubernetes_configs
-  name: envsubst
-  args:
-  - trillian/examples/deployment/kubernetes/ctfe-deployment.yaml
-  - trillian/examples/deployment/kubernetes/ctfe-service.yaml
-  - trillian/examples/deployment/kubernetes/ctfe-ingress.yaml
-  env:
-  - PROJECT_ID=${PROJECT_ID}
-  - IMAGE_TAG=${COMMIT_SHA}
-  waitFor:
-  - build_envsubst
-- id: update_kubernetes_configs
-  name: gcr.io/cloud-builders/kubectl
-  args:
-  - apply
-  - -f=trillian/examples/deployment/kubernetes/ctfe-deployment.yaml
-  - -f=trillian/examples/deployment/kubernetes/ctfe-service.yaml
-  - -f=trillian/examples/deployment/kubernetes/ctfe-ingress.yaml
-  env:
-  - CLOUDSDK_COMPUTE_ZONE=${_MASTER_ZONE}
-  - CLOUDSDK_CONTAINER_CLUSTER=${_CLUSTER_NAME}
-  waitFor:
-  - envsubst_kubernetes_configs
-  - push_ctfe
 
 images:
 - gcr.io/${PROJECT_ID}/ctfe:${COMMIT_SHA}


### PR DESCRIPTION
Remove GKE CI from cloudbuild configs.

The GKE instance has been out of action for a long time and has now been turned down.

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
